### PR TITLE
fix(shell): readable reply tables, visible quiet commands, menu allow_custom

### DIFF
--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -130,7 +130,9 @@ Call
 `analyze_github_ci_reliability(owner="<owner>", repo="<repo>", include_benchmarks=true)`
 for the chosen repository. The tool paints the report (key results first)
 and the comparison table itself. Do not restate figures, do not output
-`headline`, and do not call the tool again for benchmarks.
+`headline`, and do not call the tool again for benchmarks. A peer without
+a same-day snapshot is skipped (named in `benchmarks_skipped`); do not
+fetch it yourself.
 
 ### 4. Offer what to do next
 
@@ -146,8 +148,9 @@ Wait for the answer, then follow the selected option.
 **Recurring check:** Call
 `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the
 analyzed repository, output its `response_text` verbatim, and stop. Each
-tick is deterministic (no model turn); `/loops service install` keeps it
-running when no shell is open.
+tick is the same analytics report, not a CI code fix. `/loops service
+install` keeps it running when no shell is open. Do not call
+`fix_github_pr_ci` from this skill.
 
 **Slack setup:** Call `cli_exec` with payload `integrations verify slack`.
 If Slack is not configured, call `slash_invoke` with

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
@@ -7,9 +7,10 @@ this reference only when the user asks what a compared figure means.
 
 ## Rules
 
-- The host table is the source. Do not call `analyze_github_ci_reliability`
-  again for a benchmark, and never quote a figure from memory, a blog post,
-  or a previous session.
+- The host table is the source. Peers come from today's snapshot only; a
+  miss is skipped, not fetched live. Do not call
+  `analyze_github_ci_reliability` again for a benchmark, and never quote a
+  figure from memory, a blog post, or a previous session.
 - Compare **rates and durations**, never raw counts. A repository with 40 000
   runs a month and one with 400 are not comparable on `executions`,
   `pr_failures`, or `blocked_minutes`; they are comparable on

--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -499,10 +499,11 @@ def _apply_theme(theme: CliTheme) -> None:
 
     MARKDOWN_THEME = Theme(
         {
-            # Sunny Droid-like reply: bright warm-grey body (#D0D0D0 TEXT), warm
-            # ``Ω`` accent. Strong stays bold TEXT; avoid icy blue chrome.
+            # Bright warm-grey body with the accent reserved for code spans; bold
+            # marks headings, strong text and table headers only, so structure
+            # stays visible when a reply is mostly file names and flags.
             "markdown.paragraph": theme.TEXT,
-            "markdown.code": f"bold {theme.HIGHLIGHT}",
+            "markdown.code": theme.HIGHLIGHT,
             "markdown.code_block": theme.TEXT,
             "markdown.h1": f"bold {theme.HIGHLIGHT}",
             "markdown.h2": f"bold {theme.WARNING}",
@@ -516,6 +517,8 @@ def _apply_theme(theme: CliTheme) -> None:
             "markdown.link": f"underline {theme.HIGHLIGHT}",
             "markdown.link_url": theme.DIM,
             "markdown.hr": theme.DIM,
+            "markdown.table.header": f"bold {theme.TEXT}",
+            "markdown.table.border": theme.DIM,
         }
     )
 

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -139,10 +139,33 @@ def comparison_figures(report: CiAnalyticsReport) -> dict[str, str]:
     }
 
 
+def skip_lines(skipped: list[str]) -> list[str]:
+    """Guest-visible reason a benchmark column is missing."""
+    return [f"Skipped {item}." for item in skipped]
+
+
 def render_comparison(
-    console: Any, user: CiAnalyticsReport, peers: list[CiAnalyticsReport]
+    console: Any,
+    user: CiAnalyticsReport,
+    peers: list[CiAnalyticsReport],
+    *,
+    skipped: list[str] | None = None,
 ) -> None:
     """One table: the user's repo first, then the benchmark columns."""
+    missed = list(skipped or [])
+    if not peers:
+        parts: list[Any] = [
+            Text(""),
+            Text("Compared with well-known repositories", style="bold"),
+            Text(
+                "No benchmark columns — no same-day snapshot. "
+                "The report above is this repository only.",
+                style="dim",
+            ),
+        ]
+        parts.extend(Text(line, style="dim") for line in skip_lines(missed))
+        console.print(Padding(Group(*parts), (0, 0, 0, 2)))
+        return
     reports = [user, *peers]
     labels = [f"{item.owner}/{item.repo}" for item in reports]
     figures = [comparison_figures(item) for item in reports]
@@ -153,7 +176,7 @@ def render_comparison(
     for metric in figures[0]:
         table.add_row(metric, *[row.get(metric, "n/a") for row in figures])
     peers_label = " and ".join(labels[1:]) if labels[1:] else "benchmarks"
-    parts: list[Any] = [
+    parts = [
         Text(""),
         Text(f"Compared with {peers_label} over the same {user.window_days} days", style="bold"),
         table,
@@ -162,13 +185,28 @@ def render_comparison(
             style="dim",
         ),
     ]
-    for notice in _comparison_notes(peers):
-        parts.append(Text(notice, style="dim"))
+    parts.extend(Text(notice, style="dim") for notice in _comparison_notes(peers))
+    parts.extend(Text(line, style="dim") for line in skip_lines(missed))
     console.print(Padding(Group(*parts), (0, 0, 0, 2)))
 
 
-def comparison_markdown(user: CiAnalyticsReport, peers: list[CiAnalyticsReport]) -> str:
+def comparison_markdown(
+    user: CiAnalyticsReport,
+    peers: list[CiAnalyticsReport],
+    *,
+    skipped: list[str] | None = None,
+) -> str:
     """Markdown form of :func:`render_comparison`."""
+    missed = list(skipped or [])
+    if not peers:
+        lines = [
+            "Compared with well-known repositories:",
+            "",
+            "No benchmark columns — no same-day snapshot. "
+            "The report above is this repository only.",
+            *skip_lines(missed),
+        ]
+        return "\n".join(lines)
     reports = [user, *peers]
     labels = [f"{item.owner}/{item.repo}" for item in reports]
     figures = [comparison_figures(item) for item in reports]
@@ -189,6 +227,7 @@ def comparison_markdown(user: CiAnalyticsReport, peers: list[CiAnalyticsReport])
             "",
             "Red time = red_hours / (days × 24); CI-caused = reliability_failures / PR runs.",
             *_comparison_notes(peers),
+            *skip_lines(missed),
         ]
     )
 
@@ -554,6 +593,7 @@ __all__ = [
     "ci_report_headline",
     "comparison_figures",
     "comparison_markdown",
+    "skip_lines",
     "key_results",
     "key_results_payload",
     "render_ci_report",

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -162,7 +162,7 @@ def render_comparison(
             style="dim",
         ),
     ]
-    for notice in (item for peer in peers for item in peer.coverage_notices):
+    for notice in _comparison_notes(peers):
         parts.append(Text(notice, style="dim"))
     console.print(Padding(Group(*parts), (0, 0, 0, 2)))
 
@@ -188,8 +188,25 @@ def comparison_markdown(user: CiAnalyticsReport, peers: list[CiAnalyticsReport])
             *rows,
             "",
             "Red time = red_hours / (days × 24); CI-caused = reliability_failures / PR runs.",
+            *_comparison_notes(peers),
         ]
     )
+
+
+def _comparison_notes(peers: list[CiAnalyticsReport]) -> list[str]:
+    """Say when 0% red is a green window, not a missing fetch."""
+    notes: list[str] = []
+    seen: set[str] = set()
+    for peer in peers:
+        name = f"{peer.owner}/{peer.repo}"
+        if peer.red_hours == 0 and name not in seen:
+            seen.add(name)
+            if peer.branch_runs:
+                notes.append(f"{name}: default branch stayed green in this window.")
+            else:
+                notes.append(f"{name}: no default-branch runs in this window.")
+        notes.extend(peer.coverage_notices)
+    return notes
 
 
 def _details_markdown(report: CiAnalyticsReport) -> list[str]:

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -184,7 +184,6 @@ def _from_snapshot(
     console: Any,
     *,
     include_benchmarks: bool = False,
-    token: str = "",
 ) -> dict[str, Any]:
     """Answer from a same-day snapshot with the same renderer as a live analysis."""
     generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
@@ -204,7 +203,6 @@ def _from_snapshot(
             window,
             console,
             include_benchmarks=include_benchmarks,
-            token=token,
         )
         result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
         result["from_snapshot"] = snapshot.get("generated_at")
@@ -257,44 +255,16 @@ def _load_peer_report(
     repo: str,
     *,
     window: int,
-    token: str,
     now: datetime,
-    console: Any,
 ) -> tuple[CiAnalyticsReport, str | None] | None:
-    """A benchmark report from today's snapshot, or a live read. ``None`` on failure."""
+    """Today's snapshot for a benchmark repo, or ``None`` (no live fetch)."""
     snapshot = read_fresh_snapshot(snapshot_root(), owner, repo, window_days=window, now=now)
-    if snapshot is not None:
-        saved = snapshot.get("report")
-        if isinstance(saved, dict):
-            report = report_from_dict(saved)
-            return report, str(snapshot.get("generated_at") or "")
-    if console is not None:
-        console.print(
-            f"  [dim]Reading GitHub Actions history for {escape(f'{owner}/{repo}')} "
-            f"(benchmark), last {window} days…[/dim]"
-        )
-    try:
-        analysis = analyze_repository(owner, repo, token=token, days=window, now=now)
-    except (GitHubApiError, ValueError):
-        logger.warning("Benchmark analysis failed for %s/%s", owner, repo, exc_info=True)
+    if snapshot is None:
         return None
-    try:
-        write_snapshot(
-            snapshot_root(),
-            owner,
-            repo,
-            now,
-            {
-                "generated_at": now.isoformat(),
-                "window_days": window,
-                "headline": headline(analysis.report),
-                "report": report_to_dict(analysis.report),
-                **report_payload(analysis.report),
-            },
-        )
-    except OSError:
-        logger.warning("Could not save the CI reliability snapshot", exc_info=True)
-    return analysis.report, None
+    saved = snapshot.get("report")
+    if not isinstance(saved, dict):
+        return None
+    return report_from_dict(saved), str(snapshot.get("generated_at") or "")
 
 
 def _attach_benchmarks(
@@ -302,10 +272,9 @@ def _attach_benchmarks(
     report: CiAnalyticsReport,
     *,
     window: int,
-    token: str,
     console: Any,
 ) -> dict[str, Any]:
-    """Add the host comparison table and structured benchmark rows."""
+    """Add the host comparison table from same-day peer snapshots."""
     now = datetime.now(UTC)
     peers: list[CiAnalyticsReport] = []
     rows: list[dict[str, Any]] = []
@@ -313,11 +282,9 @@ def _attach_benchmarks(
     for owner, repo in _DEFAULT_BENCHMARKS:
         if owner == report.owner and repo == report.repo:
             continue
-        loaded = _load_peer_report(
-            owner, repo, window=window, token=token, now=now, console=console
-        )
+        loaded = _load_peer_report(owner, repo, window=window, now=now)
         if loaded is None:
-            skipped.append(f"{owner}/{repo}")
+            skipped.append(f"{owner}/{repo} (no same-day snapshot)")
             continue
         peer, stamp = loaded
         peers.append(peer)
@@ -344,7 +311,6 @@ def _result(
     console: Any,
     *,
     include_benchmarks: bool = False,
-    token: str = "",
 ) -> dict[str, Any]:
     """The tool's return for ``report``: painted in the shell, markdown elsewhere."""
     summary = (
@@ -376,8 +342,8 @@ def _result(
         }
     else:
         result = {**base, **report_payload(report), "response_text": render_markdown(report)}
-    if include_benchmarks and token:
-        result = _attach_benchmarks(result, report, window=window, token=token, console=console)
+    if include_benchmarks:
+        result = _attach_benchmarks(result, report, window=window, console=console)
     return result
 
 
@@ -390,7 +356,8 @@ def _result(
         "reliability KPIs: executions, PR failure rate, failures classified as "
         "CI-caused (same commit passed later) versus source-code, developer time "
         "blocked by unreliable CI on merged PRs, and default-branch red time. "
-        "Read-only; needs a GitHub token."
+        "Read-only. A same-day snapshot answers without a token; a live GitHub "
+        "read needs a token."
     ),
     use_cases=[
         "Analyze a repository's CI/CD performance and reliability",
@@ -489,18 +456,12 @@ def analyze_github_ci_reliability(
             "owner/repo is required unless the workspace origin identifies a GitHub repository.",
             response_text="I need a GitHub repository (owner/repo) to analyze.",
         )
-    token = resolve_github_token(github_token)
-    if not token:
-        message = (
-            f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "
-            "Run `opensre integrations setup github` and try again."
-        )
-        return tool_unavailable(_SOURCE, message, response_text=message)
     now = datetime.now(UTC)
     console = _console(context)
     snapshot = read_fresh_snapshot(
         snapshot_root(), repo_owner, repo_name, window_days=window, now=now
     )
+    token = resolve_github_token(github_token)
     if snapshot is not None:
         return _from_snapshot(
             snapshot,
@@ -509,8 +470,13 @@ def analyze_github_ci_reliability(
             window,
             console,
             include_benchmarks=compare,
-            token=token,
         )
+    if not token:
+        message = (
+            f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "
+            "Run `opensre integrations setup github` and try again."
+        )
+        return tool_unavailable(_SOURCE, message, response_text=message)
     if console is not None:
         # Two-column lead matches the shell's reply gutter so the tool's lines
         # hang with the agent's notes instead of breaking the transcript edge.
@@ -571,7 +537,6 @@ def analyze_github_ci_reliability(
         window,
         console,
         include_benchmarks=compare,
-        token=token,
     )
 
 

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -292,12 +292,10 @@ def _attach_benchmarks(
     result["benchmarks"] = rows
     if skipped:
         result["benchmarks_skipped"] = skipped
-    if not peers:
-        return result
     if console is not None:
-        render_comparison(console, report, peers)
+        render_comparison(console, report, peers, skipped=skipped)
         return result
-    compare = comparison_markdown(report, peers)
+    compare = comparison_markdown(report, peers, skipped=skipped)
     result["comparison_text"] = compare
     result["response_text"] = f"{result['response_text']}\n\n{compare}"
     return result

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -38,15 +38,15 @@ def _echo_answer(text: str) -> None:
         click.echo(text)
         return
     from rich.console import Console
-    from rich.markdown import Markdown
 
     from infrastructure.safety.terminal_output import strip_terminal_controls
     from infrastructure.terminal.theme import MARKDOWN_CODE_THEME, MARKDOWN_THEME
+    from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 
     console = Console()
     safe = strip_terminal_controls(text, keep_whitespace=True)
     with console.use_theme(MARKDOWN_THEME):
-        console.print(Markdown(safe, code_theme=MARKDOWN_CODE_THEME))
+        console.print(ReplyMarkdown(safe, code_theme=MARKDOWN_CODE_THEME))
 
 
 def _render_outcome(outcome: AskOutcome) -> None:

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -113,7 +113,7 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         session.terminal.awaiting_handoff_answer = False
         session.terminal.set_auto_command(command)
         return True
-    render_choice_selection(console, items[0].title, picked_one)
+    render_choice_selection(console, items[0].title, picked_one, options=items[0].options)
     # The answer travels with its question, as the batched wizard's does: a bare
     # label such as "owner/repo (757 commits, CI configured)" reads to the
     # planner like a fresh request and gets re-asked or re-routed.

--- a/surfaces/interactive_shell/command_registry/session_cmds/resume_rendering.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/resume_rendering.py
@@ -34,10 +34,9 @@ def render_resumed_session_history(
     messages: list[tuple[str, str]],
 ) -> None:
     """Render prior session activity in REPL turn order, including slash commands."""
-    from rich.markdown import Markdown
-
     from infrastructure.terminal.theme import MARKDOWN_THEME
     from surfaces.interactive_shell.ui.streaming import render_response_header
+    from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 
     if not history and not messages:
         return
@@ -70,7 +69,7 @@ def render_resumed_session_history(
             if response:
                 render_response_header(console, "assistant")
                 with console.use_theme(MARKDOWN_THEME):
-                    console.print(Markdown(response, code_theme="ansi_dark"))
+                    console.print(ReplyMarkdown(response, code_theme="ansi_dark"))
         console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
         return
 
@@ -82,7 +81,7 @@ def render_resumed_session_history(
         elif role == "assistant" and has_pending_user:
             render_response_header(console, "assistant")
             with console.use_theme(MARKDOWN_THEME):
-                console.print(Markdown(text, code_theme="ansi_dark"))
+                console.print(ReplyMarkdown(text, code_theme="ansi_dark"))
             has_pending_user = False
     console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
 

--- a/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
+++ b/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
@@ -8,7 +8,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from rich.markdown import Markdown
 from rich.markup import escape
 from rich.text import Text
 
@@ -38,6 +37,7 @@ from surfaces.shared.terminal.components.choice_menu import (
     repl_choose_one,
 )
 from surfaces.shared.terminal.components.loaders import llm_loader
+from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 from tools.system.workspace_git_scan.render import snapshot_renderable
 from tools.system.workspace_git_scan.scan import RepoActivity, WorkspaceSnapshot, scan_workspace
 
@@ -194,7 +194,7 @@ def _run_first_pass(console: Console | None, task_id: str, *, owner: str, repo: 
     if console is not None:
         console.print()
         render_note_block(console, "The first report, as it will land in /loops messages:")
-        console.print(reply_gutter(Markdown(report), lead=False))
+        console.print(reply_gutter(ReplyMarkdown(report), lead=False))
         console.print()
 
 

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -20,7 +20,13 @@ def _display_safe(text: str) -> str:
     return "\n".join(strip_terminal_controls(line) for line in text.splitlines())
 
 
-def render_choice_selection(console: Console, title: str, answer: str) -> None:
+def render_choice_selection(
+    console: Console,
+    title: str,
+    answer: str,
+    *,
+    options: tuple[str, ...] = (),
+) -> None:
     """Persist the pick after the menu closes, as an answer line rather than a repeated question.
 
     The menu itself is erased, so this is the transcript's only record of the
@@ -28,6 +34,8 @@ def render_choice_selection(console: Console, title: str, answer: str) -> None:
     header, the question dim on one line with a single answer after it, and a
     multi-select listed underneath. Must not use the plan-step ``✓`` glyph.
     Leading blank separates it from Plan complete / reply text above.
+    ``options`` are the rows that were offered; they follow on one dim line so
+    a reader of the transcript sees what the choice was made against.
     """
     console.print()
     question = _display_safe(title.strip())
@@ -39,13 +47,16 @@ def render_choice_selection(console: Console, title: str, answer: str) -> None:
         line.append("  ", style=str(ui_theme.DIM))
         line.append(answers[0], style=str(ui_theme.BRAND))
         console.print(line)
-        return
-    console.print(line)
-    for item in answers:
-        aline = Text()
-        aline.append("      ", style=str(ui_theme.DIM))
-        aline.append(item, style=str(ui_theme.BRAND))
-        console.print(aline)
+    else:
+        console.print(line)
+        for item in answers:
+            aline = Text()
+            aline.append("      ", style=str(ui_theme.DIM))
+            aline.append(item, style=str(ui_theme.BRAND))
+            console.print(aline)
+    offered = [_display_safe(item.strip()) for item in options if item.strip()]
+    if len(offered) > 1:
+        console.print(Text("    offered: " + " · ".join(offered), style=str(ui_theme.DIM)))
 
 
 def render_ask_user_qa(console: Console, pairs: list[tuple[str, str]]) -> None:

--- a/surfaces/interactive_shell/ui/streaming/__init__.py
+++ b/surfaces/interactive_shell/ui/streaming/__init__.py
@@ -29,11 +29,6 @@ menus are not rendered until the harness flushes the canonical closer.
 
 from __future__ import annotations
 
-# Not part of __all__: exists so tests can substitute the renderer's Markdown
-# class via ``streaming.Markdown = ...`` — renderer._build_markdown_block reads
-# it back off this package rather than importing it directly.
-from rich.markdown import Markdown  # noqa: F401
-
 from surfaces.interactive_shell.ui.streaming.closer import finish_deferred_closer
 from surfaces.interactive_shell.ui.streaming.console import StreamingConsole
 from surfaces.interactive_shell.ui.streaming.loop import (
@@ -49,6 +44,11 @@ from surfaces.interactive_shell.ui.streaming.renderer import (
     render_note_block,
     render_response_header,
 )
+
+# Not part of __all__: exists so tests can substitute the renderer's Markdown
+# class via ``streaming.Markdown = ...`` — renderer._build_markdown_block reads
+# it back off this package rather than importing it directly.
+from surfaces.shared.terminal.components.markdown import ReplyMarkdown as Markdown  # noqa: F401
 from surfaces.shared.terminal.components.token_format import (
     _CHARS_PER_TOKEN,  # noqa: F401  # not in __all__, but tests import it from this path directly
     format_token_count_short,

--- a/surfaces/shared/terminal/components/__init__.py
+++ b/surfaces/shared/terminal/components/__init__.py
@@ -7,6 +7,7 @@ from surfaces.shared.terminal.components.choice_menu import (
     repl_tty_interactive,
 )
 from surfaces.shared.terminal.components.loaders import DEFAULT_LOADER_LABEL, llm_loader
+from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 from surfaces.shared.terminal.components.rendering import (
     print_repl_json,
     print_repl_table,
@@ -25,6 +26,7 @@ from surfaces.shared.terminal.components.token_format import (
 
 __all__ = [
     "DEFAULT_LOADER_LABEL",
+    "ReplyMarkdown",
     "_CHARS_PER_TOKEN",
     "format_repl_duration",
     "format_repl_timestamp",

--- a/surfaces/shared/terminal/components/markdown.py
+++ b/surfaces/shared/terminal/components/markdown.py
@@ -1,0 +1,43 @@
+"""Markdown renderable for terminal replies.
+
+Rich's stock markdown table has no column rules and cuts long cells with an
+ellipsis; a reply table here wraps every cell and draws the same minimal
+column rules as ``repl_table``.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from rich.console import Console, ConsoleOptions, RenderResult
+from rich.markdown import Markdown, MarkdownElement, TableElement
+
+from surfaces.shared.terminal.components.rendering import repl_table
+
+
+class ReplyTableElement(TableElement):
+    """Markdown table with column rules and folded cells."""
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        table = repl_table(style="markdown.table.border")
+        if self.header is not None and self.header.row is not None:
+            for column in self.header.row.cells:
+                heading = column.content.copy()
+                heading.stylize("markdown.table.header")
+                table.add_column(heading, overflow="fold")
+        if self.body is not None:
+            for row in self.body.rows:
+                table.add_row(*[cell.content for cell in row.cells])
+        yield table
+
+
+class ReplyMarkdown(Markdown):
+    """``rich.Markdown`` whose tables render through ``ReplyTableElement``."""
+
+    elements: ClassVar[dict[str, type[MarkdownElement]]] = {
+        **Markdown.elements,
+        "table_open": ReplyTableElement,
+    }
+
+
+__all__ = ["ReplyMarkdown", "ReplyTableElement"]

--- a/surfaces/shared/terminal/output/live_display.py
+++ b/surfaces/shared/terminal/output/live_display.py
@@ -250,12 +250,12 @@ class _EventLogDisplay:
     def print_above(self, text: str) -> None:
         if not text.strip():
             return
-        from rich.markdown import Markdown
+        from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 
         from infrastructure.terminal.theme import MARKDOWN_THEME
 
         with self._live.console.use_theme(MARKDOWN_THEME):
-            self._live.console.print(Markdown(text, code_theme="ansi_dark"))
+            self._live.console.print(ReplyMarkdown(text, code_theme="ansi_dark"))
 
     def print_above_renderable(self, renderable: Any) -> None:
         self._live.console.print(renderable)

--- a/surfaces/shared/terminal/output/repl_display.py
+++ b/surfaces/shared/terminal/output/repl_display.py
@@ -158,12 +158,12 @@ class _ReplEventLogDisplay:
     def print_above(self, text: str) -> None:
         if not text.strip():
             return
-        from rich.markdown import Markdown
+        from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 
         from infrastructure.terminal.theme import MARKDOWN_THEME
 
         with self._console.use_theme(MARKDOWN_THEME):
-            self._emit(Markdown(text, code_theme="ansi_dark"))
+            self._emit(ReplyMarkdown(text, code_theme="ansi_dark"))
 
     def print_above_renderable(self, renderable: Any) -> None:
         self._emit(renderable)

--- a/tests/core/agent/orchestration/test_ask_choice_tool.py
+++ b/tests/core/agent/orchestration/test_ask_choice_tool.py
@@ -14,8 +14,12 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness.tools.tool_context import ActionToolScope
+from core.agent_harness.tools.tool_context import (
+    ACTION_TOOL_CONTEXT_RESOURCE_KEY,
+    ActionToolScope,
+)
 from core.agent_harness.turns.headless_adapters import InMemorySessionState
+from core.tool import AgentToolContext
 from surfaces.interactive_shell.session import Session
 from tools.interactive_shell.actions.ask_choice import (
     ask_user_choice_tool,
@@ -250,3 +254,23 @@ def test_per_question_multi_select_string_false() -> None:
     assert result["ok"] is True
     assert session.pending_user_choice is not None
     assert session.pending_user_choice.questions[0].multi_select is False
+
+
+def test_allow_custom_from_the_model_reaches_the_pending_choice() -> None:
+    # Arrange: the registry calls ``run`` with the model's public arguments as
+    # keywords, so every schema property must be accepted by the signature.
+    session = Session()
+    context = AgentToolContext(
+        resolved_integrations={},
+        resources={ACTION_TOOL_CONTEXT_RESOURCE_KEY: _ctx(session=session)},
+    )
+
+    # Act
+    result = ask_user_choice_tool.run(
+        title=_TITLE, options=_OPTIONS, allow_custom=False, context=context
+    )
+
+    # Assert
+    assert result["ok"] is True
+    assert session.pending_user_choice is not None
+    assert session.pending_user_choice.custom_answer is False

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -182,3 +182,16 @@ def test_palette_registry_keys_match_the_config_vocabulary() -> None:
     from infrastructure.terminal.theme import THEME_REGISTRY
 
     assert tuple(THEME_REGISTRY.keys()) == THEME_NAMES
+
+
+def test_markdown_theme_reserves_bold_for_structure() -> None:
+    # Arrange
+    from infrastructure.terminal import theme as ui_theme
+
+    styles = ui_theme.MARKDOWN_THEME.styles
+
+    # Act / Assert: code spans keep their colour without bold; table header is
+    # bold and the border is dim, so the body of a table never outweighs it.
+    assert styles["markdown.code"].bold is not True
+    assert styles["markdown.table.header"].bold is True
+    assert styles["markdown.table.border"] == styles["markdown.hr"]

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -274,28 +274,54 @@ def test_include_benchmarks_skips_a_peer_that_cannot_be_fetched(
 ) -> None:
     from typing import Any, cast
 
-    from integrations.github.client import GitHubApiError
     from integrations.github.tools.ci_analytics import tool as tool_module
 
     now = datetime.now(UTC)
     _write_report_snapshot(tmp_path, _report(owner="acme", repo="app"), now)
     _write_report_snapshot(tmp_path, _report(), now)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
 
-    def _fail(owner: str, repo: str, **_k: Any) -> Any:
-        raise GitHubApiError(f"{owner}/{repo} unavailable", status_code=404)
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("A missing peer must not start a live GitHub read")
 
-    monkeypatch.setattr(tool_module, "analyze_repository", _fail)
+    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
 
     result = cast(Any, tool_module.analyze_github_ci_reliability)(
         owner="acme",
         repo="app",
         days=30,
         include_benchmarks=True,
-        github_token="tok",
     )
 
-    assert result["benchmarks_skipped"] == ["fastapi/fastapi"]
+    assert result["benchmarks_skipped"] == ["fastapi/fastapi (no same-day snapshot)"]
     assert [row["repo"] for row in result["benchmarks"]] == ["airflow"]
     assert "Compared with apache/airflow" in result["response_text"]
+
+
+def test_a_fresh_snapshot_answers_without_a_github_token(tmp_path: Path, monkeypatch) -> None:
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    now = datetime.now(UTC)
+    _write_report_snapshot(tmp_path, _report(owner="acme", repo="app", red_hours=48.0), now)
+    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
+    _write_report_snapshot(tmp_path, _report(owner="fastapi", repo="fastapi", red_hours=0.0), now)
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("GitHub must not be read when snapshots exist")
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
+
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="acme", repo="app", days=30, include_benchmarks=True
+    )
+
+    assert result["success"] is True
+    assert result["from_snapshot"]
+    assert "Compared with apache/airflow and fastapi/fastapi" in result["response_text"]
+    assert "fastapi/fastapi: default branch stayed green in this window." in result["response_text"]
+    assert "opensre integrations setup github" not in result.get("response_text", "")

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -297,6 +297,35 @@ def test_include_benchmarks_skips_a_peer_that_cannot_be_fetched(
     assert result["benchmarks_skipped"] == ["fastapi/fastapi (no same-day snapshot)"]
     assert [row["repo"] for row in result["benchmarks"]] == ["airflow"]
     assert "Compared with apache/airflow" in result["response_text"]
+    assert "Skipped fastapi/fastapi (no same-day snapshot)." in result["response_text"]
+
+
+def test_include_benchmarks_says_when_every_peer_snapshot_is_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    now = datetime.now(UTC)
+    _write_report_snapshot(tmp_path, _report(owner="acme", repo="app"), now)
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("A missing peer must not start a live GitHub read")
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
+
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="acme", repo="app", days=30, include_benchmarks=True
+    )
+
+    assert result["success"] is True
+    assert result["benchmarks"] == []
+    assert "No benchmark columns" in result["response_text"]
+    assert "Skipped apache/airflow (no same-day snapshot)." in result["response_text"]
+    assert "Skipped fastapi/fastapi (no same-day snapshot)." in result["response_text"]
 
 
 def test_a_fresh_snapshot_answers_without_a_github_token(tmp_path: Path, monkeypatch) -> None:

--- a/tests/interactive_shell/runtime/test_subprocess_runner.py
+++ b/tests/interactive_shell/runtime/test_subprocess_runner.py
@@ -184,8 +184,8 @@ def test_run_shell_command_quiet_cd_hides_cwd(
 
     result = run_shell_command("cd /tmp/example", _presenter(session, console), quiet=True)
 
-    assert "$" not in buf.getvalue()
-    assert "/tmp/example" not in buf.getvalue()
+    # The dim command line shows what ran; the new cwd stays hidden.
+    assert buf.getvalue().strip() == "$ cd /tmp/example"
     assert result["ok"] is True
     assert result["response_text"] == "/tmp/example"
 
@@ -396,7 +396,7 @@ def test_run_shell_command_outputless_success_omits_marker(
     assert session.history[-1] == {"type": "shell", "text": "true", "ok": True}
 
 
-def test_run_shell_command_quiet_hides_command_and_stdout(
+def test_run_shell_command_quiet_prints_a_dim_command_line_and_no_stdout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
@@ -422,8 +422,7 @@ def test_run_shell_command_quiet_hides_command_and_stdout(
 
     result = run_shell_command("echo hi", _presenter(session, console), quiet=True)
     out = buf.getvalue()
-    assert "$" not in out
-    assert "hi" not in out
+    assert out.strip() == "$ echo hi"
     assert GLYPH_SUCCESS not in out
     assert result["ok"] is True
     assert result["stdout"] == "hi"
@@ -431,14 +430,12 @@ def test_run_shell_command_quiet_hides_command_and_stdout(
     assert session.history[-1]["ok"] is True
 
 
-def test_run_shell_command_quiet_outputless_success_prints_nothing(
+def test_run_shell_command_quiet_outputless_success_prints_only_the_command_line(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Quiet ``touch`` must not print a live success glyph.
+    """Quiet ``touch`` prints the dim command line and no live success glyph.
 
-    Quiet hides ``$`` and stdout. Outputless success has neither; a live
-    marker would still leak intermediate probes before a composed closing.
-    Loud mode prints the glyph. Quiet leaves the terminal blank here — the
+    Quiet hides stdout and the glyph, not the fact that a command ran. The
     action closer (kept for quiet ``shell_run``) is the turn's display.
     """
 
@@ -466,7 +463,7 @@ def test_run_shell_command_quiet_outputless_success_prints_nothing(
     result = run_shell_command("touch file", _presenter(session, console), quiet=True)
 
     out = buf.getvalue()
-    assert out == ""
+    assert out.strip() == "$ touch file"
     assert GLYPH_SUCCESS not in out
     assert result["ok"] is True
     assert "response_text" not in result

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -240,3 +240,23 @@ def test_plain_assistant_question_does_not_tag_the_next_turn() -> None:
     output = buffer.getvalue()
     assert "↗ answer" not in output
     assert "how many open PRs in opensre?" in output
+
+
+def test_selection_recap_lists_the_offered_rows() -> None:
+    """The picker erases itself; the recap keeps what the choice was made against."""
+    import io
+
+    from rich.console import Console
+
+    console = Console(file=io.StringIO(), force_terminal=False, width=120)
+
+    render_choice_selection(
+        console,
+        "What would you like to do next?",
+        "Exit demo",
+        options=("Set up an agent", "Connect to Slack", "Exit demo"),
+    )
+
+    out = console.file.getvalue()  # type: ignore[union-attr]
+    assert "↳ What would you like to do next?  Exit demo" in out
+    assert "offered: Set up an agent · Connect to Slack · Exit demo" in out

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -70,7 +70,7 @@ def test_table_reply_renders_as_a_table_not_flattened_pipes() -> None:
     out = buf.getvalue()
     assert "| Rank | Folder |" not in out  # not the raw flattened markdown row
     assert "Rank" in out and "Folder" in out and "Size" in out
-    assert "─" in out  # rendered as a table with a header rule
+    assert "━" in out and "│" in out  # rendered as a table with header rule and column rules
 
 
 def test_prose_reply_keeps_the_inline_marker() -> None:

--- a/tests/shared/terminal/test_reply_markdown.py
+++ b/tests/shared/terminal/test_reply_markdown.py
@@ -1,0 +1,56 @@
+"""Reply markdown tables wrap long cells and mark the header, not the body."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+from rich.text import Text
+
+import infrastructure.terminal.theme as ui_theme
+from surfaces.shared.terminal.components.markdown import ReplyMarkdown
+
+_TABLE = "| File | Jobs |\n| --- | --- |\n| .github/workflows/celebrate-merged-pr.yml | 1 |\n"
+
+
+def _render(width: int) -> str:
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=True, color_system="truecolor", width=width)
+    with console.use_theme(ui_theme.MARKDOWN_THEME):
+        console.print(ReplyMarkdown(_TABLE))
+    return buf.getvalue()
+
+
+def test_long_cell_folds_instead_of_truncating() -> None:
+    # Arrange: the file name cannot fit the column at this width.
+    width = 40
+
+    # Act
+    plain = Text.from_ansi(_render(width)).plain
+
+    # Assert: the name continues on the next line and no ellipsis was inserted.
+    assert "…" not in plain
+    first_column = "".join(line.split("│")[0].strip() for line in plain.splitlines())
+    assert ".github/workflows/celebrate-merged-pr.yml" in first_column
+    assert "│" in plain
+
+
+def test_header_is_bold_and_body_is_not() -> None:
+    # Arrange / Act
+    text = Text.from_ansi(_render(80))
+
+    # Assert
+    header_at = text.plain.index("File")
+    body_at = text.plain.index("celebrate")
+    header_bold = any(
+        span.start <= header_at < span.end and span.style.bold  # type: ignore[union-attr]
+        for span in text.spans
+        if not isinstance(span.style, str)
+    )
+    body_bold = any(
+        span.start <= body_at < span.end and span.style.bold  # type: ignore[union-attr]
+        for span in text.spans
+        if not isinstance(span.style, str)
+    )
+    assert header_bold
+    assert not body_bold

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -255,6 +255,7 @@ def run_ask_user_choice(
     questions: list[dict[str, Any]] | None = None,
     multi_select: bool = False,
     note: str = "",
+    allow_custom: bool = True,
     context: Any,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
@@ -262,6 +263,7 @@ def run_ask_user_choice(
         "options": options or [],
         "multi_select": multi_select,
         "note": note,
+        "allow_custom": allow_custom,
     }
     if questions is not None:
         payload["questions"] = questions

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -61,9 +61,12 @@ shell_run_tool = RegisteredTool(
         "a specific command, propose it exactly as requested — the approval gate confirms "
         "anything risky before it runs, so do not refuse a destructive command the user "
         "explicitly asked for. Do not volunteer destructive, credential-exfiltrating, or "
-        "unrelated commands the user did not ask for. Set quiet=true to hide the $ line "
-        "and stdout/stderr from the terminal while still returning output to the agent "
-        "(required for intermediate skill probes)."
+        "unrelated commands the user did not ask for. Set quiet=true to hide stdout/stderr "
+        "from the terminal while still returning output to the agent (required for "
+        "intermediate skill probes); a dim command line still shows what ran. When a "
+        "command errors (missing module, non-zero exit), fix and rerun it rather than "
+        "estimating the result another way; never present an approximation as the "
+        "measured figure."
     ),
     input_schema=object_schema(
         properties={
@@ -82,8 +85,8 @@ shell_run_tool = RegisteredTool(
             "quiet": {
                 "type": "boolean",
                 "description": (
-                    "When true, do not print the command line or stdout/stderr to the "
-                    "interactive shell. Tool result payload is unchanged. Use for "
+                    "When true, do not print stdout/stderr to the interactive shell; the "
+                    "command line still prints dimmed. Tool result payload is unchanged. Use for "
                     "intermediate skill fetches (delivering-morning-briefings weather/news "
                     "curls, repository scans) when the user should only see the "
                     "composed answer, not the raw $ output twice."

--- a/tools/interactive_shell/shell/display.py
+++ b/tools/interactive_shell/shell/display.py
@@ -20,6 +20,14 @@ def _closing_delimiter_line(line: str, *, delimiter: str, strip_tabs: bool) -> b
     return normalized == delimiter
 
 
+def summarize_shell_command(command: str, *, width: int = 96) -> str:
+    """One-line command entry for quiet runs: whitespace collapsed, cut with an ellipsis."""
+    one_line = " ".join(format_shell_command_for_display(command).split())
+    if len(one_line) <= width:
+        return one_line
+    return one_line[: width - 1].rstrip() + "…"
+
+
 def format_shell_command_for_display(command: str) -> str:
     """Return a compact, user-facing command string for the REPL prompt area.
 

--- a/tools/interactive_shell/shell/runner.py
+++ b/tools/interactive_shell/shell/runner.py
@@ -9,9 +9,12 @@ from pathlib import Path
 from typing import Any
 
 import config.constants.platform as _platform
-from infrastructure.terminal.theme import ERROR, GLYPH_ERROR
+from infrastructure.terminal.theme import DIM, ERROR, GLYPH_ERROR
 from tools.interactive_shell.shell import execution as shell_execution
-from tools.interactive_shell.shell.display import format_shell_command_for_display
+from tools.interactive_shell.shell.display import (
+    format_shell_command_for_display,
+    summarize_shell_command,
+)
 from tools.interactive_shell.shell.parsing import (
     argv_for_repl_builtin_detection,
     parse_shell_command,
@@ -78,7 +81,10 @@ def run_shell_command(
             cancelled=plan.policy.verdict != "deny",
         )
 
-    if not quiet:
+    if quiet:
+        # Quiet hides the output, not the fact that a command ran.
+        presenter.print(f"[{DIM}]$ {summarize_shell_command(display_command)}[/]")
+    else:
         presenter.print_bold_command(display_command)
 
     argv_builtin = argv_for_repl_builtin_detection(parsed=parsed, is_windows=_platform.IS_WINDOWS)


### PR DESCRIPTION
- Markdown tables render through ReplyMarkdown: bold header, dim column and
  header rules, cells fold instead of ellipsis; code spans keep colour only.
- Quiet shell_run prints a dim one-line command entry and hides the output.
- Menu recap lists the offered rows on a dim line.
- ask_user_choice accepts allow_custom on the run path; the schema property
  crashed every call that used it and the same menu was asked in a loop.