### PR TITLE
feat(demo): benchmark comparison, progress while reading, key results at the end of the CI report

### DIFF
--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -48,6 +48,7 @@ after_tool:
     args:
       title: What would you like to do next?
       options:
+        - Compare these numbers with well-known open-source repositories
         - Set up an agent that improves CI/CD reliability over time
         - Connect OpenSRE to Slack and hand off DevOps chores for your team
         - Exit demo
@@ -133,11 +134,21 @@ bullet list.
 The host opens `What would you like to do next?` after the analysis with
 these options:
 
+- `Compare these numbers with well-known open-source repositories`
 - `Set up an agent that improves CI/CD reliability over time`
 - `Connect OpenSRE to Slack and hand off DevOps chores for your team`
 - `Exit demo`
 
 Wait for the answer, then follow the selected option.
+
+**Compare with benchmarks:** Call
+`skill_view(name="cicd-analytics-demo", reference="benchmarks")` and follow
+it: one `analyze_github_ci_reliability` call per benchmark repository with
+the same `days`, then the comparison table, user's repository first. A
+benchmark analysed earlier today comes back from its snapshot in a second
+(`from_snapshot` gives the time); say "as of <time>" for those rows. Then
+offer the remaining options again with `ask_user_choice`, title `What would
+you like to do next?`, without the comparison row.
 
 **Recurring check:** Call
 `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -24,7 +24,7 @@ metadata:
     - GitHub token usable by OpenSRE with read access to the repository's Actions history
     - A local git checkout for the workspace scan (optional; a named repository also works)
   type: analytics
-  version: "1.2"
+  version: "1.3"
 tools:
   - scan_local_git_workspace
   - analyze_github_ci_reliability
@@ -48,7 +48,6 @@ after_tool:
     args:
       title: What would you like to do next?
       options:
-        - Compare these numbers with well-known open-source repositories
         - Set up an agent that improves CI/CD reliability over time
         - Connect OpenSRE to Slack and hand off DevOps chores for your team
         - Exit demo
@@ -87,6 +86,9 @@ Slack setup.
   Load it only when the user asks what a figure means or which metric to
   fix first, with `skill_view(name="cicd-analytics-demo", reference="metrics")`;
   answer from it and the tool's numbers. Do not load it during steps 1-4.
+- **Benchmark table**: [references/benchmarks.md](references/benchmarks.md).
+  Load it only when the user asks what a compared figure means. The analyze
+  call already paints the comparison; do not load this to re-run peers.
 
 ## Plan
 
@@ -124,31 +126,22 @@ the answer.
 
 ### 3. Analyze CI/CD reliability
 
-Call `analyze_github_ci_reliability(owner="<owner>", repo="<repo>")` for the
-chosen repository. Output its `headline` field verbatim as its own line.
-Nothing else: no computed, converted, or reworded figures, no recap, no
-bullet list.
+Call
+`analyze_github_ci_reliability(owner="<owner>", repo="<repo>", include_benchmarks=true)`
+for the chosen repository. The tool paints the report (key results first)
+and the comparison table itself. Do not restate figures, do not output
+`headline`, and do not call the tool again for benchmarks.
 
 ### 4. Offer what to do next
 
 The host opens `What would you like to do next?` after the analysis with
 these options:
 
-- `Compare these numbers with well-known open-source repositories`
 - `Set up an agent that improves CI/CD reliability over time`
 - `Connect OpenSRE to Slack and hand off DevOps chores for your team`
 - `Exit demo`
 
 Wait for the answer, then follow the selected option.
-
-**Compare with benchmarks:** Call
-`skill_view(name="cicd-analytics-demo", reference="benchmarks")` and follow
-it: one `analyze_github_ci_reliability` call per benchmark repository with
-the same `days`, then the comparison table, user's repository first. A
-benchmark analysed earlier today comes back from its snapshot in a second
-(`from_snapshot` gives the time); say "as of <time>" for those rows. Then
-offer the remaining options again with `ask_user_choice`, title `What would
-you like to do next?`, without the comparison row.
 
 **Recurring check:** Call
 `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
@@ -1,15 +1,19 @@
 # Comparing a repository's CI/CD metrics to public benchmarks
 
-Phase 2 of the analytics demo (see `insights.md`): after the user's own
-numbers are on screen, put them next to one or two well-known open-source
-repositories so the user can tell "is 6 % flake rate bad?" without prior
-experience. Load this reference only when the user asks how they compare, or
-when the analysis is done and a comparison is the natural next question.
+Phase 2 of the analytics demo (metric definitions in `metrics.md`): after
+the user's own numbers are on screen, put them next to one or two well-known
+open-source repositories so the user can tell "is 6 % flake rate bad?"
+without prior experience. The demo's next-step menu offers this as
+`Compare these numbers with well-known open-source repositories`; also load
+it when the user asks how they compare.
 
 ## Rules
 
 - Benchmark numbers come from `analyze_github_ci_reliability`, called on the
-  benchmark repository with the **same `days`** as the user's analysis. Never
+  benchmark repository with the **same `days`** as the user's analysis. A
+  benchmark analysed earlier today is answered from its saved snapshot
+  (`from_snapshot` carries the time) instead of reading GitHub again, which
+  takes minutes for a large repository; say "as of <time>" for that row. Never
   quote a benchmark figure from memory, a blog post, or a previous session;
   public repositories change week to week and the tool is the only source the
   reply may cite.

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
@@ -1,119 +1,50 @@
 # Comparing a repository's CI/CD metrics to public benchmarks
 
-Phase 2 of the analytics demo (metric definitions in `metrics.md`): after
-the user's own numbers are on screen, put them next to one or two well-known
-open-source repositories so the user can tell "is 6 % flake rate bad?"
-without prior experience. The demo's next-step menu offers this as
-`Compare these numbers with well-known open-source repositories`; also load
-it when the user asks how they compare.
+Phase 2 of the analytics demo (metric definitions in `metrics.md`): the
+analyze call with `include_benchmarks=true` already paints one comparison
+table next to apache/airflow and fastapi/fastapi over the same window. Load
+this reference only when the user asks what a compared figure means.
 
 ## Rules
 
-- Benchmark numbers come from `analyze_github_ci_reliability`, called on the
-  benchmark repository with the **same `days`** as the user's analysis. A
-  benchmark analysed earlier today is answered from its saved snapshot
-  (`from_snapshot` carries the time) instead of reading GitHub again, which
-  takes minutes for a large repository; say "as of <time>" for that row. Never
-  quote a benchmark figure from memory, a blog post, or a previous session;
-  public repositories change week to week and the tool is the only source the
-  reply may cite.
+- The host table is the source. Do not call `analyze_github_ci_reliability`
+  again for a benchmark, and never quote a figure from memory, a blog post,
+  or a previous session.
 - Compare **rates and durations**, never raw counts. A repository with 40 000
   runs a month and one with 400 are not comparable on `executions`,
   `pr_failures`, or `blocked_minutes`; they are comparable on
   `pr_failure_rate`, flake share, red share, `mean_recovery_hours`, and
   `normal_minutes`.
-- Keep the user's repository first and the benchmarks after it; the benchmark
-  is context for the user's number, not the headline.
-- If the tool returns `coverage_notices` for a benchmark, say so in one line
-  next to that benchmark row. Do not drop the row silently and do not
-  substitute another repository without telling the user.
-- A benchmark call that fails on a missing token or rate limit ends the
-  comparison for that repository; report the user's own numbers unchanged and
-  say which benchmark could not be fetched.
+- The user's repository is the first column; the benchmarks are context.
+- If the tool returns `benchmarks_skipped` or `coverage_notices` for a
+  peer, say so in one line. Do not substitute another repository without
+  telling the user.
 
-## Picking benchmarks
+## Default benchmarks
 
-The tool reads GitHub Actions workflow runs, so a benchmark must run its CI on
-Actions. Default to one benchmark of a similar size and one much larger
-project the user will recognize:
+The tool always uses these two when `include_benchmarks` is true:
 
 | Repository | Why it works as a benchmark |
 |------------|-----------------------------|
-| `apache/airflow` | Python monorepo, dozens of Actions workflows, high PR volume, familiar to most teams |
-| `fastapi/fastapi` | Mid-size Python project with a lean Actions setup; a realistic target for a small team |
-| `pydantic/pydantic` | Library CI with a matrix build; good "normal duration" reference |
-| `astral-sh/ruff` | Rust toolchain on Actions; fast, disciplined CI |
-| `huggingface/transformers` | Large ML repo; heavy matrix, long-running jobs |
-| `pytorch/pytorch` | Very large Actions fleet; upper bound for duration and outage counts |
-| `grafana/grafana` | Large Go/TypeScript monorepo; good for teams that run both |
+| `apache/airflow` | Python monorepo, dozens of Actions workflows, high PR volume |
+| `fastapi/fastapi` | Mid-size Python project with a lean Actions setup |
 
-Do not use `kubernetes/kubernetes` as a benchmark for this tool. Its CI runs on
-Prow (`prow.k8s.io`), and the repository keeps only a handful of GitHub
-Actions workflows (Copilot, dependency graph), so the tool would report a
-near-empty picture that says nothing about Kubernetes' actual CI health. If
-the user asks for Kubernetes by name, say this in one sentence and offer
-`grafana/grafana` or `pytorch/pytorch` as a large-project stand-in.
-
-Let the user pick when they name a repository; otherwise take
-`apache/airflow` plus the row above closest to the user's language
-and repository size.
+Do not use `kubernetes/kubernetes` as a stand-in. Its CI runs on Prow, and
+the repository keeps only a handful of GitHub Actions workflows, so the
+numbers would say nothing about Kubernetes' actual CI health.
 
 ## Metric mapping
 
-Each metric in `metrics.md` maps to fields the tool already returns. Compute
-the derived shares in the reply only from those fields, and show the formula
-once in the table caption so the user can reproduce it.
+Each metric in `metrics.md` maps to fields the tool already returns.
 
 | Metric (`metrics.md`) | Field(s) | Comparable form |
 |-----------------------|----------|-----------------|
 | #1 Red time on main | `red_hours`, window `days` | `red_hours / (days × 24)` as a percentage |
-| #2 Mean time to green | `mean_recovery_hours`, `outages` | hours per outage; note `outages` so a single long outage is not read as a trend |
+| #2 Mean time to green | `mean_recovery_hours`, `outages` | hours per outage |
 | #3 Flake rate | `reliability_failures`, `pr_executions` | `reliability_failures / pr_executions` as a percentage |
-| #4 Normal CI duration | `workflows[].normal_minutes` | median of `normal_minutes` across workflows with runs, in minutes |
-| #5 Merged PRs delayed by a flake | `blocked_prs`, `merged_pr_branches` | `len(blocked_prs) / merged_pr_branches` as a percentage (the tool caps `blocked_prs` at 10; if it returns exactly 10, label the share "≥") |
+| #4 Normal CI duration | `workflows[].normal_minutes` | slowest `normal_minutes` in the table (not a median across workflows) |
 | PR failure rate | `pr_failure_rate` | as returned |
 
 `blocked_working_minutes`, `developers_affected`, and the per-developer list
 depend on team size and working hours and are **not** compared across
-repositories. Mention the user's own values for these only if the user asks;
-the headline already covers the biggest one.
-
-## Workflow
-
-1. Confirm the user's analysis exists in this session (step 3 of the demo).
-   If it does not, run it first; do not benchmark an unanalyzed repository.
-2. Choose benchmarks per "Picking benchmarks". If the user did not name one,
-   say which two you are using and why in one sentence.
-3. Call `analyze_github_ci_reliability(owner=…, repo=…, days=<same window>)`
-   once per benchmark. Do not re-run it for the user's repository.
-4. Render one table, user first, using the "Comparable form" column above.
-   Round percentages to one decimal and durations to whole minutes or one
-   decimal hour. Put `coverage_notices` as a footnote line under the table.
-5. Close with at most two sentences: the one metric where the user's
-   repository differs most from the benchmarks, and what the demo can do about
-   it (the recurring reliability agent from step 4 of the demo). No further
-   recap.
-
-## Reply shape
-
-```
-Compared with apache/airflow and fastapi/fastapi over the same 30 days:
-
-| Metric                       | <owner/repo> | apache/airflow | fastapi/fastapi |
-|------------------------------|-------------:|---------------:|----------------:|
-| Red time on main             |        4.2 % |                  1.1 % |           0.3 % |
-| Mean time to green (h)       |          6.5 |                    1.8 |             0.9 |
-| Flake rate                   |        7.9 % |                  2.4 % |           0.6 % |
-| Normal CI duration (median)  |       23 min |                 14 min |           9 min |
-| Merged PRs delayed by flakes |       18.0 % |                  5.2 % |           1.4 % |
-| PR failure rate              |       21.0 % |                 12.7 % |           4.9 % |
-
-Red time = red_hours / (days × 24); flake rate = reliability_failures / pr_executions.
-fastapi/fastapi: <coverage notice from the tool, if any>
-
-Your flake rate is roughly three times Airflow's; the recurring reliability agent
-targets exactly those same-commit fail-then-pass runs.
-```
-
-The figures above are placeholders showing layout only; every number in a
-real reply must come from the tool calls made in this session.
+repositories.

