### PR TITLE
fix(shell): rerun failed commands before answering; full command in tool frame rows

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -346,6 +346,8 @@ When using the shell, you must adhere to the following guidelines:
 
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
 - Do not use python scripts to attempt to output larger chunks of a file.
+- When a command fails (a missing module, a non-zero exit, a traceback), fix it and run it again before answering; in this checkout `uv run python` has the project's libraries. Never replace a failed measurement with a regex, a guess or a rough count presented as the measured figure. If you must estimate, say it is an estimate and why.
+- `quiet=true` on `shell_run` hides the output only; the command line still shows dimmed, so quiet is never a way to hide what ran.
 - Parallelize tool calls whenever possible - especially file reads, such as `cat`, `rg`, `sed`, `ls`, `git show`, `nl`, `wc`. Use `multi_tool_use.parallel` to parallelize tool calls and only this.
 
 # Proactive messaging

--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -346,7 +346,7 @@ When using the shell, you must adhere to the following guidelines:
 
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
 - Do not use python scripts to attempt to output larger chunks of a file.
-- When a command fails (a missing module, a non-zero exit, a traceback), fix it and run it again before answering; in this checkout `uv run python` has the project's libraries. Never replace a failed measurement with a regex, a guess or a rough count presented as the measured figure. If you must estimate, say it is an estimate and why.
+- When a read-only measurement fails (a missing module, a non-zero exit, a traceback), fix it and run it again before answering; in this checkout `uv run python` has the project's libraries. Do not rerun a command that may already have written files or changed state. Never replace a failed measurement with a regex, a guess or a rough count presented as the measured figure. If you must estimate, say it is an estimate and why.
 - `quiet=true` on `shell_run` hides the output only; the command line still shows dimmed, so quiet is never a way to hide what ran.
 - Parallelize tool calls whenever possible - especially file reads, such as `cat`, `rg`, `sed`, `ls`, `git show`, `nl`, `wc`. Use `multi_tool_use.parallel` to parallelize tool calls and only this.
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -119,9 +119,14 @@ def _is_internal_choice_command(name: str, data: dict[str, Any]) -> bool:
     return isinstance(args, dict) and str(args.get("command", "")).strip() == "/choose"
 
 
+def _collapsed_line(value: str) -> str:
+    """One line, whitespace collapsed. Do not truncate — the action log clips to width."""
+    return " ".join(value.split())
+
+
 def _bounded_preview(value: str, *, limit: int = _TOOL_PREVIEW_MAX_CHARS) -> str:
     """Keep live progress on one useful terminal line."""
-    collapsed = " ".join(value.split())
+    collapsed = _collapsed_line(value)
     if len(collapsed) <= limit:
         return collapsed
     return collapsed[: limit - 1].rstrip() + "…"
@@ -204,7 +209,7 @@ def _github_cli_display(args: dict[str, Any]) -> tuple[str, str]:
         command.extend(["-R", repo])
     command.extend(_compact_gh_args(args.get("args")))
     preview = shlex.join(command).replace("'…'", "…")
-    return "GitHub CLI", _bounded_preview(preview)
+    return "GitHub CLI", preview
 
 
 def _python_execution_display(args: dict[str, Any]) -> tuple[str, str]:
@@ -535,7 +540,7 @@ class ActionRenderObserver:
         args = data.get("input")
         label, content = tool_call_display(name, args if isinstance(args, dict) else {})
         if label in _COMMAND_TOOL_LABELS:
-            concise = _bounded_preview(content) if content else ""
+            concise = _collapsed_line(content) if content else ""
             detail = f"{_TOOL_CALL_MARKER} {label} · {content}" if content else f"{label}"
         else:
             concise = ""

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -535,7 +535,7 @@ class ActionRenderObserver:
         args = data.get("input")
         label, content = tool_call_display(name, args if isinstance(args, dict) else {})
         if label in _COMMAND_TOOL_LABELS:
