### PR TITLE
fix(ci): pin external GitHub Actions to immutable SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,12 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
   - package-ecosystem: "uv"
     directory: "/"
     schedule:

--- a/.github/workflows/celebrate-merged-pr.yml
+++ b/.github/workflows/celebrate-merged-pr.yml
@@ -19,7 +19,7 @@ jobs:
       github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Build celebration comment
         id: celebrate

--- a/.github/workflows/ci-labels-windows.yml
+++ b/.github/workflows/ci-labels-windows.yml
@@ -29,10 +29,10 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -41,7 +41,7 @@ jobs:
             uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -81,10 +81,10 @@ jobs:
       PYTHONUTF8: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -93,7 +93,7 @@ jobs:
             uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Detect source changes
         id: changes
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install uv
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -48,7 +48,7 @@ jobs:
 
       - name: Set up Python
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -95,7 +95,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Detect source changes
         id: changes
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install uv
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"
           enable-cache: true
@@ -113,13 +113,13 @@ jobs:
 
       - name: Set up Python
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
       - name: Restore mypy cache
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .mypy_cache
           key: >-
@@ -494,7 +494,7 @@ jobs:
       PYTHONUTF8: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Detect source changes
         id: changes
@@ -502,7 +502,7 @@ jobs:
 
       - name: Install uv
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -512,7 +512,7 @@ jobs:
 
       - name: Set up Python
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -585,7 +585,7 @@ jobs:
           always() &&
           github.event_name == 'push' &&
           github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-data-${{ matrix.shard }}
           path: .coverage.${{ matrix.shard }}*
@@ -598,7 +598,7 @@ jobs:
           always() &&
           github.event_name == 'push' &&
           github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pytest-timings-${{ matrix.shard }}
           path: .pytest-file-durations-${{ matrix.shard }}.json
@@ -620,10 +620,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -632,7 +632,7 @@ jobs:
             uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -640,14 +640,14 @@ jobs:
         run: uv sync --frozen --extra dev
 
       - name: Download shard coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: coverage-data-*
           path: ./
           merge-multiple: true
 
       - name: Download shard timing artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: pytest-timings-*
           path: .pytest-timings
@@ -665,7 +665,7 @@ jobs:
           .pytest-timings/.pytest-file-durations-*.json
 
       - name: Upload combined coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report-ubuntu-latest
           path: |
@@ -674,7 +674,7 @@ jobs:
           retention-days: 7
 
       - name: Upload reviewable pytest timing snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pytest-file-durations-snapshot
           path: .pytest-timings/pytest-file-durations.json
