### PR TITLE
fix(shell): keep a menu batch's open questions when some were just answered

### DIFF
--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -147,8 +147,9 @@ Wait for the answer, then follow the selected option.
 
 **Recurring check:** Call
 `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the
-analyzed repository, output its `response_text` verbatim, and stop. Each
-tick is the same analytics report, not a CI code fix. `/loops service
+analyzed repository, output its `response_text` verbatim, and stop. The
+report was already shown in step 3, so do not pass `include_report`.
+Each later tick is the same analytics report, not a CI code fix. `/loops service
 install` keeps it running when no shell is open. Do not call
 `fix_github_pr_ci` from this skill.
 

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
@@ -93,6 +93,8 @@ Wait for the answer.
 
 ### 4. Schedule the loop
 
-Call `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for
-weekdays, or pass `weekdays=false` when they chose every day. Output
-`response_text` verbatim and stop.
+Call `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>",
+include_report=true)` for weekdays, or pass `weekdays=false` when they
+chose every day. Output `response_text` verbatim and stop. When a same-day
+report exists it comes first, then the schedule card; otherwise the card
+alone.

--- a/integrations/github/tools/ci_analytics/loop_tool.py
+++ b/integrations/github/tools/ci_analytics/loop_tool.py
@@ -8,6 +8,7 @@ from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
 from core.tool_framework import tool
 from integrations.github.tools.ci_analytics import loop as ci_loop
+from integrations.github.tools.ci_analytics.tool import report_text_from_snapshot
 
 TOOL_NAME = "schedule_ci_reliability_loop"
 
@@ -20,8 +21,10 @@ TOOL_NAME = "schedule_ci_reliability_loop"
         "Schedule a recurring CI/CD reliability check for one repository: a local "
         "prompt loop that re-runs the reliability analytics and delivers the report "
         "to this shell's inbox. Weekdays at 08:00 local time unless told otherwise. "
-        "Never posts to Slack or any chat channel. Returns the schedule to repeat "
-        "verbatim."
+        "Never posts to Slack or any chat channel. Returns the schedule card to "
+        "repeat verbatim; with include_report=true, today's saved report (key "
+        "results and compare) comes first when a same-day snapshot exists. Never "
+        "reads GitHub live."
     ),
     use_cases=[
         "Set up an agent that improves CI/CD reliability over time",
@@ -38,7 +41,10 @@ TOOL_NAME = "schedule_ci_reliability_loop"
         "task_id": "Id of the scheduled loop, for /loops commands",
         "next_run": "When the loop fires next",
         "reused": "True when the repository already had this loop",
-        "response_text": "The schedule card, to repeat verbatim",
+        "report_as_of": (
+            "Snapshot time of the report placed above the card; empty when the card stands alone"
+        ),
+        "response_text": "The schedule card, preceded by today's report when included",
     },
     surfaces=(ToolSurface.ACTION,),
     side_effect_level=SideEffectLevel.MUTATING,
@@ -56,6 +62,13 @@ TOOL_NAME = "schedule_ci_reliability_loop"
                 "type": "boolean",
                 "description": "Run Monday to Friday only (default true); false runs every day.",
             },
+            "include_report": {
+                "type": "boolean",
+                "description": (
+                    "Put today's saved reliability report above the schedule card "
+                    "(default false). Use when no report was shown this turn."
+                ),
+            },
         },
         "required": ["owner", "repo"],
         "additionalProperties": False,
@@ -67,6 +80,7 @@ def schedule_ci_reliability_loop(
     repo: str,
     time: str | None = None,
     weekdays: bool | None = None,
+    include_report: bool | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     owner = owner.strip()
@@ -83,6 +97,8 @@ def schedule_ci_reliability_loop(
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
     task = scheduled.loop.task
+    card = "\n".join(ci_loop.loop_card(scheduled))
+    report, report_as_of = report_text_from_snapshot(owner, repo) if include_report else ("", "")
     return {
         "ok": True,
         "task_id": task.id,
@@ -91,7 +107,8 @@ def schedule_ci_reliability_loop(
         "timezone": task.timezone,
         "next_run": scheduled.loop.next_run,
         "reused": scheduled.reused,
-        "response_text": "\n".join(ci_loop.loop_card(scheduled)),
+        "report_as_of": report_as_of if report else "",
+        "response_text": f"{report}\n\n{card}" if report else card,
     }
 
 

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -22,15 +22,16 @@ _TOP_BLOCKED_PRS = 5
 _TOP_DEVELOPERS = 3
 
 
-def render_markdown(report: CiAnalyticsReport) -> str:
-    """Compact report: key results lead; counts follow."""
+def render_markdown(report: CiAnalyticsReport, *, compact: bool = False) -> str:
+    """Markdown report: key results lead. ``compact`` omits the counts appendix."""
     lines = [
         f"**CI/CD reliability for {report.owner}/{report.repo}, last {report.window_days} days**",
         "",
     ]
     lines.extend(_key_results_markdown(report))
     if report.executions:
-        lines.extend(_details_markdown(report))
+        if not compact:
+            lines.extend(_details_markdown(report))
     else:
         lines.extend(["", "No completed workflow runs were found in this window."])
     lines.extend(f"- {notice}" for notice in report.coverage_notices)
@@ -180,10 +181,6 @@ def render_comparison(
         Text(""),
         Text(f"Compared with {peers_label} over the same {user.window_days} days", style="bold"),
         table,
-        Text(
-            "Red time = red_hours / (days × 24); CI-caused = reliability_failures / PR runs.",
-            style="dim",
-        ),
     ]
     parts.extend(Text(notice, style="dim") for notice in _comparison_notes(peers))
     parts.extend(Text(line, style="dim") for line in skip_lines(missed))
@@ -225,9 +222,7 @@ def comparison_markdown(
             align,
             *rows,
             "",
-            "Red time = red_hours / (days × 24); CI-caused = reliability_failures / PR runs.",
-            *_comparison_notes(peers),
-            *skip_lines(missed),
+            *[f"- {note}" for note in [*_comparison_notes(peers), *skip_lines(missed)]],
         ]
     )
 

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -236,6 +236,25 @@ def _from_snapshot(
     }
 
 
+def report_text_from_snapshot(
+    owner: str, repo: str, *, days: int = _DEFAULT_WINDOW_DAYS, include_benchmarks: bool = True
+) -> tuple[str, str]:
+    """``(markdown, generated_at)`` from today's snapshot, or ``("", "")`` when none.
+
+    Reads saved snapshots only; never resolves a token or starts a live fetch.
+    """
+    now = datetime.now(UTC)
+    snapshot = read_fresh_snapshot(snapshot_root(), owner, repo, window_days=days, now=now)
+    if snapshot is None:
+        return "", ""
+    result = _from_snapshot(
+        snapshot, owner, repo, days, None, include_benchmarks=include_benchmarks
+    )
+    if not result.get("success"):
+        return "", ""
+    return str(result.get("response_text") or "").strip(), str(snapshot.get("generated_at", ""))
+
+
 def _peer_payload(report: CiAnalyticsReport, *, from_snapshot: str | None) -> dict[str, Any]:
     return {
         "owner": report.owner,
@@ -538,4 +557,4 @@ def analyze_github_ci_reliability(
     )
 
 
-__all__ = ["TOOL_NAME", "analyze_github_ci_reliability"]
+__all__ = ["report_text_from_snapshot", "TOOL_NAME", "analyze_github_ci_reliability"]

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -24,6 +24,7 @@ from integrations.github.helpers import (
 )
 from integrations.github.repo_scope import detect_git_remote_repo_scope
 from integrations.github.tools.ci_analytics.analysis import analyze_repository
+from integrations.github.tools.ci_analytics.loop import LOOP_WINDOW_DAYS
 from integrations.github.tools.ci_analytics.models import CiAnalyticsReport, FailureKind
 from integrations.github.tools.ci_analytics.render import (
     comparison_markdown,
@@ -244,11 +245,15 @@ def report_text_from_snapshot(
     Reads saved snapshots only; never resolves a token or starts a live fetch.
     """
     now = datetime.now(UTC)
-    snapshot = read_fresh_snapshot(snapshot_root(), owner, repo, window_days=days, now=now)
-    if snapshot is None:
+    # The scheduled loop saves its own window; a same-day loop report counts too.
+    for window in dict.fromkeys((days, LOOP_WINDOW_DAYS)):
+        snapshot = read_fresh_snapshot(snapshot_root(), owner, repo, window_days=window, now=now)
+        if snapshot is not None:
+            break
+    else:
         return "", ""
     result = _from_snapshot(
-        snapshot, owner, repo, days, None, include_benchmarks=include_benchmarks
+        snapshot, owner, repo, window, None, include_benchmarks=include_benchmarks
     )
     if not result.get("success"):
         return "", ""
@@ -358,7 +363,11 @@ def _result(
             "response_text": summary,
         }
     else:
-        result = {**base, **report_payload(report), "response_text": render_markdown(report)}
+        result = {
+            **base,
+            **report_payload(report),
+            "response_text": render_markdown(report, compact=include_benchmarks),
+        }
     if include_benchmarks:
         result = _attach_benchmarks(result, report, window=window, console=console)
     return result

--- a/tests/core/agent/orchestration/test_ask_choice_tool.py
+++ b/tests/core/agent/orchestration/test_ask_choice_tool.py
@@ -316,3 +316,58 @@ def test_a_different_question_still_queues_on_an_answer_turn() -> None:
     # Assert
     assert result["ok"] is True
     assert result["menu"] == "queued"
+
+
+def _question(label: str, title: str) -> dict[str, Any]:
+    return {"label": label, "title": title, "options": ["Weekdays at 08:00", "Every day"]}
+
+
+def test_a_batch_keeps_its_unanswered_questions() -> None:
+    # Arrange: one of three batched questions was answered in this message.
+    session = Session()
+    ctx = _answer_turn(session, "1. When should it run?\nEvery day")
+    batch = [
+        _question("Cadence", "When should it run?"),
+        _question("Channel", "Where should reports go?"),
+        _question("Window", "How many days back?"),
+    ]
+
+    # Act
+    result = execute_ask_user_choice_tool({"questions": batch}, ctx)
+
+    # Assert: the two open questions are queued, the answered one is gone.
+    assert result["ok"] is True
+    assert session.pending_user_choice is not None
+    titles = [q.title for q in session.pending_user_choice.questions]
+    assert titles == ["Where should reports go?", "How many days back?"]
+
+
+def test_a_batch_with_one_open_question_becomes_a_single_decision() -> None:
+    # Arrange
+    session = Session()
+    ctx = _answer_turn(session, "1. When should it run?\nEvery day")
+    batch = [_question("Cadence", "When should it run?"), _question("Channel", "Where to?")]
+
+    # Act
+    result = execute_ask_user_choice_tool({"questions": batch}, ctx)
+
+    # Assert
+    assert result["ok"] is True
+    assert session.pending_user_choice is not None
+    assert session.pending_user_choice.title == "Where to?"
+    assert session.pending_user_choice.questions == ()
+
+
+def test_a_fully_answered_batch_is_refused_with_the_answers() -> None:
+    # Arrange
+    session = Session()
+    ctx = _answer_turn(session, "1. When should it run?\nEvery day\n\n2. Where to?\nInbox")
+    batch = [_question("Cadence", "When should it run?"), _question("Channel", "Where to?")]
+
+    # Act
+    result = execute_ask_user_choice_tool({"questions": batch}, ctx)
+
+    # Assert
+    assert result["ok"] is False
+    assert "'Every day'" in result["error"] and "'Inbox'" in result["error"]
+    assert session.pending_user_choice is None

--- a/tests/core/agent/orchestration/test_ask_choice_tool.py
+++ b/tests/core/agent/orchestration/test_ask_choice_tool.py
@@ -202,6 +202,20 @@ def test_one_item_questions_array_is_rejected() -> None:
     assert "title and options" in result["error"]
 
 
+def test_duplicate_question_titles_are_rejected() -> None:
+    result = execute_ask_user_choice_tool(
+        {
+            "questions": [
+                _question("Cadence", "When should it run?"),
+                _question("Again", "  WHEN SHOULD IT RUN?  "),
+            ]
+        },
+        _ctx(),
+    )
+    assert result["ok"] is False
+    assert "already used" in result["error"]
+
+
 def test_malformed_question_is_rejected() -> None:
     result = execute_ask_user_choice_tool(
         {"title": "Ask User", "questions": [{"label": "Codebase", "title": "Where?"}]},

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -84,6 +84,8 @@ def test_tool_returns_the_card_and_reports_a_bad_time(monkeypatch: pytest.Monkey
     assert ok["ok"] is True
     assert ok["task_id"] == "task1"
     assert "/loops messages" in ok["response_text"]
+    assert ok["report_as_of"] == ""
+    assert "Key results" not in ok["response_text"]
     assert calls[0]["time_text"] == ci_loop.DEFAULT_LOOP_TIME
     assert calls[0]["weekdays"] is True
     assert bad == {"ok": False, "error": "time must look like 08:30"}
@@ -106,6 +108,73 @@ def _scheduled_stub(owner: str, repo: str) -> ci_loop.ScheduledLoop:
     )
     loop = ManualLoop(task=task, channels=(Provider.INTERACTIVE_SHELL,), next_run="soon")
     return ci_loop.ScheduledLoop(loop=loop, reused=False)
+
+
+def test_tool_puts_todays_snapshot_report_above_the_schedule_card(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+    from integrations.github.tools.ci_analytics.models import (
+        CiAnalyticsReport,
+        Outage,
+        WorkflowSummary,
+    )
+    from integrations.github.tools.ci_analytics.snapshots import report_to_dict, write_snapshot
+
+    now = datetime.now(UTC)
+    report = CiAnalyticsReport(
+        owner="acme",
+        repo="app",
+        default_branch="main",
+        window_days=30,
+        generated_at=now,
+        executions=100,
+        pr_executions=80,
+        pr_failures=8,
+        classified=(),
+        merged_pr_branches=10,
+        blocked_minutes=120.0,
+        blocked_minutes_all=150.0,
+        branch_runs=20,
+        branch_failures=2,
+        red_hours=36.4,
+        outages=(Outage(workflow="CI", started_at=now, ended_at=None, first_failure_url="u"),),
+        mean_recovery_hours=1.0,
+        workflows=(WorkflowSummary("CI", 100, 8, 3, 12.0),),
+        coverage_notices=(),
+        working_hours_label="Mon-Fri 09:00-18:00 UTC",
+    )
+    write_snapshot(
+        tmp_path,
+        "acme",
+        "app",
+        now - timedelta(minutes=5),
+        {
+            "generated_at": (now - timedelta(minutes=5)).isoformat(),
+            "window_days": 30,
+            "headline": "h",
+            "report": report_to_dict(report),
+        },
+    )
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
+
+    def _schedule(*_a: object, **_k: object) -> ci_loop.ScheduledLoop:
+        return _scheduled_stub("acme", "app")
+
+    monkeypatch.setattr(ci_loop, "schedule_ci_reliability_loop", _schedule)
+
+    result = loop_tool.schedule_ci_reliability_loop(owner="acme", repo="app", include_report=True)
+
+    assert result["ok"] is True
+    assert result["report_as_of"].startswith(str(now.year))
+    text = result["response_text"]
+    assert text.index("Key results") < text.index("Scheduled:")
+    assert "36.4h of 30 days" in text
+    assert "Compared with" in text
+    assert "/loops messages" in text
 
 
 def test_loop_names_the_deterministic_builder_with_its_arguments(store_path: Path) -> None:
@@ -202,3 +271,43 @@ def test_build_report_without_a_token_raises_a_generic_error(
 
     with pytest.raises(RuntimeError, match="No GitHub token"):
         ci_loop.build_report({"owner": "acme", "repo": "app"})
+
+
+def test_tool_never_reads_github_live_when_no_snapshot_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange: a token is available and no snapshot exists for the repository.
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    monkeypatch.setenv("GITHUB_TOKEN", "stub-token")
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    live_calls: list[tuple[str, str]] = []
+
+    def _analyze(owner: str, repo: str, **_kwargs: object) -> object:
+        live_calls.append((owner, repo))
+        raise AssertionError("live read")
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
+    monkeypatch.setattr(
+        ci_loop, "schedule_ci_reliability_loop", lambda *_a, **_k: _scheduled_stub("acme", "app")
+    )
+
+    # Act
+    result = loop_tool.schedule_ci_reliability_loop(owner="acme", repo="app", include_report=True)
+
+    # Assert: the card alone, and GitHub was never contacted.
+    assert live_calls == []
+    assert result["ok"] is True
+    assert result["report_as_of"] == ""
+    assert result["response_text"].startswith("Scheduled:")
+
+
+def test_registered_tool_runs_the_scheduling_function() -> None:
+    # Arrange / Act: the registry entry is what the model actually calls.
+    from tools.registry import get_registered_tool
+
+    registered = get_registered_tool(loop_tool.TOOL_NAME)
+
+    # Assert
+    assert registered is not None
+    assert registered.run is loop_tool.schedule_ci_reliability_loop

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -110,12 +111,9 @@ def _scheduled_stub(owner: str, repo: str) -> ci_loop.ScheduledLoop:
     return ci_loop.ScheduledLoop(loop=loop, reused=False)
 
 
-def test_tool_puts_todays_snapshot_report_above_the_schedule_card(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def _write_report_snapshot(root: Path, *, window_days: int) -> datetime:
     from datetime import UTC, datetime, timedelta
 
-    from integrations.github.tools.ci_analytics import tool as tool_module
     from integrations.github.tools.ci_analytics.models import (
         CiAnalyticsReport,
         Outage,
@@ -128,7 +126,7 @@ def test_tool_puts_todays_snapshot_report_above_the_schedule_card(
         owner="acme",
         repo="app",
         default_branch="main",
-        window_days=30,
+        window_days=window_days,
         generated_at=now,
         executions=100,
         pr_executions=80,
@@ -147,17 +145,26 @@ def test_tool_puts_todays_snapshot_report_above_the_schedule_card(
         working_hours_label="Mon-Fri 09:00-18:00 UTC",
     )
     write_snapshot(
-        tmp_path,
+        root,
         "acme",
         "app",
         now - timedelta(minutes=5),
         {
             "generated_at": (now - timedelta(minutes=5)).isoformat(),
-            "window_days": 30,
+            "window_days": window_days,
             "headline": "h",
             "report": report_to_dict(report),
         },
     )
+    return now
+
+
+def test_tool_puts_todays_snapshot_report_above_the_schedule_card(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    now = _write_report_snapshot(tmp_path, window_days=30)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
 
@@ -311,3 +318,27 @@ def test_registered_tool_runs_the_scheduling_function() -> None:
     # Assert
     assert registered is not None
     assert registered.run is loop_tool.schedule_ci_reliability_loop
+
+
+def test_tool_uses_the_loops_seven_day_snapshot_when_no_thirty_day_one_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange: only the scheduled loop's own snapshot window is saved today.
+    from integrations.github.tools.ci_analytics import tool as tool_module
+    from integrations.github.tools.ci_analytics.loop import LOOP_WINDOW_DAYS
+
+    _write_report_snapshot(tmp_path, window_days=LOOP_WINDOW_DAYS)
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(
+        ci_loop, "schedule_ci_reliability_loop", lambda *_a, **_k: _scheduled_stub("acme", "app")
+    )
+
+    # Act
+    result = loop_tool.schedule_ci_reliability_loop(owner="acme", repo="app", include_report=True)
+
+    # Assert: the loop's report is used and says which window it covers.
+    assert result["report_as_of"] != ""
+    assert f"last {LOOP_WINDOW_DAYS} days" in result["response_text"]
+    assert result["response_text"].index("Key results") < result["response_text"].index(
+        "Scheduled:"
+    )

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -141,6 +141,11 @@ def _parse_bool(value: object, *, default: bool = False) -> bool:
     return default
 
 
+def _normalize_title(title: str) -> str:
+    """Identity for matching a question to an answer in this turn's message."""
+    return " ".join(title.split()).casefold()
+
+
 def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | None]:
     """Return ``(questions, error)``. Absent/empty ``raw`` yields ``([], None)``."""
     if raw is None:
@@ -150,6 +155,7 @@ def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | N
     if not raw:
         return [], None
     parsed: list[AskUserQuestion] = []
+    seen_titles: set[str] = set()
     for index, item in enumerate(raw):
         if not isinstance(item, dict):
             return None, f"questions[{index}] must be an object"
@@ -160,6 +166,12 @@ def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | N
             return None, f"questions[{index}].label is required"
         if not title:
             return None, f"questions[{index}].title is required"
+        title_key = _normalize_title(title)
+        if title_key in seen_titles:
+            return None, (
+                f"questions[{index}].title is already used; each question needs its own title"
+            )
+        seen_titles.add(title_key)
         option_error = _options_error(options)
         if option_error is not None:
             return None, f"questions[{index}]: {option_error}"
@@ -179,11 +191,11 @@ def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | N
 
 def _answered_this_turn(ctx: ActionToolScope, title: str) -> str | None:
     """The answer the user gave to ``title`` in this turn's message, if any."""
-    wanted = " ".join(title.split()).casefold()
+    wanted = _normalize_title(title)
     if not wanted:
         return None
     for asked, answer in parse_ask_user_answers(getattr(ctx, "turn_user_message", "") or ""):
-        if " ".join(asked.split()).casefold() == wanted:
+        if _normalize_title(asked) == wanted:
             return answer
     return None
 

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -188,23 +188,36 @@ def _answered_this_turn(ctx: ActionToolScope, title: str) -> str | None:
     return None
 
 
+def _already_answered_error(answered: dict[str, str]) -> str:
+    listed = "; ".join(f"{asked!r}: {answer!r}" for asked, answer in answered.items())
+    return (
+        f"The user already answered in this message: {listed}. "
+        "Use the answers and continue with the next step; do not ask again."
+    )
+
+
 def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
     questions, questions_error = _parse_questions(args.get("questions"))
     if questions_error is not None:
         return {"ok": False, "error": questions_error}
 
     title = strip_terminal_controls(str(args.get("title", ""))).strip()
-    for asked in [title, *[question.title for question in questions or ()]]:
-        answer = _answered_this_turn(ctx, asked)
-        if answer is not None:
-            return {
-                "ok": False,
-                "error": (
-                    f"The user already answered {asked!r} in this message: {answer!r}. "
-                    "Use that answer and continue with the next step; do not ask again."
-                ),
-            }
     options = _parse_options(args.get("options"))
+    multi_select = _parse_bool(args.get("multi_select"), default=False)
+
+    if questions:
+        # Answered questions leave the batch; the rest are still asked.
+        answered = {q.title: a for q in questions if (a := _answered_this_turn(ctx, q.title))}
+        questions = [q for q in questions if q.title not in answered]
+        if not questions:
+            return {"ok": False, "error": _already_answered_error(answered)}
+        if answered and len(questions) == 1:
+            # One question left after the drop: ask it as a single decision.
+            only = questions[0]
+            title, options, multi_select = only.title, list(only.options), only.multi_select
+            questions = None
+    elif (answer := _answered_this_turn(ctx, title)) is not None:
+        return {"ok": False, "error": _already_answered_error({title: answer})}
 
     if questions:
         if getattr(ctx.session, "ask_user_rounds", 0) >= _MAX_ASK_ROUNDS:
@@ -240,7 +253,6 @@ def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolScope) -> 
         option_error = _options_error(options)
         if option_error is not None:
             return {"ok": False, "error": option_error}
-        multi_select = _parse_bool(args.get("multi_select"), default=False)
         pending = PendingUserChoice(
             title=title,
             options=tuple(options),


### PR DESCRIPTION
Follow-up to #6158, which made `ask_user_choice` refuse a question the user
had already answered in the same message (demo B asked "When should it run?"
four times). Greptile flagged a P1: when a batched request mixed one answered
question with unanswered ones, the whole batch was refused and the open
questions were lost, so the model had to rebuild a smaller batch on its own.

The guard now works per question:

- answered questions leave the batch, the rest are queued as before;
- when one question remains, it is asked as a plain single decision so the
  two-question minimum for batches does not reject it;
- the tool refuses only when every question was already answered, and the
  error lists each question with its answer so the model can continue.