-            concise = _bounded_preview(content, limit=72) if content else ""
+            concise = _bounded_preview(content) if content else ""
             detail = f"{_TOOL_CALL_MARKER} {label} · {content}" if content else f"{label}"
         else:
             concise = ""

--- a/tests/core/agent/orchestration/test_ask_choice_tool.py
+++ b/tests/core/agent/orchestration/test_ask_choice_tool.py
@@ -274,3 +274,45 @@ def test_allow_custom_from_the_model_reaches_the_pending_choice() -> None:
     assert result["ok"] is True
     assert session.pending_user_choice is not None
     assert session.pending_user_choice.custom_answer is False
+
+
+def _answer_turn(session: Session, message: str) -> ActionToolScope:
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    return ActionToolScope(
+        session=session, console=console, slash_ports=_Ports(), turn_user_message=message
+    )
+
+
+def test_a_question_answered_in_this_message_is_not_asked_again() -> None:
+    # Arrange: the turn's user message is the answer to the same question.
+    session = Session()
+    ctx = _answer_turn(session, "1. When should it run?\nWeekdays at 08:00 (recommended)")
+
+    # Act
+    result = execute_ask_user_choice_tool(
+        {
+            "title": "When should it run?",
+            "options": ["Weekdays at 08:00 (recommended)", "Every day"],
+        },
+        ctx,
+    )
+
+    # Assert: refused with the answer, nothing queued.
+    assert result["ok"] is False
+    assert "Weekdays at 08:00 (recommended)" in result["error"]
+    assert session.pending_user_choice is None
+
+
+def test_a_different_question_still_queues_on_an_answer_turn() -> None:
+    # Arrange
+    session = Session()
+    ctx = _answer_turn(session, "1. Which repository should the agent watch?\nTracer-Cloud/opensre")
+
+    # Act
+    result = execute_ask_user_choice_tool(
+        {"title": "When should it run?", "options": ["Weekdays at 08:00", "Every day"]}, ctx
+    )
+
+    # Assert
+    assert result["ok"] is True
+    assert result["menu"] == "queued"

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -90,6 +90,8 @@ def test_failed_commands_are_rerun_not_estimated() -> None:
     shell_section = _SYSTEM_PROMPT_BASE.split("## Shell commands", 1)[1]
 
     # Assert
+    assert "read-only measurement" in shell_section
     assert "fix it and run it again before answering" in shell_section
+    assert "Do not rerun a command that may already have written files" in shell_section
     assert "Never replace a failed measurement" in shell_section
     assert "the command line still shows dimmed" in shell_section

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -83,3 +83,13 @@ def test_proactive_messages_are_new_actionable_and_time_sensitive() -> None:
     assert "Broadcast only decisions, anomalies, or milestones" in collapsed
     assert "when the underlying state has not changed" in collapsed
     assert "Do not ask whether to adopt this policy" in collapsed
+
+
+def test_failed_commands_are_rerun_not_estimated() -> None:
+    # Arrange / Act: the shell guidelines carry the rule as one bullet.
+    shell_section = _SYSTEM_PROMPT_BASE.split("## Shell commands", 1)[1]
+
+    # Assert
+    assert "fix it and run it again before answering" in shell_section
+    assert "Never replace a failed measurement" in shell_section
+    assert "the command line still shows dimmed" in shell_section

--- a/tests/interactive_shell/ui/test_action_log.py
+++ b/tests/interactive_shell/ui/test_action_log.py
@@ -61,6 +61,25 @@ def test_no_inline_dotted_arguments_on_a_single_call() -> None:
     assert "per_page" not in out  # args are hidden behind Ctrl+O
 
 