@@ -688,7 +688,7 @@ jobs:
       session_persistence: ${{ steps.changes.outputs.session_persistence }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Detect changes
         id: changes
@@ -710,7 +710,7 @@ jobs:
 
       - name: Install uv
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -720,7 +720,7 @@ jobs:
 
       - name: Set up Python
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -744,7 +744,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Detect packaging changes
         id: changes
@@ -774,7 +774,7 @@ jobs:
 
       - name: Install uv
         if: steps.changes.outputs.packaging == 'true'
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"
           enable-cache: true
@@ -784,7 +784,7 @@ jobs:
 
       - name: Set up Python
         if: steps.changes.outputs.packaging == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,10 +43,10 @@ jobs:
         language: [python, javascript-typescript]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@311b4ee155dcdab395044f00946f664bd51ff173 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
@@ -54,7 +54,7 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@311b4ee155dcdab395044f00946f664bd51ff173 # v4
         with:
           # Preserve the canonical category so each full scan supersedes the
           # repository's historical results instead of leaving stale alerts open.
@@ -69,16 +69,16 @@ jobs:
     runs-on: ${{ inputs.runner_label }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@311b4ee155dcdab395044f00946f664bd51ff173 # v4
         with:
           languages: python
           build-mode: none
           config-file: .github/codeql/codeql-pr-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@311b4ee155dcdab395044f00946f664bd51ff173 # v4
         with:
           category: /language:python/pr-fast

--- a/.github/workflows/good-first-issue-assign.yml
+++ b/.github/workflows/good-first-issue-assign.yml
@@ -26,7 +26,7 @@ jobs:
       github.event.comment.user.type != 'Bot' &&
       !github.event.issue.pull_request
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Decide assign + notice body
         id: decide

--- a/.github/workflows/installer-canary.yml
+++ b/.github/workflows/installer-canary.yml
@@ -52,10 +52,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known" # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -64,7 +64,7 @@ jobs:
             uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: installer-canary-${{ matrix.target }}
           path: installer-canary-${{ matrix.target }}.log

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Apply size label
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Keep excluded paths and thresholds in sync with any doc that

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       version_name: ${{ steps.meta.outputs.version_name }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
@@ -114,10 +114,10 @@ jobs:
     if: github.event_name != 'push'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -126,7 +126,7 @@ jobs:
             uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -150,10 +150,10 @@ jobs:
       TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -162,7 +162,7 @@ jobs:
             uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -187,7 +187,7 @@ jobs:
             "dist/opensre-${VERSION}-py3-none-any.whl"
 
       - name: Upload Python distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-python-dist
           path: dist/*
@@ -236,10 +236,10 @@ jobs:
       VERSION_NAME: ${{ needs.prepare.outputs.version_name }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest-known"  # avoid live ndjson "latest" fetch flakes
           enable-cache: true
@@ -248,7 +248,7 @@ jobs:
             uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -508,7 +508,7 @@ jobs:
           Set-Content -Path "${assetBaseName}.zip.sha256" -Value "$hash  ${assetBaseName}.zip"
 
       - name: Upload binary archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.RELEASE_CHANNEL == 'main' && 'main-' || '' }}release-${{ matrix.target }}
           path: |
@@ -528,13 +528,13 @@ jobs:
       - build-binaries
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: release-*
           path: release-assets
@@ -775,7 +775,7 @@ jobs:
       - build-binaries
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
           # The rolling `main-build` tag is force-moved to each new main commit
@@ -794,7 +794,7 @@ jobs:
           persist-credentials: true
 
       - name: Download main release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: main-release-*
           path: main-release-assets

--- a/tests/github_ci/test_action_pinning.py
+++ b/tests/github_ci/test_action_pinning.py
@@ -1,0 +1,25 @@
+"""Security contracts for immutable external GitHub Actions references."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+_USES_RE = re.compile(r"^\s*(?:-\s+)?uses:\s*(?P<reference>\S+)")
+_COMMIT_SHA_RE = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+
+
+def test_external_github_actions_are_pinned_to_immutable_commits() -> None:
+    """Keep mutable third-party action tags out of trusted automation."""
+    offenders: list[str] = []
+    for path in sorted((_REPOSITORY_ROOT / ".github").rglob("*.y*ml")):
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            match = _USES_RE.match(line)
+            if match is None or match["reference"].startswith("./"):
+                continue
+            reference = match.group("reference")
+            if not _COMMIT_SHA_RE.fullmatch(reference):
+                offenders.append(f"{path.relative_to(_REPOSITORY_ROOT)}:{line_number}: {reference}")
+
+    assert not offenders, "External actions must use full commit SHAs:\n" + "\n".join(offenders)

--- a/tests/github_ci/test_action_pinning.py
+++ b/tests/github_ci/test_action_pinning.py
@@ -3,23 +3,44 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-_USES_RE = re.compile(r"^\s*(?:-\s+)?uses:\s*(?P<reference>\S+)")
 _COMMIT_SHA_RE = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+
+
+def _external_action_references(value: Any) -> Iterator[str]:
+    """Yield external-action references from a parsed GitHub YAML document."""
+    if isinstance(value, dict):
+        reference = value.get("uses")
+        if isinstance(reference, str):
+            yield reference
+        for child in value.values():
+            yield from _external_action_references(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _external_action_references(child)
+
+
+def test_quoted_uses_key_is_checked() -> None:
+    """Treat quoted YAML keys exactly like the unquoted ``uses`` key."""
+    document = yaml.safe_load('"uses": actions/checkout@v5')
+
+    assert list(_external_action_references(document)) == ["actions/checkout@v5"]
 
 
 def test_external_github_actions_are_pinned_to_immutable_commits() -> None:
     """Keep mutable third-party action tags out of trusted automation."""
     offenders: list[str] = []
     for path in sorted((_REPOSITORY_ROOT / ".github").rglob("*.y*ml")):
-        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-            match = _USES_RE.match(line)
-            if match is None or match["reference"].startswith("./"):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for reference in _external_action_references(document):
+            if reference.startswith("./") or _COMMIT_SHA_RE.fullmatch(reference):
                 continue
-            reference = match.group("reference")
-            if not _COMMIT_SHA_RE.fullmatch(reference):
-                offenders.append(f"{path.relative_to(_REPOSITORY_ROOT)}:{line_number}: {reference}")
+            offenders.append(f"{path.relative_to(_REPOSITORY_ROOT)}: {reference}")
 
     assert not offenders, "External actions must use full commit SHAs:\n" + "\n".join(offenders)


### PR DESCRIPTION
Fixes #6154

  #### Describe the changes you have made in this PR -

  - Replaced mutable external GitHub Action tags with their currently resolved,
    full commit SHAs across CI, release, CodeQL, and repository automation workflows.
  - Added weekly Dependabot updates for the `github-actions` ecosystem so pins
    receive regular update PRs.
  - Added a CI contract test that rejects future external action references unless
    they use a full 40-character commit SHA. Local actions remain allowed.

  Explain your implementation approach:

  GitHub Action tags are mutable, so a workflow can execute different code without
  a repository change. Each external uses: reference is pinned to the immutable
  commit currently behind its existing version tag. Dependabot creates weekly update
  PRs for future action releases. The regression test scans GitHub YAML files and
  fails when a non-local action reference is not a full commit SHA.