--- a/core/agent_harness/turns/skill_scope.py
+++ b/core/agent_harness/turns/skill_scope.py
@@ -28,8 +28,10 @@ _ALWAYS_OFFERED = frozenset(
 
 def scope_tools_to_active_skill(tools: list[Any], session: Any, message: str) -> list[Any]:
     """Filter ``tools`` for an answer turn inside a skill; reset the scope otherwise."""
-    if message.strip() == "/choose" and getattr(session, "pending_user_choice", None) is not None:
-        # The literal transport command needs slash_invoke, but is not a new request.
+    if message.strip().startswith("/"):
+        # A slash command (/choose, /auto, /cost) is transport or a setting, not a
+        # new request: it neither narrows the tools nor ends the skill whose
+        # menu is waiting for its answer.
         return tools
     declared = tuple(getattr(session, "active_skill_tools", ()) or ())
     if not parse_ask_user_answers(message):

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -36,7 +36,9 @@ The agent guides you through the selected demo in the shell.
 2. **Pick a repository.** A menu lists your checkouts that have GitHub Actions
    workflows, then the open-source example, then a row to type your own.
 3. **Analyze.** It reads the repository's Actions history for the last 30 days
-   under a spinner and paints the report, ending with the one-sentence headline.
+   and paints the report (key results first: how long main was red) plus a
+   comparison table against apache/airflow and fastapi/fastapi over the same
+   window. A repository already read today is answered from its snapshot.
 4. **Next step.** A menu offers the CI reliability agent (it schedules the
    check for the repository you just analyzed, no second repository question),
    the Slack hand-off, or exit.

--- a/integrations/github/tools/ci_analytics/analysis.py
+++ b/integrations/github/tools/ci_analytics/analysis.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from integrations.github.client import GitHubRestClient
-from integrations.github.tools.ci_analytics.collector import collect_runs
+from integrations.github.tools.ci_analytics.collector import ProgressFn, collect_runs
 from integrations.github.tools.ci_analytics.metrics import compute_report
 from integrations.github.tools.ci_analytics.models import CiAnalyticsReport
 from integrations.github.tools.ci_analytics.working_hours import WorkingHours, local_working_hours
@@ -30,6 +30,7 @@ def analyze_repository(
     days: int = DEFAULT_WINDOW_DAYS,
     working_hours: WorkingHours | None = None,
     now: datetime | None = None,
+    progress: ProgressFn | None = None,
 ) -> Analysis:
     """Read the window's Actions history and compute the report.
 
@@ -38,7 +39,12 @@ def analyze_repository(
     """
     at = now or datetime.now(UTC)
     collected = collect_runs(
-        GitHubRestClient(token), owner=owner, repo=repo, window_days=days, now=at
+        GitHubRestClient(token),
+        owner=owner,
+        repo=repo,
+        window_days=days,
+        now=at,
+        progress=progress,
     )
     report = compute_report(
         owner=owner,

--- a/integrations/github/tools/ci_analytics/collector.py
+++ b/integrations/github/tools/ci_analytics/collector.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import threading
-from concurrent.futures import ThreadPoolExecutor
+import time
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -40,6 +42,9 @@ class CollectedRuns:
     coverage_notices: list[str]
 
 
+ProgressFn = Callable[[str], None]
+
+
 def collect_runs(
     client: GitHubRestClient,
     *,
@@ -47,8 +52,19 @@ def collect_runs(
     repo: str,
     window_days: int,
     now: datetime,
+    progress: ProgressFn | None = None,
 ) -> CollectedRuns:
-    """Fetch completed default-branch and PR runs plus merged PRs in the window."""
+    """Fetch completed default-branch and PR runs plus merged PRs in the window.
+
+    ``progress`` receives one short line as each stage finishes, so a surface
+    can show that a long read is moving instead of a silent wait.
+    """
+    say = progress or (lambda _line: None)
+    started = time.monotonic()
+
+    def elapsed() -> str:
+        return f"{time.monotonic() - started:.0f}s"
+
     root = f"/repos/{_segment(owner)}/{_segment(repo)}"
     repository = client.request("GET", root)
     default_branch = (
@@ -58,6 +74,10 @@ def collect_runs(
         raise ValueError(f"GitHub repository {owner}/{repo} has no readable default branch.")
     since = now - timedelta(days=window_days)
     notices: list[str] = []
+    say(
+        f"Reading {default_branch} runs, pull request runs and merged pull requests "
+        f"of the last {window_days} days in parallel…"
+    )
     # Each scope is an independent paginated listing; fetching them together
     # keeps the demo well under a minute on busy repositories.
     with ThreadPoolExecutor(max_workers=len(_DEFAULT_BRANCH_EVENTS) + 2) as pool:
@@ -85,11 +105,25 @@ def collect_runs(
             notices=notices,
         )
         merged_future = pool.submit(_merged_prs, client, root, since=since, notices=notices)
+        labels: dict[Future[Any], str] = {
+            future: f"{default_branch} {event} runs"
+            for future, event in zip(branch_futures, _DEFAULT_BRANCH_EVENTS, strict=True)
+        }
+        labels[pr_future] = "pull request runs"
+        labels[merged_future] = "merged pull requests"
+        for future in as_completed(list(labels)):
+            say(f"{labels[future]}: {len(future.result())} read ({elapsed()})")
         branch_runs = [run for future in branch_futures for run in future.result()]
         merged = merged_future.result()
+        listed = pr_future.result()
+        reruns = sum(1 for run in listed if run.succeeded and run.attempt > 1)
+        if reruns:
+            say(f"Checking the attempt history of {reruns} re-run pull request runs…")
         # Only PR reruns affect failure rate and blocked time; skip extra
         # attempt fetches on default-branch listings.
-        pr_runs = _annotate_reruns(client, root, pr_future.result(), merged=merged, notices=notices)
+        pr_runs = _annotate_reruns(client, root, listed, merged=merged, notices=notices)
+        if reruns:
+            say(f"Attempt history checked ({elapsed()}); computing the report.")
     return CollectedRuns(
         default_branch=default_branch,
         branch_runs=branch_runs,

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from config.constants.paths import OPENSRE_HOME_DIR
 from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_PROMPT_PARAM,
     LOOP_REPORT_ARGS_PARAM,
@@ -22,6 +21,11 @@ from infrastructure.scheduling.scheduler.loops import (
 )
 from infrastructure.scheduling.scheduler.storage import list_tasks, update_task
 from infrastructure.scheduling.scheduler.types import Provider, TaskKind
+from integrations.github.tools.ci_analytics.snapshots import (
+    SNAPSHOT_DIRNAME,
+    snapshot_root,
+    write_snapshot,
+)
 from integrations.github.tools.ci_analytics.working_hours import (
     local_timezone,
     local_working_hours,
@@ -32,7 +36,6 @@ LOOP_WINDOW_DAYS = 7
 REPORT_NAME = "github_ci_reliability"
 """Builder name the manual-loop runner maps to :func:`build_report`."""
 
-SNAPSHOT_DIRNAME = "ci_reliability_reports"
 _LOCAL_CHANNEL = Provider.INTERACTIVE_SHELL.value
 
 
@@ -150,21 +153,20 @@ def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -
     except (GitHubApiError, ValueError) as exc:
         raise RuntimeError(f"Could not read the GitHub Actions history of {owner}/{repo}.") from exc
     report = analysis.report
-    snapshot = _write_snapshot(
-        snapshot_dir or OPENSRE_HOME_DIR / SNAPSHOT_DIRNAME,
+    snapshot = write_snapshot(
+        snapshot_root(snapshot_dir),
         owner,
         repo,
         now,
-        {"generated_at": now.isoformat(), "headline": headline(report), **report_payload(report)},
+        {
+            "generated_at": now.isoformat(),
+            "window_days": days,
+            "headline": headline(report),
+            "markdown": render_markdown(report),
+            **report_payload(report),
+        },
     )
     return "\n".join([render_markdown(report), "", headline(report), "", f"Raw data: {snapshot}"])
-
-
-def _write_snapshot(root: Path, owner: str, repo: str, now: datetime, payload: dict) -> Path:
-    target = root / f"{owner}-{repo}" / f"{now:%Y-%m-%dT%H%M%SZ}.json"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
-    return target
 
 
 def loop_card(scheduled: ScheduledLoop) -> list[str]:

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -23,6 +23,7 @@ from infrastructure.scheduling.scheduler.storage import list_tasks, update_task
 from infrastructure.scheduling.scheduler.types import Provider, TaskKind
 from integrations.github.tools.ci_analytics.snapshots import (
     SNAPSHOT_DIRNAME,
+    report_to_dict,
     snapshot_root,
     write_snapshot,
 )
@@ -162,7 +163,7 @@ def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -
             "generated_at": now.isoformat(),
             "window_days": days,
             "headline": headline(report),
-            "markdown": render_markdown(report),
+            "report": report_to_dict(report),
             **report_payload(report),
         },
     )

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -62,8 +62,8 @@ def loop_prompt(owner: str, repo: str) -> str:
         f"Scheduled CI/CD reliability report for {owner}/{repo}. First call "
         f'analyze_github_ci_reliability(owner="{owner}", repo="{repo}", days={LOOP_WINDOW_DAYS}); '
         "this read-only tool is the only source of the report. The report body is the tool's "
-        "response_text followed by its headline, exactly as returned: do not compute, convert, "
-        "reword, or omit any figure, and never answer without the tool result."
+        "response_text exactly as returned: do not compute, convert, reword, or omit any "
+        "figure, do not add the headline, and never answer without the tool result."
     )
 
 

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -20,14 +20,6 @@ from integrations.github.tools.ci_analytics.models import (
 _TOP_WORKFLOWS = 5
 _TOP_BLOCKED_PRS = 5
 _TOP_DEVELOPERS = 3
-_METHOD_LINES = (
-    "For each merged PR whose CI failed and later passed on the same commit:",
-    "  expected green = first run queued + normal duration "
-    "(median first-attempt pass of the slowest workflow)",
-    "  actually green = last workflow's first pass, or the next push / merge if earlier",
-    "  blocked        = actually green - expected green, counted in working hours ({hours}); "
-    "parallel workflows count once",
-)
 
 
 def render_markdown(report: CiAnalyticsReport) -> str:
@@ -61,6 +53,7 @@ def render_markdown(report: CiAnalyticsReport) -> str:
     if not report.executions:
         lines.extend(["", "No completed workflow runs were found in this window."])
     lines.extend(f"- {notice}" for notice in report.coverage_notices)
+    lines.extend(_key_results_markdown(report))
     return "\n".join(lines)
 
 
@@ -96,12 +89,13 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
                 Text(_downtime_headline(report), style="bold"),
             ]
         )
-        parts.extend(Text(line, style="dim") for line in _method_lines(report))
+        parts.append(Text(f"Working hours: {report.working_hours_label}", style="dim"))
         blocked = report.blocked_pr_delays
         if blocked:
             parts.append(Text(""))
             parts.append(_blocked_table(blocked))
-            parts.extend(Text(line) for line in _roll_up_lines(report))
+            parts.append(Text(""))
+            parts.extend(_kpi_line(label, value) for label, value in _roll_up_lines(report))
         if report.blocked_minutes_all > report.blocked_minutes:
             parts.append(
                 _kpi_line(
@@ -151,8 +145,82 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
     if not report.executions:
         parts.append(Text("No completed workflow runs were found in this window.", style="dim"))
     parts.extend(Text(notice, style="dim") for notice in report.coverage_notices)
+    if report.executions:
+        parts.append(Text(""))
+        parts.append(Text("Key results", style="bold"))
+        for label, value, share in key_results(report):
+            line = _kpi_line(label, value)
+            if share is not None:
+                line.append(f"  {_bar(share)}", style="dim")
+            parts.append(line)
     # Hang the block in the shell's two-column reply gutter like agent output.
     console.print(Padding(Group(*parts), (0, 0, 0, 2)))
+
+
+_BAR_WIDTH = 20
+
+
+def _bar(share: float) -> str:
+    """A plain text bar for a share between 0 and 1, twenty cells wide."""
+    filled = max(0, min(_BAR_WIDTH, round(share * _BAR_WIDTH)))
+    return "█" * filled + "░" * (_BAR_WIDTH - filled)
+
+
+def key_results(report: CiAnalyticsReport) -> list[tuple[str, str, float | None]]:
+    """The five figures a reader takes away, each with an optional share for a bar.
+
+    Order follows the metric priority in the demo's metrics reference: red time
+    on the default branch, recovery, CI-caused failures, normal duration,
+    developer time blocked.
+    """
+    window_hours = max(1, report.window_days * 24)
+    results: list[tuple[str, str, float | None]] = []
+    red_share = report.red_hours / window_hours
+    results.append(
+        (
+            f"{report.default_branch} branch red",
+            f"{_hours(report.red_hours)} of {report.window_days} days ({red_share:.1%}), "
+            f"{len(report.outages)} {_plural(len(report.outages), 'breakage')}",
+            red_share,
+        )
+    )
+    if report.mean_recovery_hours is not None:
+        results.append(("Mean time back to green", _hours(report.mean_recovery_hours), None))
+    if report.pr_executions:
+        flaky = report.count(FailureKind.RELIABILITY)
+        flake_share = flaky / report.pr_executions
+        results.append(
+            (
+                "CI-caused failures",
+                f"{flaky} of {report.pr_executions} PR runs ({flake_share:.1%})",
+                flake_share,
+            )
+        )
+    slowest = max(
+        (w for w in report.workflows if w.normal_minutes is not None),
+        key=lambda w: w.normal_minutes or 0.0,
+        default=None,
+    )
+    if slowest is not None:
+        results.append(
+            ("Slowest normal run", f"{slowest.workflow}, {slowest.normal_minutes:.0f}m", None)
+        )
+    if report.blocked_working_minutes > 0:
+        developers = report.developers_affected
+        per_week = (
+            report.blocked_working_minutes / developers / (report.window_days / 7)
+            if developers
+            else 0.0
+        )
+        results.append(
+            (
+                "Developer time blocked",
+                f"{_working(report.blocked_working_minutes)} of working time"
+                + (f", about {_working(per_week)} per developer a week" if developers else ""),
+                None,
+            )
+        )
+    return results
 
 
 def _working(minutes: float) -> str:
@@ -169,22 +237,18 @@ def _downtime_headline(report: CiAnalyticsReport) -> str:
     )
 
 
-def _method_lines(report: CiAnalyticsReport) -> list[str]:
-    return [line.format(hours=report.working_hours_label) for line in _METHOD_LINES]
+_BLOCKED_COLUMNS = (
+    ("PR", "left"),
+    ("Author", "left"),
+    ("CI failed", "left"),
+    ("Blocked (working hours)", "right"),
+    ("Wall clock", "right"),
+)
 
 
 def _blocked_table(blocked: tuple[PullRequestDelay, ...]) -> Table:
     table = Table(show_edge=False, pad_edge=False, box=None, header_style="dim")
-    for column, justify in (
-        ("PR", "left"),
-        ("Author", "left"),
-        ("Queued (UTC)", "left"),
-        ("+ normal", "right"),
-        ("= expected green", "left"),
-        ("Actually green", "left"),
-        ("Blocked, working", "right"),
-        ("Wall clock", "right"),
-    ):
+    for column, justify in _BLOCKED_COLUMNS:
         table.add_column(column, justify=justify)  # type: ignore[arg-type]
     for item in blocked[:_TOP_BLOCKED_PRS]:
         table.add_row(*_blocked_row(item))
@@ -195,42 +259,46 @@ def _blocked_row(item: PullRequestDelay) -> tuple[str, ...]:
     return (
         f"#{item.pr_number}" if item.pr_number else "-",
         item.author or "-",
-        _stamp(item.first_queued),
-        _minutes(item.normal_minutes),
-        _stamp(item.expected_green),
-        _stamp(item.actual_green),
+        _day(item.first_queued),
         _working(item.working_minutes),
         _minutes(item.delay_minutes),
     )
 
 
-def _roll_up_lines(report: CiAnalyticsReport) -> list[str]:
-    """The sum and the per-developer division, written as arithmetic."""
+def _roll_up_lines(report: CiAnalyticsReport) -> list[tuple[str, str]]:
+    """Labelled totals under the table: what the blocked time adds up to and who carries it."""
     blocked = report.blocked_pr_delays
     developers = report.developers_affected
     weeks = report.window_days / 7
-    lines: list[str] = []
+    lines: list[tuple[str, str]] = []
     rest = blocked[_TOP_BLOCKED_PRS:]
     if rest:
         lines.append(
-            f"+ {len(rest)} more {_plural(len(rest), 'PR')}: "
-            f"{_working(sum(item.working_minutes for item in rest))} of working time"
+            (
+                f"Not shown, {len(rest)} more {_plural(len(rest), 'PR')}",
+                f"{_working(sum(item.working_minutes for item in rest))} of working time",
+            )
         )
     lines.append(
-        f"Σ blocked = {_working(report.blocked_working_minutes)} of working time across "
-        f"{len(blocked)} merged {_plural(len(blocked), 'PR')} "
-        f"({_minutes(report.blocked_minutes)} wall clock)"
+        (
+            f"Total across {len(blocked)} merged {_plural(len(blocked), 'PR')}",
+            f"{_working(report.blocked_working_minutes)} of working time "
+            f"({_minutes(report.blocked_minutes)} wall clock)",
+        )
     )
     if developers:
         each = report.blocked_working_minutes / developers
         lines.append(
-            f"÷ {developers} {_plural(developers, 'developer')} = {_working(each)} each in "
-            f"{report.window_days} days, about {_working(each / weeks)} per developer per week; "
-            f"typical blocked PR {_working(report.median_working_minutes or 0.0)}"
+            (
+                f"Per developer ({developers})",
+                f"{_working(each)} in {report.window_days} days, "
+                f"about {_working(each / weeks)} a week",
+            )
         )
+        lines.append(("Typical blocked PR", _working(report.median_working_minutes or 0.0)))
     heaviest = _heaviest_developers(report)
     if heaviest:
-        lines.append(f"Heaviest hit: {heaviest}")
+        lines.append(("Most affected", heaviest))
     return lines
 
 
@@ -245,6 +313,10 @@ def _heaviest_developers(report: CiAnalyticsReport) -> str:
 
 def _stamp(when: datetime | None) -> str:
     return when.strftime("%b %d %H:%M") if when else "-"
+
+
+def _day(when: datetime | None) -> str:
+    return when.strftime("%b %d") if when else "-"
 
 
 def headline(report: CiAnalyticsReport) -> str:
@@ -299,19 +371,20 @@ def _classification(report: CiAnalyticsReport) -> list[str]:
 
 
 def _blocked_time(report: CiAnalyticsReport) -> list[str]:
-    lines = ["", f"**{_downtime_headline(report)}**"]
-    lines.extend(f"- {line.strip()}" for line in _method_lines(report))
+    lines = [
+        "",
+        f"**{_downtime_headline(report)}**",
+        f"Working hours: {report.working_hours_label}",
+    ]
     blocked = report.blocked_pr_delays
     if blocked:
         lines.append("")
-        lines.append(
-            "| PR | Author | Queued (UTC) | + normal | = expected green | Actually green | "
-            "Blocked, working | Wall clock |"
-        )
-        lines.append("| --- | --- | --- | ---: | --- | --- | ---: | ---: |")
+        lines.append("| " + " | ".join(name for name, _ in _BLOCKED_COLUMNS) + " |")
+        lines.append("| --- | --- | --- | ---: | ---: |")
         for item in blocked[:_TOP_BLOCKED_PRS]:
             lines.append("| " + " | ".join(_blocked_row(item)) + " |")
-        lines.extend(f"- {line}" for line in _roll_up_lines(report))
+        lines.append("")
+        lines.extend(f"- {label}: {value}" for label, value in _roll_up_lines(report))
     if report.blocked_minutes_all > report.blocked_minutes:
         lines.append(
             f"- Including PRs not merged yet: {_minutes(report.blocked_minutes_all)} wall clock"
@@ -365,6 +438,15 @@ def _rate(value: float | None) -> str:
 
 def _plural(count: int, noun: str) -> str:
     return noun if count == 1 else f"{noun}s"
+
+
+def _key_results_markdown(report: CiAnalyticsReport) -> list[str]:
+    if not report.executions:
+        return []
+    lines = ["", "**Key results**"]
+    for label, value, _share in key_results(report):
+        lines.append(f"- {label}: **{value}**")
+    return lines
 
 
 render_ci_report = render_report

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -23,37 +23,17 @@ _TOP_DEVELOPERS = 3
 
 
 def render_markdown(report: CiAnalyticsReport) -> str:
-    """Compact report the shell prints as-is."""
+    """Compact report the shell prints as-is. Key results lead; counts follow."""
     lines = [
         f"**CI/CD reliability for {report.owner}/{report.repo}, last {report.window_days} days**",
         "",
-        f"- GitHub Actions executions: **{report.executions}**",
-        f"- PR-triggered workflow executions: **{report.pr_executions}**",
-        f"- PR-triggered failed workflows: **{report.pr_failures}**",
-        f"- Raw PR workflow failure rate: **{_rate(report.pr_failure_rate)}**",
     ]
-    if report.pr_failures:
-        lines.extend(_classification(report))
-        lines.extend(_blocked_time(report))
-    lines.extend(_default_branch(report))
-    if report.workflows:
-        lines.extend(
-            [
-                "",
-                "| Workflow | Runs | Failed | CI-caused | Normal duration |",
-                "| --- | ---: | ---: | ---: | ---: |",
-            ]
-        )
-        for summary in report.workflows[:_TOP_WORKFLOWS]:
-            normal = "n/a" if summary.normal_minutes is None else f"{summary.normal_minutes:.0f}m"
-            lines.append(
-                f"| {summary.workflow} | {summary.runs} | {summary.failures} |"
-                f" {summary.reliability_failures} | {normal} |"
-            )
-    if not report.executions:
+    lines.extend(_key_results_markdown(report))
+    if report.executions:
+        lines.extend(_details_markdown(report))
+    else:
         lines.extend(["", "No completed workflow runs were found in this window."])
     lines.extend(f"- {notice}" for notice in report.coverage_notices)
-    lines.extend(_key_results_markdown(report))
     return "\n".join(lines)
 
 
@@ -186,14 +166,16 @@ def key_results(report: CiAnalyticsReport) -> list[tuple[str, str, float | None]
     )
     if report.mean_recovery_hours is not None:
         results.append(("Mean time back to green", _hours(report.mean_recovery_hours), None))
-    if report.pr_executions:
+    if report.pr_failures:
         flaky = report.count(FailureKind.RELIABILITY)
-        flake_share = flaky / report.pr_executions
+        of_failures = flaky / report.pr_failures
+        of_runs = flaky / report.pr_executions if report.pr_executions else 0.0
         results.append(
             (
                 "CI-caused failures",
-                f"{flaky} of {report.pr_executions} PR runs ({flake_share:.1%})",
-                flake_share,
+                f"{flaky} of {report.pr_failures} failed PR runs ({of_failures:.1%}); "
+                f"{of_runs:.1%} of all {report.pr_executions} PR runs",
+                of_failures,
             )
         )
     slowest = max(

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -23,7 +23,7 @@ _TOP_DEVELOPERS = 3
 
 
 def render_markdown(report: CiAnalyticsReport) -> str:
-    """Compact report the shell prints as-is. Key results lead; counts follow."""
+    """Compact report: key results lead; counts follow."""
     lines = [
         f"**CI/CD reliability for {report.owner}/{report.repo}, last {report.window_days} days**",
         "",
@@ -37,14 +37,193 @@ def render_markdown(report: CiAnalyticsReport) -> str:
     return "\n".join(lines)
 
 
-def render_report(console: Any, report: CiAnalyticsReport) -> None:
-    """Paint the report to a Rich console: headline KPIs, classification, blocked time, table."""
-    now = report.generated_at
+def render_report(console: Any, report: CiAnalyticsReport, *, compact: bool = False) -> None:
+    """Paint the report: key results first. ``compact`` omits the counts appendix."""
     parts: list[Any] = [
         Text(
             f"CI/CD reliability for {report.owner}/{report.repo}, last {report.window_days} days",
             style="bold",
         ),
+        Text(""),
+    ]
+    if report.executions:
+        parts.append(Text("Key results", style="bold"))
+        for label, value in key_results(report):
+            parts.append(_kpi_line(label, value))
+        if not compact:
+            parts.extend(_details_parts(report))
+    else:
+        parts.append(Text("No completed workflow runs were found in this window.", style="dim"))
+    parts.extend(Text(notice, style="dim") for notice in report.coverage_notices)
+    console.print(Padding(Group(*parts), (0, 0, 0, 2)))
+
+
+def key_results(report: CiAnalyticsReport) -> list[tuple[str, str]]:
+    """The five figures a reader takes away, red time first."""
+    window_hours = max(1, report.window_days * 24)
+    red_share = report.red_hours / window_hours
+    results: list[tuple[str, str]] = [
+        (
+            f"{report.default_branch} branch red",
+            f"{_hours(report.red_hours)} of {report.window_days} days ({red_share:.1%}), "
+            f"{len(report.outages)} {_plural(len(report.outages), 'breakage')}",
+        )
+    ]
+    if report.mean_recovery_hours is not None:
+        results.append(("Mean time back to green", _hours(report.mean_recovery_hours)))
+    if report.pr_failures:
+        flaky = report.count(FailureKind.RELIABILITY)
+        of_failures = flaky / report.pr_failures
+        of_runs = flaky / report.pr_executions if report.pr_executions else 0.0
+        results.append(
+            (
+                "CI-caused failures",
+                f"{flaky} of {report.pr_failures} failed PR runs ({of_failures:.1%}); "
+                f"{of_runs:.1%} of all {report.pr_executions} PR runs",
+            )
+        )
+    elif report.pr_executions:
+        flaky = report.count(FailureKind.RELIABILITY)
+        flake_share = flaky / report.pr_executions
+        results.append(
+            ("CI-caused failures", f"{flaky} of {report.pr_executions} PR runs ({flake_share:.1%})")
+        )
+    slowest = max(
+        (w for w in report.workflows if w.normal_minutes is not None),
+        key=lambda w: w.normal_minutes or 0.0,
+        default=None,
+    )
+    if slowest is not None:
+        results.append(("Slowest normal run", f"{slowest.workflow}, {slowest.normal_minutes:.0f}m"))
+    if report.blocked_working_minutes > 0:
+        developers = report.developers_affected
+        per_week = (
+            report.blocked_working_minutes / developers / (report.window_days / 7)
+            if developers
+            else 0.0
+        )
+        extra = f", about {_working(per_week)} per developer a week" if developers else ""
+        results.append(
+            (
+                "Developer time blocked",
+                f"{_working(report.blocked_working_minutes)} of working time{extra}",
+            )
+        )
+    return results
+
+
+def key_results_payload(report: CiAnalyticsReport) -> list[dict[str, str]]:
+    """The key-results rows as JSON-ready pairs."""
+    return [{"label": label, "value": value} for label, value in key_results(report)]
+
+
+def comparison_figures(report: CiAnalyticsReport) -> dict[str, str]:
+    """Rate and duration fields that can sit next to another repository."""
+    window_hours = max(1, report.window_days * 24)
+    red_share = report.red_hours / window_hours
+    flaky = report.count(FailureKind.RELIABILITY)
+    flake = f"{flaky / report.pr_executions:.1%}" if report.pr_executions else "n/a"
+    slowest = max(
+        (w for w in report.workflows if w.normal_minutes is not None),
+        key=lambda w: w.normal_minutes or 0.0,
+        default=None,
+    )
+    return {
+        "Red time on main": f"{red_share:.1%}",
+        "Mean time to green": (
+            _hours(report.mean_recovery_hours) if report.mean_recovery_hours is not None else "n/a"
+        ),
+        "CI-caused failure rate": flake,
+        "Slowest normal run": f"{slowest.normal_minutes:.0f}m" if slowest is not None else "n/a",
+        "PR failure rate": _rate(report.pr_failure_rate),
+    }
+
+
+def render_comparison(
+    console: Any, user: CiAnalyticsReport, peers: list[CiAnalyticsReport]
+) -> None:
+    """One table: the user's repo first, then the benchmark columns."""
+    reports = [user, *peers]
+    labels = [f"{item.owner}/{item.repo}" for item in reports]
+    figures = [comparison_figures(item) for item in reports]
+    table = Table(show_edge=False, pad_edge=False, box=None, header_style="dim")
+    table.add_column("Metric", justify="left")
+    for label in labels:
+        table.add_column(label, justify="right")
+    for metric in figures[0]:
+        table.add_row(metric, *[row.get(metric, "n/a") for row in figures])
+    peers_label = " and ".join(labels[1:]) if labels[1:] else "benchmarks"
+    parts: list[Any] = [
+        Text(""),
+        Text(f"Compared with {peers_label} over the same {user.window_days} days", style="bold"),
+        table,
+        Text(
+            "Red time = red_hours / (days × 24); CI-caused = reliability_failures / PR runs.",
+            style="dim",
+        ),
+    ]
+    for notice in (item for peer in peers for item in peer.coverage_notices):
+        parts.append(Text(notice, style="dim"))
+    console.print(Padding(Group(*parts), (0, 0, 0, 2)))
+
+
+def comparison_markdown(user: CiAnalyticsReport, peers: list[CiAnalyticsReport]) -> str:
+    """Markdown form of :func:`render_comparison`."""
+    reports = [user, *peers]
+    labels = [f"{item.owner}/{item.repo}" for item in reports]
+    figures = [comparison_figures(item) for item in reports]
+    header = "| Metric | " + " | ".join(labels) + " |"
+    align = "| --- | " + " | ".join("---:" for _ in labels) + " |"
+    rows = [
+        "| " + metric + " | " + " | ".join(row.get(metric, "n/a") for row in figures) + " |"
+        for metric in figures[0]
+    ]
+    peers_label = " and ".join(labels[1:]) if labels[1:] else "benchmarks"
+    return "\n".join(
+        [
+            f"Compared with {peers_label} over the same {user.window_days} days:",
+            "",
+            header,
+            align,
+            *rows,
+            "",
+            "Red time = red_hours / (days × 24); CI-caused = reliability_failures / PR runs.",
+        ]
+    )
+
+
+def _details_markdown(report: CiAnalyticsReport) -> list[str]:
+    lines = [
+        "",
+        f"- GitHub Actions executions: **{report.executions}**",
+        f"- PR-triggered workflow executions: **{report.pr_executions}**",
+        f"- PR-triggered failed workflows: **{report.pr_failures}**",
+        f"- Raw PR workflow failure rate: **{_rate(report.pr_failure_rate)}**",
+    ]
+    if report.pr_failures:
+        lines.extend(_classification(report))
+        lines.extend(_blocked_time(report))
+    lines.extend(_default_branch(report))
+    if report.workflows:
+        lines.extend(
+            [
+                "",
+                "| Workflow | Runs | Failed | CI-caused | Normal duration |",
+                "| --- | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for summary in report.workflows[:_TOP_WORKFLOWS]:
+            normal = "n/a" if summary.normal_minutes is None else f"{summary.normal_minutes:.0f}m"
+            lines.append(
+                f"| {summary.workflow} | {summary.runs} | {summary.failures} |"
+                f" {summary.reliability_failures} | {normal} |"
+            )
+    return lines
+
+
+def _details_parts(report: CiAnalyticsReport) -> list[Any]:
+    now = report.generated_at
+    parts: list[Any] = [
         Text(""),
         _kpi_line("GitHub Actions executions", str(report.executions)),
         _kpi_line("PR-triggered workflow executions", str(report.pr_executions)),
@@ -122,87 +301,7 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
                 normal,
             )
         parts.extend([Text(""), table])
-    if not report.executions:
-        parts.append(Text("No completed workflow runs were found in this window.", style="dim"))
-    parts.extend(Text(notice, style="dim") for notice in report.coverage_notices)
-    if report.executions:
-        parts.append(Text(""))
-        parts.append(Text("Key results", style="bold"))
-        for label, value, share in key_results(report):
-            line = _kpi_line(label, value)
-            if share is not None:
-                line.append(f"  {_bar(share)}", style="dim")
-            parts.append(line)
-    # Hang the block in the shell's two-column reply gutter like agent output.
-    console.print(Padding(Group(*parts), (0, 0, 0, 2)))
-
-
-_BAR_WIDTH = 20
-
-
-def _bar(share: float) -> str:
-    """A plain text bar for a share between 0 and 1, twenty cells wide."""
-    filled = max(0, min(_BAR_WIDTH, round(share * _BAR_WIDTH)))
-    return "█" * filled + "░" * (_BAR_WIDTH - filled)
-
-
-def key_results(report: CiAnalyticsReport) -> list[tuple[str, str, float | None]]:
-    """The five figures a reader takes away, each with an optional share for a bar.
-
-    Order follows the metric priority in the demo's metrics reference: red time
-    on the default branch, recovery, CI-caused failures, normal duration,
-    developer time blocked.
-    """
-    window_hours = max(1, report.window_days * 24)
-    results: list[tuple[str, str, float | None]] = []
-    red_share = report.red_hours / window_hours
-    results.append(
-        (
-            f"{report.default_branch} branch red",
-            f"{_hours(report.red_hours)} of {report.window_days} days ({red_share:.1%}), "
-            f"{len(report.outages)} {_plural(len(report.outages), 'breakage')}",
-            red_share,
-        )
-    )
-    if report.mean_recovery_hours is not None:
-        results.append(("Mean time back to green", _hours(report.mean_recovery_hours), None))
-    if report.pr_failures:
-        flaky = report.count(FailureKind.RELIABILITY)
-        of_failures = flaky / report.pr_failures
-        of_runs = flaky / report.pr_executions if report.pr_executions else 0.0
-        results.append(
-            (
-                "CI-caused failures",
-                f"{flaky} of {report.pr_failures} failed PR runs ({of_failures:.1%}); "
-                f"{of_runs:.1%} of all {report.pr_executions} PR runs",
-                of_failures,
-            )
-        )
-    slowest = max(
-        (w for w in report.workflows if w.normal_minutes is not None),
-        key=lambda w: w.normal_minutes or 0.0,
-        default=None,
-    )
-    if slowest is not None:
-        results.append(
-            ("Slowest normal run", f"{slowest.workflow}, {slowest.normal_minutes:.0f}m", None)
-        )
-    if report.blocked_working_minutes > 0:
-        developers = report.developers_affected
-        per_week = (
-            report.blocked_working_minutes / developers / (report.window_days / 7)
-            if developers
-            else 0.0
-        )
-        results.append(
-            (
-                "Developer time blocked",
-                f"{_working(report.blocked_working_minutes)} of working time"
-                + (f", about {_working(per_week)} per developer a week" if developers else ""),
-                None,
-            )
-        )
-    return results
+    return parts
 
 
 def _working(minutes: float) -> str:
@@ -302,7 +401,7 @@ def _day(when: datetime | None) -> str:
 
 
 def headline(report: CiAnalyticsReport) -> str:
-    """One deterministic sentence naming the biggest cost, for the agent to repeat verbatim."""
+    """One deterministic sentence naming the biggest cost."""
     if report.blocked_working_minutes > 0:
         heaviest = report.developer_waits[0]
         developers = report.developers_affected
@@ -425,8 +524,8 @@ def _plural(count: int, noun: str) -> str:
 def _key_results_markdown(report: CiAnalyticsReport) -> list[str]:
     if not report.executions:
         return []
-    lines = ["", "**Key results**"]
-    for label, value, _share in key_results(report):
+    lines = ["**Key results**"]
+    for label, value in key_results(report):
         lines.append(f"- {label}: **{value}**")
     return lines
 
@@ -436,7 +535,12 @@ ci_report_headline = headline
 
 __all__ = [
     "ci_report_headline",
+    "comparison_figures",
+    "comparison_markdown",
+    "key_results",
+    "key_results_payload",
     "render_ci_report",
+    "render_comparison",
     "format_minutes",
     "headline",
     "render_markdown",

--- a/integrations/github/tools/ci_analytics/snapshots.py
+++ b/integrations/github/tools/ci_analytics/snapshots.py
@@ -1,0 +1,76 @@
+"""On-disk snapshots of CI reliability reports, shared by the loop tick and the tool.
+
+A snapshot is the report's raw figures plus when they were computed. The
+loop writes one per tick; the tool writes one per live analysis and reuses a
+fresh one for the same repository and window instead of reading GitHub
+again, which matters for benchmark repositories whose 30-day history takes
+minutes to read.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from config.constants.paths import OPENSRE_HOME_DIR
+
+SNAPSHOT_DIRNAME = "ci_reliability_reports"
+SNAPSHOT_MAX_AGE_HOURS = 24
+
+
+def snapshot_root(root: Path | None = None) -> Path:
+    return root or OPENSRE_HOME_DIR / SNAPSHOT_DIRNAME
+
+
+def write_snapshot(
+    root: Path, owner: str, repo: str, now: datetime, payload: dict[str, Any]
+) -> Path:
+    """Write ``payload`` under ``<root>/<owner>-<repo>/<timestamp>.json`` and return the path."""
+    target = root / f"{owner}-{repo}" / f"{now:%Y-%m-%dT%H%M%SZ}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+    return target
+
+
+def read_fresh_snapshot(
+    root: Path,
+    owner: str,
+    repo: str,
+    *,
+    window_days: int,
+    now: datetime,
+    max_age_hours: int = SNAPSHOT_MAX_AGE_HOURS,
+) -> dict[str, Any] | None:
+    """The newest snapshot for ``owner/repo`` with the same window, if young enough."""
+    folder = root / f"{owner}-{repo}"
+    if not folder.is_dir():
+        return None
+    for path in sorted(folder.glob("*.json"), reverse=True):
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            generated = datetime.fromisoformat(str(loaded["generated_at"]))
+        except (OSError, ValueError, KeyError, TypeError):
+            continue
+        if not isinstance(loaded, dict):
+            continue
+        payload: dict[str, Any] = dict(loaded)
+        if generated.tzinfo is None:
+            generated = generated.replace(tzinfo=UTC)
+        if int(payload.get("window_days", -1)) != window_days:
+            continue
+        if (now - generated).total_seconds() > max_age_hours * 3600:
+            return None
+        payload["snapshot_path"] = str(path)
+        return payload
+    return None
+
+
+__all__ = [
+    "SNAPSHOT_DIRNAME",
+    "SNAPSHOT_MAX_AGE_HOURS",
+    "read_fresh_snapshot",
+    "snapshot_root",
+    "write_snapshot",
+]

--- a/integrations/github/tools/ci_analytics/snapshots.py
+++ b/integrations/github/tools/ci_analytics/snapshots.py
@@ -29,13 +29,23 @@ def snapshot_root(root: Path | None = None) -> Path:
     return root or OPENSRE_HOME_DIR / SNAPSHOT_DIRNAME
 
 
+def _folder(root: Path, owner: str, repo: str) -> Path:
+    """One directory per repository, nested so ``foo/bar-baz`` and ``foo-bar/baz`` never meet."""
+    return root / owner / repo
+
+
 def write_snapshot(
     root: Path, owner: str, repo: str, now: datetime, payload: dict[str, Any]
 ) -> Path:
-    """Write ``payload`` under ``<root>/<owner>-<repo>/<timestamp>.json`` and return the path."""
-    target = root / f"{owner}-{repo}" / f"{now:%Y-%m-%dT%H%M%SZ}.json"
+    """Write ``payload`` under ``<root>/<owner>/<repo>/<timestamp>.json`` and return the path.
+
+    The owner and repository are stored in the file too, so a read can check
+    that a snapshot belongs to the repository it is answering for.
+    """
+    target = _folder(root, owner, repo) / f"{now:%Y-%m-%dT%H%M%SZ}.json"
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+    stamped = {**payload, "owner": owner, "repo": repo}
+    target.write_text(json.dumps(stamped, indent=2, sort_keys=True, default=str), encoding="utf-8")
     return target
 
 
@@ -49,7 +59,7 @@ def read_fresh_snapshot(
     max_age_hours: int = SNAPSHOT_MAX_AGE_HOURS,
 ) -> dict[str, Any] | None:
     """The newest snapshot for ``owner/repo`` with the same window, if young enough."""
-    folder = root / f"{owner}-{repo}"
+    folder = _folder(root, owner, repo)
     if not folder.is_dir():
         return None
     for path in sorted(folder.glob("*.json"), reverse=True):
@@ -63,6 +73,8 @@ def read_fresh_snapshot(
         payload: dict[str, Any] = dict(loaded)
         if generated.tzinfo is None:
             generated = generated.replace(tzinfo=UTC)
+        if payload.get("owner") != owner or payload.get("repo") != repo:
+            continue
         if int(payload.get("window_days", -1)) != window_days:
             continue
         if (now - generated).total_seconds() > max_age_hours * 3600:

--- a/integrations/github/tools/ci_analytics/snapshots.py
+++ b/integrations/github/tools/ci_analytics/snapshots.py
@@ -9,12 +9,17 @@ minutes to read.
 
 from __future__ import annotations
 
+import dataclasses
 import json
+import types
+from collections.abc import Mapping
 from datetime import UTC, datetime
+from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Union, cast, get_args, get_origin, get_type_hints
 
 from config.constants.paths import OPENSRE_HOME_DIR
+from integrations.github.tools.ci_analytics.models import CiAnalyticsReport
 
 SNAPSHOT_DIRNAME = "ci_reliability_reports"
 SNAPSHOT_MAX_AGE_HOURS = 24
@@ -67,10 +72,61 @@ def read_fresh_snapshot(
     return None
 
 
+def report_to_dict(report: CiAnalyticsReport) -> dict[str, Any]:
+    """The report as JSON-ready data: datetimes as ISO strings, enums as values."""
+    return cast(dict[str, Any], _to_json_value(dataclasses.asdict(report)))
+
+
+def report_from_dict(data: Mapping[str, Any]) -> CiAnalyticsReport:
+    """Rebuild a report saved by :func:`report_to_dict`."""
+    built = _from_json_value(CiAnalyticsReport, dict(data))
+    return cast(CiAnalyticsReport, built)
+
+
+def _to_json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _to_json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_json_value(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _from_json_value(annotation: Any, value: Any) -> Any:
+    """Rebuild ``value`` as ``annotation``: dataclasses, datetimes, enums, tuples, optionals."""
+    if value is None:
+        return None
+    origin = get_origin(annotation)
+    if origin in (types.UnionType, Union):
+        inner = [arg for arg in get_args(annotation) if arg is not type(None)]
+        return _from_json_value(inner[0], value) if len(inner) == 1 else value
+    if origin is tuple:
+        item_type = get_args(annotation)[0]
+        return tuple(_from_json_value(item_type, item) for item in value)
+    if annotation is datetime:
+        return datetime.fromisoformat(str(value))
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        return annotation(value)
+    if dataclasses.is_dataclass(annotation) and isinstance(value, Mapping):
+        hints = get_type_hints(annotation)
+        kwargs = {
+            field.name: _from_json_value(hints[field.name], value.get(field.name))
+            for field in dataclasses.fields(annotation)
+            if field.name in value
+        }
+        return cast(Any, annotation)(**kwargs)
+    return value
+
+
 __all__ = [
     "SNAPSHOT_DIRNAME",
     "SNAPSHOT_MAX_AGE_HOURS",
     "read_fresh_snapshot",
+    "report_from_dict",
+    "report_to_dict",
     "snapshot_root",
     "write_snapshot",
 ]

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import Any
 
-from rich.markdown import Markdown
 from rich.markup import escape
 
 from core.agent_harness.tools import action_context_from_agent_context
@@ -33,6 +32,8 @@ from integrations.github.tools.ci_analytics.render import (
 )
 from integrations.github.tools.ci_analytics.snapshots import (
     read_fresh_snapshot,
+    report_from_dict,
+    report_to_dict,
     snapshot_root,
     write_snapshot,
 )
@@ -165,28 +166,35 @@ def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
 def _from_snapshot(
     snapshot: dict[str, Any], owner: str, repo: str, window: int, console: Any
 ) -> dict[str, Any]:
-    """Answer from a same-day snapshot: the figures, and when they were computed."""
+    """Answer from a same-day snapshot with the same renderer as a live analysis."""
     generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
-    summary = (
-        f"{owner}/{repo}: {snapshot.get('executions')} runs in {window} days, "
-        f"{snapshot.get('pr_failures')} of {snapshot.get('pr_executions')} PR runs failed, "
-        f"{snapshot.get('reliability_failures')} CI-caused "
-        f"(figures as of {generated} UTC, from the saved snapshot)."
-    )
-    markdown = str(snapshot.get("markdown") or "")
+    saved = snapshot.get("report")
+    report = report_from_dict(saved) if isinstance(saved, dict) else None
     if console is not None:
         console.print(
             f"  [dim]Using the CI reliability snapshot of {escape(f'{owner}/{repo}')} "
             f"from {generated} UTC (same {window}-day window).[/dim]"
         )
-        if markdown:
-            console.print(Markdown(markdown))
         console.print()
+    if report is not None:
+        result = _result(report, owner, repo, window, console)
+        result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
+        result["from_snapshot"] = snapshot.get("generated_at")
+        if console is not None:
+            result["response_text"] = result["summary"]
+        return result
+    # An older snapshot without the report object: the figures only.
     figures = {
         key: value
         for key, value in snapshot.items()
         if key not in {"generated_at", "headline", "snapshot_path", "window_days", "markdown"}
     }
+    summary = (
+        f"{owner}/{repo}: {snapshot.get('executions')} runs in {window} days, "
+        f"{snapshot.get('pr_failures')} of {snapshot.get('pr_executions')} PR runs failed, "
+        f"{snapshot.get('reliability_failures')} CI-caused. "
+        f"Figures as of {generated} UTC, from the saved snapshot."
+    )
     return {
         "source": _SOURCE,
         "success": True,
@@ -196,10 +204,40 @@ def _from_snapshot(
         "summary": summary,
         "headline": str(snapshot.get("headline", "")),
         "from_snapshot": snapshot.get("generated_at"),
-        "rendered_in_shell": console is not None and bool(markdown),
+        "rendered_in_shell": False,
         **figures,
-        "response_text": summary if console is not None else (markdown or summary),
+        "response_text": summary,
     }
+
+
+def _result(
+    report: CiAnalyticsReport, owner: str, repo: str, window: int, console: Any
+) -> dict[str, Any]:
+    """The tool's return for ``report``: painted in the shell, markdown elsewhere."""
+    summary = (
+        f"{owner}/{repo}: {report.executions} runs in {window} days, "
+        f"{report.pr_failures} of {report.pr_executions} PR runs failed, "
+        f"{report.count(FailureKind.RELIABILITY)} CI-caused, "
+        f"{format_minutes(report.blocked_working_minutes)} of developer downtime "
+        f"({format_minutes(report.blocked_minutes)} wall clock) on merged PRs."
+    )
+    base = {
+        "source": _SOURCE,
+        "success": True,
+        "owner": owner,
+        "repo": repo,
+        "default_branch": report.default_branch,
+        "window_days": window,
+        "summary": summary,
+        "headline": headline(report),
+        "rendered_in_shell": console is not None,
+    }
+    if console is not None:
+        # The shell already shows every figure; handing the raw numbers back
+        # as well only invites the model to retype them, so they stay out.
+        render_report(console, report)
+        return {**base, "coverage_notices": list(report.coverage_notices), "response_text": summary}
+    return {**base, **report_payload(report), "response_text": render_markdown(report)}
 
 
 @tool(
@@ -350,44 +388,16 @@ def analyze_github_ci_reliability(
             "generated_at": now.isoformat(),
             "window_days": window,
             "headline": headline(report),
-            "markdown": render_markdown(report),
+            "report": report_to_dict(report),
             **report_payload(report),
         },
     )
-    summary = (
-        f"{repo_owner}/{repo_name}: {report.executions} runs in {window} days, "
-        f"{report.pr_failures} of {report.pr_executions} PR runs failed, "
-        f"{report.count(FailureKind.RELIABILITY)} CI-caused, "
-        f"{format_minutes(report.blocked_working_minutes)} of developer downtime "
-        f"({format_minutes(report.blocked_minutes)} wall clock) on merged PRs."
-    )
-    rendered = console is not None
     if console is not None:
         console.print(
             f"  [dim]Read {analysis.runs_read} runs in {time.monotonic() - started:.0f}s.[/dim]"
         )
         console.print()
-    base = {
-        "source": _SOURCE,
-        "success": True,
-        "owner": repo_owner,
-        "repo": repo_name,
-        "default_branch": report.default_branch,
-        "window_days": window,
-        "summary": summary,
-        "headline": headline(report),
-        "rendered_in_shell": rendered,
-    }
-    if rendered:
-        # The shell already shows every figure; handing the raw numbers back
-        # as well only invites the model to retype them, so they stay out.
-        render_report(console, report)
-        return {
-            **base,
-            "coverage_notices": list(report.coverage_notices),
-            "response_text": summary,
-        }
-    return {**base, **report_payload(report), "response_text": render_markdown(report)}
+    return _result(report, repo_owner, repo_name, window, console)
 
 
 __all__ = ["TOOL_NAME", "analyze_github_ci_reliability"]

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import Any
 
+from rich.markdown import Markdown
 from rich.markup import escape
 
 from core.agent_harness.tools import action_context_from_agent_context
@@ -29,6 +30,11 @@ from integrations.github.tools.ci_analytics.render import (
     headline,
     render_markdown,
     render_report,
+)
+from integrations.github.tools.ci_analytics.snapshots import (
+    read_fresh_snapshot,
+    snapshot_root,
+    write_snapshot,
 )
 
 TOOL_NAME = "analyze_github_ci_reliability"
@@ -156,6 +162,46 @@ def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
     }
 
 
+def _from_snapshot(
+    snapshot: dict[str, Any], owner: str, repo: str, window: int, console: Any
+) -> dict[str, Any]:
+    """Answer from a same-day snapshot: the figures, and when they were computed."""
+    generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
+    summary = (
+        f"{owner}/{repo}: {snapshot.get('executions')} runs in {window} days, "
+        f"{snapshot.get('pr_failures')} of {snapshot.get('pr_executions')} PR runs failed, "
+        f"{snapshot.get('reliability_failures')} CI-caused "
+        f"(figures as of {generated} UTC, from the saved snapshot)."
+    )
+    markdown = str(snapshot.get("markdown") or "")
+    if console is not None:
+        console.print(
+            f"  [dim]Using the CI reliability snapshot of {escape(f'{owner}/{repo}')} "
+            f"from {generated} UTC (same {window}-day window).[/dim]"
+        )
+        if markdown:
+            console.print(Markdown(markdown))
+        console.print()
+    figures = {
+        key: value
+        for key, value in snapshot.items()
+        if key not in {"generated_at", "headline", "snapshot_path", "window_days", "markdown"}
+    }
+    return {
+        "source": _SOURCE,
+        "success": True,
+        "owner": owner,
+        "repo": repo,
+        "window_days": window,
+        "summary": summary,
+        "headline": str(snapshot.get("headline", "")),
+        "from_snapshot": snapshot.get("generated_at"),
+        "rendered_in_shell": console is not None and bool(markdown),
+        **figures,
+        "response_text": summary if console is not None else (markdown or summary),
+    }
+
+
 @tool(
     name=TOOL_NAME,
     source=_SOURCE,
@@ -260,6 +306,11 @@ def analyze_github_ci_reliability(
         return tool_unavailable(_SOURCE, message, response_text=message)
     now = datetime.now(UTC)
     console = _console(context)
+    snapshot = read_fresh_snapshot(
+        snapshot_root(), repo_owner, repo_name, window_days=window, now=now
+    )
+    if snapshot is not None:
+        return _from_snapshot(snapshot, repo_owner, repo_name, window, console)
     if console is not None:
         # Two-column lead matches the shell's reply gutter so the tool's lines
         # hang with the agent's notes instead of breaking the transcript edge.
@@ -268,8 +319,16 @@ def analyze_github_ci_reliability(
             f"last {window} days…[/dim]"
         )
     started = time.monotonic()
+    progress = None
+    if console is not None:
+
+        def progress(line: str) -> None:
+            console.print(f"  [dim]{escape(line)}[/dim]")
+
     try:
-        analysis = analyze_repository(repo_owner, repo_name, token=token, days=window, now=now)
+        analysis = analyze_repository(
+            repo_owner, repo_name, token=token, days=window, now=now, progress=progress
+        )
     except (GitHubApiError, ValueError) as exc:
         report_run_error(
             exc,
@@ -282,6 +341,19 @@ def analyze_github_ci_reliability(
         message = _failure_message(exc, repository=f"{repo_owner}/{repo_name}")
         return tool_unavailable(_SOURCE, message, response_text=message)
     report = analysis.report
+    write_snapshot(
+        snapshot_root(),
+        repo_owner,
+        repo_name,
+        now,
+        {
+            "generated_at": now.isoformat(),
+            "window_days": window,
+            "headline": headline(report),
+            "markdown": render_markdown(report),
+            **report_payload(report),
+        },
+    )
     summary = (
         f"{repo_owner}/{repo_name}: {report.executions} runs in {window} days, "
         f"{report.pr_failures} of {report.pr_executions} PR runs failed, "

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from datetime import UTC, datetime
 from http import HTTPStatus
@@ -39,6 +40,8 @@ from integrations.github.tools.ci_analytics.snapshots import (
 )
 
 TOOL_NAME = "analyze_github_ci_reliability"
+logger = logging.getLogger(__name__)
+
 _SOURCE = "github"
 _DEFAULT_WINDOW_DAYS = 30
 _MIN_WINDOW_DAYS = 1
@@ -379,19 +382,24 @@ def analyze_github_ci_reliability(
         message = _failure_message(exc, repository=f"{repo_owner}/{repo_name}")
         return tool_unavailable(_SOURCE, message, response_text=message)
     report = analysis.report
-    write_snapshot(
-        snapshot_root(),
-        repo_owner,
-        repo_name,
-        now,
-        {
-            "generated_at": now.isoformat(),
-            "window_days": window,
-            "headline": headline(report),
-            "report": report_to_dict(report),
-            **report_payload(report),
-        },
-    )
+    try:
+        write_snapshot(
+            snapshot_root(),
+            repo_owner,
+            repo_name,
+            now,
+            {
+                "generated_at": now.isoformat(),
+                "window_days": window,
+                "headline": headline(report),
+                "report": report_to_dict(report),
+                **report_payload(report),
+            },
+        )
+    except OSError:
+        # The analysis is the result; a snapshot that cannot be written only
+        # means the next call reads GitHub again.
+        logger.warning("Could not save the CI reliability snapshot", exc_info=True)
     if console is not None:
         console.print(
             f"  [dim]Read {analysis.runs_read} runs in {time.monotonic() - started:.0f}s.[/dim]"

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -52,6 +52,12 @@ _MAX_WINDOW_DAYS = 90
 _DEFAULT_BENCHMARKS = (("apache", "airflow"), ("fastapi", "fastapi"))
 
 
+def _flag(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
 def _available(sources: dict[str, dict]) -> bool:
     gh = sources.get("github", {})
     return bool(
@@ -405,8 +411,10 @@ def _result(
         "blocked_minutes": "Wall-clock minutes merged PRs waited past their expected green time",
         "blocked_working_minutes": "The part of that wait inside working hours: developer downtime",
         "red_hours": "Hours the default branch had at least one red workflow",
-        "headline": "One sentence naming the biggest cost, to repeat verbatim",
+        "headline": "One sentence naming the biggest cost (already painted; do not repeat)",
+        "key_results": "The five takeaway rows, red time first, even when the shell painted the report",
         "response_text": "The rendered report, or a one-line summary when the shell painted it",
+        "benchmarks": "When include_benchmarks is true: Airflow and FastAPI rows from the same window",
     },
     surfaces=(ToolSurface.CHAT, ToolSurface.ACTION),
     side_effect_level=SideEffectLevel.READ_ONLY,
@@ -433,6 +441,13 @@ def _result(
                 "type": "string",
                 "description": "Local checkout used to detect owner/repo when not given.",
             },
+            "include_benchmarks": {
+                "type": "boolean",
+                "description": (
+                    "Also compare this repository with apache/airflow and fastapi/fastapi "
+                    "over the same window. Default false."
+                ),
+            },
             "github_token": {"type": "string"},
         },
         "additionalProperties": False,
@@ -447,6 +462,7 @@ def analyze_github_ci_reliability(
     repo: str | None = None,
     days: int | None = None,
     workspace: str | None = None,
+    include_benchmarks: bool = False,
     github_token: str | None = None,
     context: Any = None,
     **_kwargs: Any,
@@ -456,8 +472,11 @@ def analyze_github_ci_reliability(
     In the interactive shell the report is painted straight to the console so
     every figure the user sees is the computed one; the returned
     ``response_text`` then only summarizes. Other surfaces get the markdown.
+    When ``include_benchmarks`` is true the same call also paints one comparison
+    table against apache/airflow and fastapi/fastapi (snapshots first).
     """
     window = min(max(int(days or _DEFAULT_WINDOW_DAYS), _MIN_WINDOW_DAYS), _MAX_WINDOW_DAYS)
+    compare = _flag(include_benchmarks)
     repo_owner = (owner or "").strip()
     repo_name = (repo or "").strip().removesuffix(".git")
     if not repo_owner or not repo_name:
@@ -483,7 +502,15 @@ def analyze_github_ci_reliability(
         snapshot_root(), repo_owner, repo_name, window_days=window, now=now
     )
     if snapshot is not None:
-        return _from_snapshot(snapshot, repo_owner, repo_name, window, console)
+        return _from_snapshot(
+            snapshot,
+            repo_owner,
+            repo_name,
+            window,
+            console,
+            include_benchmarks=compare,
+            token=token,
+        )
     if console is not None:
         # Two-column lead matches the shell's reply gutter so the tool's lines
         # hang with the agent's notes instead of breaking the transcript edge.
@@ -537,7 +564,15 @@ def analyze_github_ci_reliability(
             f"  [dim]Read {analysis.runs_read} runs in {time.monotonic() - started:.0f}s.[/dim]"
         )
         console.print()
-    return _result(report, repo_owner, repo_name, window, console)
+    return _result(
+        report,
+        repo_owner,
+        repo_name,
+        window,
+        console,
+        include_benchmarks=compare,
+        token=token,
+    )
 
 
 __all__ = ["TOOL_NAME", "analyze_github_ci_reliability"]

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -26,8 +26,11 @@ from integrations.github.repo_scope import detect_git_remote_repo_scope
 from integrations.github.tools.ci_analytics.analysis import analyze_repository
 from integrations.github.tools.ci_analytics.models import CiAnalyticsReport, FailureKind
 from integrations.github.tools.ci_analytics.render import (
+    comparison_markdown,
     format_minutes,
     headline,
+    key_results_payload,
+    render_comparison,
     render_markdown,
     render_report,
 )
@@ -46,6 +49,7 @@ _SOURCE = "github"
 _DEFAULT_WINDOW_DAYS = 30
 _MIN_WINDOW_DAYS = 1
 _MAX_WINDOW_DAYS = 90
+_DEFAULT_BENCHMARKS = (("apache", "airflow"), ("fastapi", "fastapi"))
 
 
 def _available(sources: dict[str, dict]) -> bool:
@@ -167,7 +171,14 @@ def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
 
 
 def _from_snapshot(
-    snapshot: dict[str, Any], owner: str, repo: str, window: int, console: Any
+    snapshot: dict[str, Any],
+    owner: str,
+    repo: str,
+    window: int,
+    console: Any,
+    *,
+    include_benchmarks: bool = False,
+    token: str = "",
 ) -> dict[str, Any]:
     """Answer from a same-day snapshot with the same renderer as a live analysis."""
     generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
@@ -180,7 +191,15 @@ def _from_snapshot(
         )
         console.print()
     if report is not None:
-        result = _result(report, owner, repo, window, console)
+        result = _result(
+            report,
+            owner,
+            repo,
+            window,
+            console,
+            include_benchmarks=include_benchmarks,
+            token=token,
+        )
         result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
         result["from_snapshot"] = snapshot.get("generated_at")
         if console is not None:
@@ -213,8 +232,113 @@ def _from_snapshot(
     }
 
 
+def _peer_payload(report: CiAnalyticsReport, *, from_snapshot: str | None) -> dict[str, Any]:
+    return {
+        "owner": report.owner,
+        "repo": report.repo,
+        "from_snapshot": from_snapshot,
+        "key_results": key_results_payload(report),
+        "red_hours": round(report.red_hours, 2),
+        "mean_recovery_hours": report.mean_recovery_hours,
+        "pr_failure_rate": report.pr_failure_rate,
+        "reliability_failures": report.count(FailureKind.RELIABILITY),
+        "pr_executions": report.pr_executions,
+    }
+
+
+def _load_peer_report(
+    owner: str,
+    repo: str,
+    *,
+    window: int,
+    token: str,
+    now: datetime,
+    console: Any,
+) -> tuple[CiAnalyticsReport, str | None] | None:
+    """A benchmark report from today's snapshot, or a live read. ``None`` on failure."""
+    snapshot = read_fresh_snapshot(snapshot_root(), owner, repo, window_days=window, now=now)
+    if snapshot is not None:
+        saved = snapshot.get("report")
+        if isinstance(saved, dict):
+            report = report_from_dict(saved)
+            return report, str(snapshot.get("generated_at") or "")
+    if console is not None:
+        console.print(
+            f"  [dim]Reading GitHub Actions history for {escape(f'{owner}/{repo}')} "
+            f"(benchmark), last {window} days…[/dim]"
+        )
+    try:
+        analysis = analyze_repository(owner, repo, token=token, days=window, now=now)
+    except (GitHubApiError, ValueError):
+        logger.warning("Benchmark analysis failed for %s/%s", owner, repo, exc_info=True)
+        return None
+    try:
+        write_snapshot(
+            snapshot_root(),
+            owner,
+            repo,
+            now,
+            {
+                "generated_at": now.isoformat(),
+                "window_days": window,
+                "headline": headline(analysis.report),
+                "report": report_to_dict(analysis.report),
+                **report_payload(analysis.report),
+            },
+        )
+    except OSError:
+        logger.warning("Could not save the CI reliability snapshot", exc_info=True)
+    return analysis.report, None
+
+
+def _attach_benchmarks(
+    result: dict[str, Any],
+    report: CiAnalyticsReport,
+    *,
+    window: int,
+    token: str,
+    console: Any,
+) -> dict[str, Any]:
+    """Add the host comparison table and structured benchmark rows."""
+    now = datetime.now(UTC)
+    peers: list[CiAnalyticsReport] = []
+    rows: list[dict[str, Any]] = []
+    skipped: list[str] = []
+    for owner, repo in _DEFAULT_BENCHMARKS:
+        if owner == report.owner and repo == report.repo:
+            continue
+        loaded = _load_peer_report(
+            owner, repo, window=window, token=token, now=now, console=console
+        )
+        if loaded is None:
+            skipped.append(f"{owner}/{repo}")
+            continue
+        peer, stamp = loaded
+        peers.append(peer)
+        rows.append(_peer_payload(peer, from_snapshot=stamp))
+    result["benchmarks"] = rows
+    if skipped:
+        result["benchmarks_skipped"] = skipped
+    if not peers:
+        return result
+    if console is not None:
+        render_comparison(console, report, peers)
+        return result
+    compare = comparison_markdown(report, peers)
+    result["comparison_text"] = compare
+    result["response_text"] = f"{result['response_text']}\n\n{compare}"
+    return result
+
+
 def _result(
-    report: CiAnalyticsReport, owner: str, repo: str, window: int, console: Any
+    report: CiAnalyticsReport,
+    owner: str,
+    repo: str,
+    window: int,
+    console: Any,
+    *,
+    include_benchmarks: bool = False,
+    token: str = "",
 ) -> dict[str, Any]:
     """The tool's return for ``report``: painted in the shell, markdown elsewhere."""
     summary = (
@@ -224,6 +348,7 @@ def _result(
         f"{format_minutes(report.blocked_working_minutes)} of developer downtime "
         f"({format_minutes(report.blocked_minutes)} wall clock) on merged PRs."
     )
+    takeaways = key_results_payload(report)
     base = {
         "source": _SOURCE,
         "success": True,
@@ -233,14 +358,21 @@ def _result(
         "window_days": window,
         "summary": summary,
         "headline": headline(report),
+        "key_results": takeaways,
         "rendered_in_shell": console is not None,
     }
     if console is not None:
-        # The shell already shows every figure; handing the raw numbers back
-        # as well only invites the model to retype them, so they stay out.
-        render_report(console, report)
-        return {**base, "coverage_notices": list(report.coverage_notices), "response_text": summary}
-    return {**base, **report_payload(report), "response_text": render_markdown(report)}
+        render_report(console, report, compact=include_benchmarks)
+        result = {
+            **base,
+            "coverage_notices": list(report.coverage_notices),
+            "response_text": summary,
+        }
+    else:
+        result = {**base, **report_payload(report), "response_text": render_markdown(report)}
+    if include_benchmarks and token:
+        result = _attach_benchmarks(result, report, window=window, token=token, console=console)
+    return result
 
 
 @tool(

--- a/tests/core/agent/orchestration/test_skill_scope.py
+++ b/tests/core/agent/orchestration/test_skill_scope.py
@@ -78,3 +78,30 @@ def test_the_goal_tick_tool_is_offered_inside_any_skill() -> None:
 
     # Assert: a /goal running through the skill can still tick its checklist.
     assert "session_goal_complete" in {tool.name for tool in scoped}
+
+
+def test_a_slash_command_between_a_menu_and_its_answer_keeps_the_skill() -> None:
+    """/auto high typed while the repository menu waits must not end the demo skill."""
+    from types import SimpleNamespace
+
+    from core.agent_harness.turns.skill_scope import scope_tools_to_active_skill
+
+    # Arrange
+    session = SimpleNamespace(
+        active_skill="cicd-analytics-demo",
+        active_skill_tools=("analyze_github_ci_reliability",),
+        pending_user_choice=None,
+        skill_hooks_fired=set(),
+    )
+    tools = [
+        SimpleNamespace(name="analyze_github_ci_reliability"),
+        SimpleNamespace(name="shell_run"),
+    ]
+
+    # Act
+    offered = scope_tools_to_active_skill(tools, session, "/auto high")
+
+    # Assert: full tool list for the slash turn, skill untouched.
+    assert [tool.name for tool in offered] == ["analyze_github_ci_reliability", "shell_run"]
+    assert session.active_skill == "cicd-analytics-demo"
+    assert session.active_skill_tools == ("analyze_github_ci_reliability",)

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -56,6 +56,16 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
         "scan_local_git_workspace",
         "analyze_github_ci_reliability",
     ]
+    next_options = analytics.after_tool[1].call.args["options"]
+    assert tuple(next_options) == (
+        "Set up an agent that improves CI/CD reliability over time",
+        "Connect OpenSRE to Slack and hand off DevOps chores for your team",
+        "Exit demo",
+    )
+    body = loader.load_skill_body("cicd-analytics-demo")
+    assert "include_benchmarks=true" in body
+    assert "Compare these numbers" not in body
+    assert "Output its `headline`" not in body
     assert menu["allow_custom"] is False
     assert GETTING_STARTED_CUSTOM not in master
     assert "not implemented yet" in loader.load_skill_body("remote-managed-service")

--- a/tests/core/agent_harness/turns/test_skill_after_tool.py
+++ b/tests/core/agent_harness/turns/test_skill_after_tool.py
@@ -65,7 +65,6 @@ def _skill_with_hooks() -> ActionSkill:
                         {
                             "title": "What would you like to do next?",
                             "options": [
-                                "Compare these numbers with well-known open-source repositories",
                                 "Set up an agent that improves CI/CD reliability over time",
                                 "Connect OpenSRE to Slack and hand off DevOps chores for your team",
                                 "Exit demo",

--- a/tests/core/agent_harness/turns/test_skill_after_tool.py
+++ b/tests/core/agent_harness/turns/test_skill_after_tool.py
@@ -65,6 +65,7 @@ def _skill_with_hooks() -> ActionSkill:
                         {
                             "title": "What would you like to do next?",
                             "options": [
+                                "Compare these numbers with well-known open-source repositories",
                                 "Set up an agent that improves CI/CD reliability over time",
                                 "Connect OpenSRE to Slack and hand off DevOps chores for your team",
                                 "Exit demo",

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -172,3 +172,42 @@ def test_a_saved_report_round_trips_and_paints_like_a_live_one(tmp_path: Path, m
     assert result["from_snapshot"]
     assert "coverage_notices" in result and "red_hours" not in result
     assert any(not isinstance(item, str) for item in painted)
+
+
+def test_repositories_whose_names_join_the_same_way_do_not_share_a_snapshot(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 9, 9, 16, 0, tzinfo=UTC)
+    write_snapshot(tmp_path, "foo", "bar-baz", now, _payload(generated_at=now.isoformat()))
+
+    assert read_fresh_snapshot(tmp_path, "foo-bar", "baz", window_days=30, now=now) is None
+    found = read_fresh_snapshot(tmp_path, "foo", "bar-baz", window_days=30, now=now)
+    assert found is not None and found["owner"] == "foo" and found["repo"] == "bar-baz"
+
+
+def test_a_snapshot_write_failure_does_not_discard_the_analysis(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+
+    def _analysis(*_a: Any, **_k: Any) -> Any:
+        return type("A", (), {"report": _report(), "runs_read": 1})()
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _analysis)
+
+    def _fail(*_a: Any, **_k: Any) -> Any:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(tool_module, "write_snapshot", _fail)
+
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="apache", repo="airflow", days=30, github_token="tok"
+    )
+
+    assert result["success"] is True
+    assert result["red_hours"] == 24.5

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 from integrations.github.tools.ci_analytics.snapshots import (
     read_fresh_snapshot,
@@ -92,6 +93,82 @@ def test_the_tool_answers_from_a_fresh_snapshot_without_reading_github(
     assert result["red_hours"] == 24.5
     assert result["headline"] == "Red for 24.5h on main"
     assert "as of" in result["summary"]
-    # Off the shell the saved report text is the response; the figures never leak as prose.
-    assert result["response_text"].startswith("# CI/CD reliability for apache/airflow")
-    assert "markdown" not in result
+
+
+def _report() -> Any:
+    from integrations.github.tools.ci_analytics.models import (
+        CiAnalyticsReport,
+        Outage,
+        WorkflowSummary,
+    )
+
+    now = datetime(2026, 9, 9, 16, 0, tzinfo=UTC)
+    return CiAnalyticsReport(
+        owner="apache",
+        repo="airflow",
+        default_branch="main",
+        window_days=30,
+        generated_at=now,
+        executions=100,
+        pr_executions=80,
+        pr_failures=8,
+        classified=(),
+        merged_pr_branches=10,
+        blocked_minutes=120.0,
+        blocked_minutes_all=150.0,
+        branch_runs=20,
+        branch_failures=2,
+        red_hours=24.5,
+        outages=(Outage(workflow="CI", started_at=now, ended_at=None, first_failure_url="u"),),
+        mean_recovery_hours=6.1,
+        workflows=(WorkflowSummary("CI", 100, 8, 3, 12.0),),
+        coverage_notices=("partial",),
+        working_hours_label="Mon-Fri 09:00-18:00 UTC",
+    )
+
+
+def test_a_saved_report_round_trips_and_paints_like_a_live_one(tmp_path: Path, monkeypatch) -> None:
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+    from integrations.github.tools.ci_analytics.snapshots import report_from_dict, report_to_dict
+
+    # Arrange: the report object is saved and rebuilt with its nested types intact.
+    report = _report()
+    rebuilt = report_from_dict(report_to_dict(report))
+    assert rebuilt == report
+    now = datetime.now(UTC)
+    write_snapshot(
+        tmp_path,
+        "apache",
+        "airflow",
+        now - timedelta(minutes=5),
+        {
+            "generated_at": (now - timedelta(minutes=5)).isoformat(),
+            "window_days": 30,
+            "headline": "h",
+            "report": report_to_dict(report),
+        },
+    )
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+    painted: list[Any] = []
+
+    class _Console:
+        is_terminal = True
+
+        def print(self, *args: Any, **_kwargs: Any) -> None:
+            painted.append(args[0] if args else "")
+
+    monkeypatch.setattr(tool_module, "_console", lambda _context: _Console())
+
+    # Act: through the shell console the saved report is painted, not markdown.
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="apache", repo="airflow", days=30, github_token="tok", context=object()
+    )
+
+    # Assert
+    assert result["rendered_in_shell"] is True
+    assert result["from_snapshot"]
+    assert "coverage_notices" in result and "red_hours" not in result
+    assert any(not isinstance(item, str) for item in painted)

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -1,0 +1,97 @@
+"""Same-day CI reliability snapshots are reused instead of re-reading GitHub."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from integrations.github.tools.ci_analytics.snapshots import (
+    read_fresh_snapshot,
+    write_snapshot,
+)
+
+
+def _payload(**extra: object) -> dict[str, object]:
+    return {"window_days": 30, "red_hours": 24.5, "executions": 8125, **extra}
+
+
+def test_a_fresh_snapshot_with_the_same_window_is_returned(tmp_path: Path) -> None:
+    # Arrange: one snapshot written an hour ago for a 30-day window.
+    now = datetime(2026, 9, 9, 16, 0, tzinfo=UTC)
+    written = now - timedelta(hours=1)
+    write_snapshot(
+        tmp_path, "apache", "airflow", written, _payload(generated_at=written.isoformat())
+    )
+
+    # Act
+    found = read_fresh_snapshot(tmp_path, "apache", "airflow", window_days=30, now=now)
+
+    # Assert
+    assert found is not None
+    assert found["red_hours"] == 24.5
+    assert found["snapshot_path"].endswith(".json")
+
+
+def test_a_different_window_or_a_stale_snapshot_is_ignored(tmp_path: Path) -> None:
+    # Arrange: a 7-day snapshot from an hour ago and a 30-day one from two days ago.
+    now = datetime(2026, 9, 9, 16, 0, tzinfo=UTC)
+    recent = now - timedelta(hours=1)
+    old = now - timedelta(days=2)
+    write_snapshot(
+        tmp_path,
+        "apache",
+        "airflow",
+        recent,
+        _payload(window_days=7, generated_at=recent.isoformat()),
+    )
+    write_snapshot(tmp_path, "apache", "airflow", old, _payload(generated_at=old.isoformat()))
+
+    # Act / Assert: neither serves a 30-day request today.
+    assert read_fresh_snapshot(tmp_path, "apache", "airflow", window_days=30, now=now) is None
+
+
+def test_the_tool_answers_from_a_fresh_snapshot_without_reading_github(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    # Arrange: a snapshot exists; GitHub must not be read.
+    now = datetime.now(UTC)
+    write_snapshot(
+        tmp_path,
+        "apache",
+        "airflow",
+        now - timedelta(minutes=5),
+        _payload(
+            generated_at=(now - timedelta(minutes=5)).isoformat(),
+            headline="Red for 24.5h on main",
+            markdown="# CI/CD reliability for apache/airflow\n| a | b |",
+            pr_failures=1168,
+            pr_executions=5722,
+            reliability_failures=333,
+        ),
+    )
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("GitHub must not be read when a fresh snapshot exists")
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
+
+    # Act
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="apache", repo="airflow", days=30, github_token="tok"
+    )
+
+    # Assert: figures and provenance come from the snapshot.
+    assert result["success"] is True
+    assert result["from_snapshot"]
+    assert result["red_hours"] == 24.5
+    assert result["headline"] == "Red for 24.5h on main"
+    assert "as of" in result["summary"]
+    # Off the shell the saved report text is the response; the figures never leak as prose.
+    assert result["response_text"].startswith("# CI/CD reliability for apache/airflow")
+    assert "markdown" not in result

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -241,9 +241,7 @@ def test_include_benchmarks_builds_the_comparison_from_snapshots(
     now = datetime.now(UTC)
     _write_report_snapshot(tmp_path, _report(owner="acme", repo="app", red_hours=48.0), now)
     _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
-    _write_report_snapshot(
-        tmp_path, _report(owner="fastapi", repo="fastapi", red_hours=2.0), now
-    )
+    _write_report_snapshot(tmp_path, _report(owner="fastapi", repo="fastapi", red_hours=2.0), now)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
 

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -95,7 +95,7 @@ def test_the_tool_answers_from_a_fresh_snapshot_without_reading_github(
     assert "as of" in result["summary"]
 
 
-def _report() -> Any:
+def _report(*, owner: str = "apache", repo: str = "airflow", red_hours: float = 24.5) -> Any:
     from integrations.github.tools.ci_analytics.models import (
         CiAnalyticsReport,
         Outage,
@@ -104,8 +104,8 @@ def _report() -> Any:
 
     now = datetime(2026, 9, 9, 16, 0, tzinfo=UTC)
     return CiAnalyticsReport(
-        owner="apache",
-        repo="airflow",
+        owner=owner,
+        repo=repo,
         default_branch="main",
         window_days=30,
         generated_at=now,
@@ -118,12 +118,29 @@ def _report() -> Any:
         blocked_minutes_all=150.0,
         branch_runs=20,
         branch_failures=2,
-        red_hours=24.5,
+        red_hours=red_hours,
         outages=(Outage(workflow="CI", started_at=now, ended_at=None, first_failure_url="u"),),
         mean_recovery_hours=6.1,
         workflows=(WorkflowSummary("CI", 100, 8, 3, 12.0),),
         coverage_notices=("partial",),
         working_hours_label="Mon-Fri 09:00-18:00 UTC",
+    )
+
+
+def _write_report_snapshot(root: Path, report: Any, now: datetime) -> None:
+    from integrations.github.tools.ci_analytics.snapshots import report_to_dict
+
+    write_snapshot(
+        root,
+        report.owner,
+        report.repo,
+        now - timedelta(minutes=5),
+        {
+            "generated_at": (now - timedelta(minutes=5)).isoformat(),
+            "window_days": 30,
+            "headline": "h",
+            "report": report_to_dict(report),
+        },
     )
 
 
@@ -171,6 +188,7 @@ def test_a_saved_report_round_trips_and_paints_like_a_live_one(tmp_path: Path, m
     assert result["rendered_in_shell"] is True
     assert result["from_snapshot"]
     assert "coverage_notices" in result and "red_hours" not in result
+    assert result["key_results"]
     assert any(not isinstance(item, str) for item in painted)
 
 
@@ -211,3 +229,75 @@ def test_a_snapshot_write_failure_does_not_discard_the_analysis(
 
     assert result["success"] is True
     assert result["red_hours"] == 24.5
+
+
+def test_include_benchmarks_builds_the_comparison_from_snapshots(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    now = datetime.now(UTC)
+    _write_report_snapshot(tmp_path, _report(owner="acme", repo="app", red_hours=48.0), now)
+    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
+    _write_report_snapshot(
+        tmp_path, _report(owner="fastapi", repo="fastapi", red_hours=2.0), now
+    )
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("GitHub must not be read when peer snapshots exist")
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
+
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="acme",
+        repo="app",
+        days=30,
+        include_benchmarks=True,
+        github_token="tok",
+    )
+
+    assert result["success"] is True
+    assert result["key_results"]
+    assert result["key_results"][0]["label"].startswith("main branch red")
+    assert "Compared with apache/airflow and fastapi/fastapi" in result["response_text"]
+    assert {row["owner"] + "/" + row["repo"] for row in result["benchmarks"]} == {
+        "apache/airflow",
+        "fastapi/fastapi",
+    }
+    assert "benchmarks_skipped" not in result
+
+
+def test_include_benchmarks_skips_a_peer_that_cannot_be_fetched(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from typing import Any, cast
+
+    from integrations.github.client import GitHubApiError
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    now = datetime.now(UTC)
+    _write_report_snapshot(tmp_path, _report(owner="acme", repo="app"), now)
+    _write_report_snapshot(tmp_path, _report(), now)
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+
+    def _fail(owner: str, repo: str, **_k: Any) -> Any:
+        raise GitHubApiError(f"{owner}/{repo} unavailable", status_code=404)
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _fail)
+
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="acme",
+        repo="app",
+        days=30,
+        include_benchmarks=True,
+        github_token="tok",
+    )
+
+    assert result["benchmarks_skipped"] == ["fastapi/fastapi"]
+    assert [row["repo"] for row in result["benchmarks"]] == ["airflow"]
+    assert "Compared with apache/airflow" in result["response_text"]

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -189,7 +189,7 @@ def test_build_report_renders_the_analytics_and_keeps_a_json_snapshot(
     assert "CI/CD reliability for acme/app, last 7 days" in report
     assert "Raw data: " in report
     snapshot = Path(report.rsplit("Raw data: ", 1)[1].strip())
-    assert snapshot.parent == tmp_path / "acme-app"
+    assert snapshot.parent == tmp_path / "acme" / "app"
     assert json.loads(snapshot.read_text())["executions"] == 0
 
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -27,6 +28,14 @@ from integrations.github.tools.ci_analytics.tool import TOOL_NAME, analyze_githu
 from tests.tools.conftest import BaseToolContract
 
 _T0 = datetime(2026, 9, 1, 9, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_snapshots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Snapshots go to a temp dir, never to the user's home, and never leak between tests."""
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
 
 
 def _run(
@@ -527,7 +536,7 @@ def test_developer_waits_group_blocked_prs_by_author() -> None:
     ]
     assert waits[0].working_minutes_per_week == 100.0
     assert report.developers_affected == 2
-    assert "Heaviest hit: alice 1.7h/week over 2 PRs" in render_markdown(report)
+    assert "Most affected: alice 1.7h/week over 2 PRs" in render_markdown(report)
 
 
 def test_merged_pr_row_keeps_the_author_login() -> None:
@@ -1060,10 +1069,11 @@ def test_render_shows_the_kpi_block_and_classification() -> None:
         in text
     )
     # The calculation is shown, not just its result: inputs, formula, sum, division.
-    assert "expected green = first run queued + normal duration" in text
-    assert "| + normal | = expected green |" in text
-    assert "Σ blocked = 40m of working time across 1 merged PR" in text
-    assert "÷ 1 developer = 40m each in 30 days" in text
+    assert "expected green" not in text
+    assert "| PR | Author | CI failed | Blocked (working hours) | Wall clock |" in text
+    assert "- Total across 1 merged PR: 40m of working time" in text
+    assert "- Per developer (1): 40m in 30 days" in text
+    assert "Σ" not in text and "÷" not in text
     assert "| CI | 3 | 1 | 1 | 10m |" in text
 
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1061,6 +1061,8 @@ def test_render_shows_the_kpi_block_and_classification() -> None:
 
     text = render_markdown(report)
 
+    assert text.index("**Key results**") < text.index("GitHub Actions executions")
+    assert "main branch red" in text
     assert "GitHub Actions executions: **3**" in text
     assert "Raw PR workflow failure rate: **50.0%**" in text
     assert "CI reliability failures, passed later on the same commit: **1**" in text
@@ -1171,6 +1173,7 @@ def test_tool_shows_progress_lines_around_the_painted_report() -> None:
     assert "CI/CD reliability for o/r[1], last 7 days" in output
     assert result["rendered_in_shell"] is True
     assert "executions" not in result
+    assert result["key_results"]
 
 
 class TestAnalyzeGithubCiReliabilityContract(BaseToolContract):


### PR DESCRIPTION
- **[A] compare with well-known repositories.** The next-step menu after the
  analysis offers "Compare these numbers with well-known open-source
  repositories". The branch loads `references/benchmarks.md` (which now
  points at `metrics.md`, not a missing file) and runs one analysis per
  benchmark with the same window, the user's repository first. Asked this
  before the change, the model compared star counts.
- **Same-day snapshots.** A 30-day analysis of apache/airflow takes about
  170 s live. Every live analysis now writes its figures and rendered
  report under `~/.opensre/ci_reliability_reports/`; a call for the same
  repository and window within 24 hours answers from it in a second, paints
  the saved report and says "as of <time>". The loop tick shares the writer.
  Prewarm the user's repository and the two benchmarks before the demo.
- **(a) progress while reading.** The collector reports each stage as it
  finishes (default-branch runs, pull request runs, merged PRs with counts
  and elapsed seconds, then the attempt-history check); the shell paints
  them as dim lines. Live: lines at 2 s, 3 s, 17 s, 51 s, 87 s, 101 s on
  Tracer-Cloud/opensre instead of one line after 107 s.
- **(b) results not buried.** No method definitions, no Σ/÷ lines; the
  blocked-PR table shows PR, author, day CI failed, blocked working hours,
  wall clock, with labelled totals under it; the report closes with a
  "Key results" block (default-branch red share with a bar, mean time back
  to green, CI-caused failure share with a bar, slowest normal run,
  developer time blocked per week). Markdown gets the same block.
- **Skill scope.** A slash command typed while a skill's menu is waiting
  (`/auto high` between the repository menu and its answer) no longer ends
  the skill, which had silently dropped the next-step menu in a live run.