+def test_a_long_collapsed_command_is_clipped_only_at_render_width() -> None:
+    command = "gh run list --workflow very-long-workflow-name-that-must-not-be-cut.yml --json " + (
+        ",".join(f"field{index}" for index in range(40))
+    )
+    session = Session()
+    _push(session, "1", "GitHub CLI", command, f"⏺ GitHub CLI · {command}")
+    buffer = io.StringIO()
+    console = Console(
+        file=buffer, force_terminal=True, highlight=False, color_system="truecolor", width=80
+    )
+
+    flush_action_log(console, session)
+
+    out = buffer.getvalue()
+    assert "field39" not in out  # clipped to the 80-column row
+    assert "very-long-workflow" in out
+    assert command in session.terminal.next_collapsed_output_for_expand()
+
+
 def test_a_lone_call_is_a_dim_line_not_a_one_row_box() -> None:
     session = Session()
     _push(session, "1", "GitHub CLI", "gh pr list", "⏺ GitHub CLI · gh pr list")

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -265,6 +265,41 @@ def test_github_cli_tool_call_display_uses_sdk_arguments_without_runtime_details
     assert "120" not in content
 
 
+def test_github_cli_tool_call_display_keeps_a_command_longer_than_the_preview_cap() -> None:
+    filename = "very-long-workflow-name-that-must-not-be-cut.yml"
+    fields = ",".join(f"field{index}" for index in range(40))
+    _label, content = tool_call_display(
+        "github_cli",
+        {"args": ["run", "list", "--workflow", filename, "--json", fields]},
+    )
+
+    assert filename in content
+    assert "field39" in content
+    assert len(content) > 180
+    assert not content.endswith("…")
+
+
+def test_action_log_keeps_the_full_collapsed_command_until_flush_clips() -> None:
+    filename = "very-long-workflow-name-that-must-not-be-cut.yml"
+    fields = ",".join(f"field{index}" for index in range(40))
+    observer, _buffer = _observer_with_buffer()
+
+    observer(
+        "tool_start",
+        {
+            "id": "t1",
+            "name": "github_cli",
+            "input": {"args": ["run", "list", "--workflow", filename, "--json", fields]},
+        },
+    )
+
+    entry = observer.session.terminal.action_log_entries[0]
+    assert filename in entry.concise
+    assert "field39" in entry.concise
+    assert len(entry.concise) > 180
+    assert not entry.concise.endswith("…")
+
+
 def test_python_tool_call_display_summarizes_execution_with_safe_input_values() -> None:
     label, content = tool_call_display(
         "execute_python_code",

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agent_harness.spi.handoff import AskUserQuestion
+from core.agent_harness.spi.handoff import AskUserQuestion, parse_ask_user_answers
 from core.agent_harness.spi.session_state import (
     PendingUserChoice,
     session_terminal,
@@ -177,12 +177,33 @@ def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | N
     return parsed, None
 
 
+def _answered_this_turn(ctx: ActionToolScope, title: str) -> str | None:
+    """The answer the user gave to ``title`` in this turn's message, if any."""
+    wanted = " ".join(title.split()).casefold()
+    if not wanted:
+        return None
+    for asked, answer in parse_ask_user_answers(getattr(ctx, "turn_user_message", "") or ""):
+        if " ".join(asked.split()).casefold() == wanted:
+            return answer
+    return None
+
+
 def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
     questions, questions_error = _parse_questions(args.get("questions"))
     if questions_error is not None:
         return {"ok": False, "error": questions_error}
 
     title = strip_terminal_controls(str(args.get("title", ""))).strip()
+    for asked in [title, *[question.title for question in questions or ()]]:
+        answer = _answered_this_turn(ctx, asked)
+        if answer is not None:
+            return {
+                "ok": False,
+                "error": (
+                    f"The user already answered {asked!r} in this message: {answer!r}. "
+                    "Use that answer and continue with the next step; do not ask again."
+                ),
+            }
     options = _parse_options(args.get("options"))
 
     if questions:


### PR DESCRIPTION
- System prompt shell rules: fix and rerun a failing command (uv run python
  has the project libraries); never present a regex or guess as a measured
  figure; quiet hides output only.
- Tool frame rows keep the full collapsed command and clip to the terminal
  width instead of a fixed 72 characters, so file names survive.