### PR TITLE
fix(shell): reply rows keep a right margin; CI report paints like a reply

### DIFF
--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -160,12 +160,17 @@ class ToolProvider(Protocol):
         confirm_fn: ConfirmFn | None,
         is_tty: bool | None,
         resolved_integrations: dict[str, Any] | None = None,
+        turn_user_message: str = "",
     ) -> list[Any]:
         """Return the agent tools available for this turn.
 
         When ``resolved_integrations`` is supplied it is the turn's single
         resolved-integration view (from ``TurnSnapshot``); the provider builds
         tools from it instead of resolving again, so tools and the prompt agree.
+
+        ``turn_user_message`` is what the user sent this turn; tools that must
+        not repeat work the message already settled (an answered menu) read it
+        from the scope.
         """
 
     def tool_resources(self) -> dict[str, Any]:

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -896,6 +896,7 @@ def _run_action_turn(
             confirm_fn=args.confirm_fn,
             is_tty=args.is_tty,
             resolved_integrations=resolved_integrations,
+            turn_user_message=message,
         ),
         session,
         message,

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -158,8 +158,9 @@ class NullToolProvider:
         confirm_fn: ConfirmFn | None,
         is_tty: bool | None,
         resolved_integrations: dict[str, Any] | None = None,
+        turn_user_message: str = "",
     ) -> list[Any]:
-        _ = (confirm_fn, is_tty, resolved_integrations)
+        _ = (confirm_fn, is_tty, resolved_integrations, turn_user_message)
         return []
 
     def tool_resources(self) -> dict[str, Any]:

--- a/infrastructure/terminal/markdown.py
+++ b/infrastructure/terminal/markdown.py
@@ -1,25 +1,35 @@
 """Markdown renderable for terminal replies.
 
 Rich's stock markdown table has no column rules and cuts long cells with an
-ellipsis; a reply table here wraps every cell and draws the same minimal
-column rules as ``repl_table``.
+ellipsis; a reply table here wraps every cell and draws minimal column rules
+under a heavy header rule. Lives beside the theme so every tier that paints a
+reply (surfaces, integrations) renders markdown the same way.
 """
 
 from __future__ import annotations
 
 from typing import ClassVar
 
+from rich import box
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.markdown import Markdown, MarkdownElement, TableElement
+from rich.table import Table
 
-from surfaces.shared.terminal.components.rendering import repl_table
+#: Minimal borders shared by reply tables and the shell's own tables.
+REPLY_TABLE_BOX = box.MINIMAL_HEAVY_HEAD
 
 
 class ReplyTableElement(TableElement):
     """Markdown table with column rules and folded cells."""
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
-        table = repl_table(style="markdown.table.border")
+        table = Table(
+            box=REPLY_TABLE_BOX,
+            show_edge=False,
+            pad_edge=False,
+            title_justify="left",
+            style="markdown.table.border",
+        )
         if self.header is not None and self.header.row is not None:
             for column in self.header.row.cells:
                 heading = column.content.copy()
@@ -40,4 +50,4 @@ class ReplyMarkdown(Markdown):
     }
 
 
-__all__ = ["ReplyMarkdown", "ReplyTableElement"]
+__all__ = ["REPLY_TABLE_BOX", "ReplyMarkdown", "ReplyTableElement"]

--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -144,8 +144,8 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         name="purple",
         HIGHLIGHT="#CCB7F0",
         BRAND="#9885B3",
-        TEXT="#B6BAC2",
-        SECONDARY="#A6A6A6",
+        TEXT="#D0D0D0",
+        SECONDARY="#B4B4BC",
         DIM="#6E6E6E",
         WARNING="#D8B06F",
         ERROR="#CF6B63",
@@ -517,7 +517,7 @@ def _apply_theme(theme: CliTheme) -> None:
             "markdown.link": f"underline {theme.HIGHLIGHT}",
             "markdown.link_url": theme.DIM,
             "markdown.hr": theme.DIM,
-            "markdown.table.header": f"bold {theme.TEXT}",
+            "markdown.table.header": f"bold {theme.HIGHLIGHT}",
             "markdown.table.border": theme.DIM,
         }
     )

--- a/integrations/github/tools/ci_analytics/collector.py
+++ b/integrations/github/tools/ci_analytics/collector.py
@@ -382,14 +382,14 @@ def _annotate_reruns(
     annotated = [checked.get(run.run_id, run) for run in runs]
     if lookups.unavailable:
         notices.append(
-            f"Coverage notice: attempt history was unavailable for {lookups.unavailable} "
-            f"re-run{'s' if lookups.unavailable != 1 else ''}; they count as plain successes."
+            f"Re-run history could not be read for {lookups.unavailable} "
+            f"re-run{'s' if lookups.unavailable != 1 else ''}; counted as passes."
         )
     if lookups.unchecked:
         notices.append(
-            f"Coverage notice: attempt history was checked for the first "
-            f"{_MAX_ATTEMPT_LOOKUPS} requests only; {lookups.unchecked} re-run"
-            f"{'s' if lookups.unchecked != 1 else ''} count as plain successes."
+            f"Re-run history was checked for the first {_MAX_ATTEMPT_LOOKUPS} runs; "
+            f"{lookups.unchecked} later re-run{'s' if lookups.unchecked != 1 else ''} "
+            "counted as passes."
         )
     return annotated
 

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -7,14 +7,27 @@ from typing import Any
 
 from rich.padding import Padding
 
+import infrastructure.terminal.theme as ui_theme
 from infrastructure.terminal.markdown import ReplyMarkdown
-from infrastructure.terminal.theme import MARKDOWN_THEME, TEXT
 from integrations.github.tools.ci_analytics.models import (
     CiAnalyticsReport,
     FailureKind,
     Outage,
     PullRequestDelay,
 )
+
+#: Characters that would be read as markup when a GitHub-supplied name
+#: (workflow, branch, login, repository) is placed in the report text. A
+#: literal ``|`` in a workflow name would otherwise split a table row.
+_MARKUP_CHARACTERS = "\\|*_`[]"
+
+
+def _plain(value: str) -> str:
+    """Escape a GitHub-supplied name so markdown renders it literally."""
+    for character in _MARKUP_CHARACTERS:
+        value = value.replace(character, f"\\{character}")
+    return value
+
 
 _TOP_WORKFLOWS = 5
 _TOP_BLOCKED_PRS = 5
@@ -24,7 +37,8 @@ _TOP_DEVELOPERS = 3
 def render_markdown(report: CiAnalyticsReport, *, compact: bool = False) -> str:
     """Markdown report: key results lead. ``compact`` omits the counts appendix."""
     lines = [
-        f"**CI/CD reliability for {report.owner}/{report.repo}, last {report.window_days} days**",
+        f"**CI/CD reliability for {_plain(report.owner)}/{_plain(report.repo)}, "
+        f"last {report.window_days} days**",
         "",
     ]
     lines.extend(_key_results_markdown(report))
@@ -43,9 +57,13 @@ def render_report(console: Any, report: CiAnalyticsReport, *, compact: bool = Fa
 
 
 def _paint(console: Any, markdown: str) -> None:
-    """Paint markdown the way the shell paints a reply: same theme, two-cell indent."""
-    with console.use_theme(MARKDOWN_THEME):
-        console.print(Padding(ReplyMarkdown(markdown), (0, 0, 0, 2)), style=str(TEXT))
+    """Paint markdown the way the shell paints a reply: same theme, two-cell indent.
+
+    The theme is read here, not at import, so a report painted after ``/theme``
+    uses the palette the rest of the turn uses.
+    """
+    with console.use_theme(ui_theme.MARKDOWN_THEME):
+        console.print(Padding(ReplyMarkdown(markdown), (0, 0, 0, 2)), style=str(ui_theme.TEXT))
 
 
 def key_results(report: CiAnalyticsReport) -> list[tuple[str, str]]:
@@ -54,7 +72,7 @@ def key_results(report: CiAnalyticsReport) -> list[tuple[str, str]]:
     red_share = report.red_hours / window_hours
     results: list[tuple[str, str]] = [
         (
-            f"{report.default_branch} branch red",
+            f"{_plain(report.default_branch)} branch red",
             f"{_hours(report.red_hours)} of {report.window_days} days ({red_share:.1%}), "
             f"{len(report.outages)} {_plural(len(report.outages), 'breakage')}",
         )
@@ -84,7 +102,9 @@ def key_results(report: CiAnalyticsReport) -> list[tuple[str, str]]:
         default=None,
     )
     if slowest is not None:
-        results.append(("Slowest normal run", f"{slowest.workflow}, {slowest.normal_minutes:.0f}m"))
+        results.append(
+            ("Slowest normal run", f"{_plain(slowest.workflow)}, {slowest.normal_minutes:.0f}m")
+        )
     if report.blocked_working_minutes > 0:
         developers = report.developers_affected
         per_week = (
@@ -131,7 +151,7 @@ def comparison_figures(report: CiAnalyticsReport) -> dict[str, str]:
 
 def skip_lines(skipped: list[str]) -> list[str]:
     """Guest-visible reason a benchmark column is missing."""
-    return [f"Skipped {item}." for item in skipped]
+    return [f"Skipped {_plain(item)}." for item in skipped]
 
 
 def render_comparison(
@@ -163,7 +183,7 @@ def comparison_markdown(
         ]
         return "\n".join(lines)
     reports = [user, *peers]
-    labels = [f"{item.owner}/{item.repo}" for item in reports]
+    labels = [f"{_plain(item.owner)}/{_plain(item.repo)}" for item in reports]
     figures = [comparison_figures(item) for item in reports]
     header = "| Metric | " + " | ".join(labels) + " |"
     align = "| --- | " + " | ".join("---:" for _ in labels) + " |"
@@ -190,7 +210,7 @@ def _comparison_notes(peers: list[CiAnalyticsReport]) -> list[str]:
     notes: list[str] = []
     seen: set[str] = set()
     for peer in peers:
-        name = f"{peer.owner}/{peer.repo}"
+        name = f"{_plain(peer.owner)}/{_plain(peer.repo)}"
         if peer.red_hours == 0 and name not in seen:
             seen.add(name)
             if peer.branch_runs:
@@ -224,7 +244,7 @@ def _details_markdown(report: CiAnalyticsReport) -> list[str]:
         for summary in report.workflows[:_TOP_WORKFLOWS]:
             normal = "n/a" if summary.normal_minutes is None else f"{summary.normal_minutes:.0f}m"
             lines.append(
-                f"| {summary.workflow} | {summary.runs} | {summary.failures} |"
+                f"| {_plain(summary.workflow)} | {summary.runs} | {summary.failures} |"
                 f" {summary.reliability_failures} | {normal} |"
             )
     return lines
@@ -256,7 +276,7 @@ _BLOCKED_COLUMNS = (
 def _blocked_row(item: PullRequestDelay) -> tuple[str, ...]:
     return (
         f"#{item.pr_number}" if item.pr_number else "-",
-        item.author or "-",
+        _plain(item.author) if item.author else "-",
         _day(item.first_queued),
         _working(item.working_minutes),
         _minutes(item.delay_minutes),
@@ -303,7 +323,7 @@ def _roll_up_lines(report: CiAnalyticsReport) -> list[tuple[str, str]]:
 def _heaviest_developers(report: CiAnalyticsReport) -> str:
     waits = [w for w in report.developer_waits if w.working_minutes > 0][:_TOP_DEVELOPERS]
     return " · ".join(
-        f"{w.login} {_working(w.working_minutes_per_week)}/week over {w.pull_requests} "
+        f"{_plain(w.login)} {_working(w.working_minutes_per_week)}/week over {w.pull_requests} "
         f"{_plural(w.pull_requests, 'PR')}"
         for w in waits
     )
@@ -337,7 +357,7 @@ def headline(report: CiAnalyticsReport) -> str:
         )
     if report.red_hours > 0:
         return (
-            f"{report.default_branch} was red for {_hours(report.red_hours)} across "
+            f"{_plain(report.default_branch)} was red for {_hours(report.red_hours)} across "
             f"{len(report.outages)} {_plural(len(report.outages), 'breakage')} in the last "
             f"{report.window_days} days, with a mean recovery of "
             f"{_hours(report.mean_recovery_hours or 0.0)}."
@@ -389,7 +409,8 @@ def _default_branch(report: CiAnalyticsReport) -> list[str]:
         return []
     lines = [
         "",
-        f"**{report.default_branch} branch**: {report.branch_failures} of {report.branch_runs} "
+        f"**{_plain(report.default_branch)} branch**: {report.branch_failures} of "
+        f"{report.branch_runs} "
         f"push-triggered runs failed, red for {_hours(report.red_hours)} across "
         f"{len(report.outages)} {_plural(len(report.outages), 'breakage')}",
     ]
@@ -407,7 +428,9 @@ def _outage(outage: Outage, *, now: datetime) -> str:
     span = _hours(outage.duration_hours(now=now))
     when = outage.started_at.strftime("%Y-%m-%d %H:%M UTC")
     state = "ongoing" if outage.ongoing else "recovered"
-    return f"{outage.workflow}, {span} from {when} ({state}) {outage.first_failure_url}".strip()
+    return (
+        f"{_plain(outage.workflow)}, {span} from {when} ({state}) {outage.first_failure_url}"
+    ).strip()
 
 
 def _minutes(value: float) -> str:

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from rich.console import Group
 from rich.padding import Padding
-from rich.table import Table
-from rich.text import Text
 
+from infrastructure.terminal.markdown import ReplyMarkdown
+from infrastructure.terminal.theme import MARKDOWN_THEME, TEXT
 from integrations.github.tools.ci_analytics.models import (
     CiAnalyticsReport,
     FailureKind,
@@ -40,23 +39,13 @@ def render_markdown(report: CiAnalyticsReport, *, compact: bool = False) -> str:
 
 def render_report(console: Any, report: CiAnalyticsReport, *, compact: bool = False) -> None:
     """Paint the report: key results first. ``compact`` omits the counts appendix."""
-    parts: list[Any] = [
-        Text(
-            f"CI/CD reliability for {report.owner}/{report.repo}, last {report.window_days} days",
-            style="bold",
-        ),
-        Text(""),
-    ]
-    if report.executions:
-        parts.append(Text("Key results", style="bold"))
-        for label, value in key_results(report):
-            parts.append(_kpi_line(label, value))
-        if not compact:
-            parts.extend(_details_parts(report))
-    else:
-        parts.append(Text("No completed workflow runs were found in this window.", style="dim"))
-    parts.extend(Text(notice, style="dim") for notice in report.coverage_notices)
-    console.print(Padding(Group(*parts), (0, 0, 0, 2)))
+    _paint(console, render_markdown(report, compact=compact))
+
+
+def _paint(console: Any, markdown: str) -> None:
+    """Paint markdown the way the shell paints a reply: same theme, two-cell indent."""
+    with console.use_theme(MARKDOWN_THEME):
+        console.print(Padding(ReplyMarkdown(markdown), (0, 0, 0, 2)), style=str(TEXT))
 
 
 def key_results(report: CiAnalyticsReport) -> list[tuple[str, str]]:
@@ -153,38 +142,7 @@ def render_comparison(
     skipped: list[str] | None = None,
 ) -> None:
     """One table: the user's repo first, then the benchmark columns."""
-    missed = list(skipped or [])
-    if not peers:
-        parts: list[Any] = [
-            Text(""),
-            Text("Compared with well-known repositories", style="bold"),
-            Text(
-                "No benchmark columns — no same-day snapshot. "
-                "The report above is this repository only.",
-                style="dim",
-            ),
-        ]
-        parts.extend(Text(line, style="dim") for line in skip_lines(missed))
-        console.print(Padding(Group(*parts), (0, 0, 0, 2)))
-        return
-    reports = [user, *peers]
-    labels = [f"{item.owner}/{item.repo}" for item in reports]
-    figures = [comparison_figures(item) for item in reports]
-    table = Table(show_edge=False, pad_edge=False, box=None, header_style="dim")
-    table.add_column("Metric", justify="left")
-    for label in labels:
-        table.add_column(label, justify="right")
-    for metric in figures[0]:
-        table.add_row(metric, *[row.get(metric, "n/a") for row in figures])
-    peers_label = " and ".join(labels[1:]) if labels[1:] else "benchmarks"
-    parts = [
-        Text(""),
-        Text(f"Compared with {peers_label} over the same {user.window_days} days", style="bold"),
-        table,
-    ]
-    parts.extend(Text(notice, style="dim") for notice in _comparison_notes(peers))
-    parts.extend(Text(line, style="dim") for line in skip_lines(missed))
-    console.print(Padding(Group(*parts), (0, 0, 0, 2)))
+    _paint(console, "\n".join(["", comparison_markdown(user, peers, skipped=skipped)]))
 
 
 def comparison_markdown(
@@ -272,89 +230,6 @@ def _details_markdown(report: CiAnalyticsReport) -> list[str]:
     return lines
 
 
-def _details_parts(report: CiAnalyticsReport) -> list[Any]:
-    now = report.generated_at
-    parts: list[Any] = [
-        Text(""),
-        _kpi_line("GitHub Actions executions", str(report.executions)),
-        _kpi_line("PR-triggered workflow executions", str(report.pr_executions)),
-        _kpi_line("PR-triggered failed workflows", str(report.pr_failures)),
-        _kpi_line("Raw PR workflow failure rate", _rate(report.pr_failure_rate)),
-    ]
-    if report.pr_failures:
-        parts.extend(
-            [
-                Text(""),
-                Text(f"Failure classification (all {report.pr_failures} classified)", style="bold"),
-                _kpi_line(
-                    "CI reliability failures, passed later on the same commit",
-                    str(report.count(FailureKind.RELIABILITY)),
-                ),
-                _kpi_line(
-                    "Source-code failures, passed only after a code change",
-                    str(report.count(FailureKind.SOURCE)),
-                ),
-                _kpi_line("Not recovered in the window", str(report.count(FailureKind.UNRESOLVED))),
-                Text(""),
-                Text(_downtime_headline(report), style="bold"),
-            ]
-        )
-        parts.append(Text(f"Working hours: {report.working_hours_label}", style="dim"))
-        blocked = report.blocked_pr_delays
-        if blocked:
-            parts.append(Text(""))
-            parts.append(_blocked_table(blocked))
-            parts.append(Text(""))
-            parts.extend(_kpi_line(label, value) for label, value in _roll_up_lines(report))
-        if report.blocked_minutes_all > report.blocked_minutes:
-            parts.append(
-                _kpi_line(
-                    "Including PRs not merged yet",
-                    f"{_minutes(report.blocked_minutes_all)} wall clock",
-                )
-            )
-    if report.branch_runs:
-        parts.extend(
-            [
-                Text(""),
-                Text(
-                    f"{report.default_branch} branch: {report.branch_failures} of "
-                    f"{report.branch_runs} push-triggered runs failed, red for "
-                    f"{_hours(report.red_hours)} across {len(report.outages)} "
-                    f"{_plural(len(report.outages), 'breakage')}",
-                    style="bold",
-                ),
-            ]
-        )
-        if report.mean_recovery_hours is not None:
-            parts.append(_kpi_line("Mean time to recovery", _hours(report.mean_recovery_hours)))
-        if report.longest_outage is not None:
-            parts.append(_kpi_line("Longest breakage", _outage(report.longest_outage, now=now)))
-        for outage in report.ongoing_outages:
-            parts.append(_kpi_line("Still red now", _outage(outage, now=now), style="bold red"))
-    if report.workflows:
-        table = Table(show_edge=False, pad_edge=False, box=None, header_style="dim")
-        for column, justify in (
-            ("Workflow", "left"),
-            ("Runs", "right"),
-            ("Failed", "right"),
-            ("CI-caused", "right"),
-            ("Normal duration", "right"),
-        ):
-            table.add_column(column, justify=justify)  # type: ignore[arg-type]
-        for summary in report.workflows[:_TOP_WORKFLOWS]:
-            normal = "n/a" if summary.normal_minutes is None else f"{summary.normal_minutes:.0f}m"
-            table.add_row(
-                summary.workflow,
-                str(summary.runs),
-                str(summary.failures),
-                str(summary.reliability_failures),
-                normal,
-            )
-        parts.extend([Text(""), table])
-    return parts
-
-
 def _working(minutes: float) -> str:
     """Working time in hours, never calendar days: 215h, not 8.9d."""
     return f"{minutes:.0f}m" if minutes < 60 else f"{minutes / 60:.1f}h"
@@ -376,15 +251,6 @@ _BLOCKED_COLUMNS = (
     ("Blocked (working hours)", "right"),
     ("Wall clock", "right"),
 )
-
-
-def _blocked_table(blocked: tuple[PullRequestDelay, ...]) -> Table:
-    table = Table(show_edge=False, pad_edge=False, box=None, header_style="dim")
-    for column, justify in _BLOCKED_COLUMNS:
-        table.add_column(column, justify=justify)  # type: ignore[arg-type]
-    for item in blocked[:_TOP_BLOCKED_PRS]:
-        table.add_row(*_blocked_row(item))
-    return table
 
 
 def _blocked_row(item: PullRequestDelay) -> tuple[str, ...]:
@@ -482,12 +348,6 @@ def headline(report: CiAnalyticsReport) -> str:
             f"last {report.window_days} days, none of them caused by CI itself."
         )
     return f"No CI failures were found in the last {report.window_days} days."
-
-
-def _kpi_line(label: str, value: str, *, style: str = "bold") -> Text:
-    line = Text(f"{label}: ", style="dim")
-    line.append(value, style=style)
-    return line
 
 
 def _classification(report: CiAnalyticsReport) -> list[str]:

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -185,6 +185,7 @@ def _from_snapshot(
     console: Any,
     *,
     include_benchmarks: bool = False,
+    compact: bool = False,
 ) -> dict[str, Any]:
     """Answer from a same-day snapshot with the same renderer as a live analysis."""
     generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
@@ -204,6 +205,7 @@ def _from_snapshot(
             window,
             console,
             include_benchmarks=include_benchmarks,
+            compact=compact,
         )
         result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
         result["from_snapshot"] = snapshot.get("generated_at")
@@ -242,6 +244,8 @@ def report_text_from_snapshot(
 ) -> tuple[str, str]:
     """``(markdown, generated_at)`` from today's snapshot, or ``("", "")`` when none.
 
+    Compact: key results and the comparison, without the counts appendix.
+
     Reads saved snapshots only; never resolves a token or starts a live fetch.
     """
     now = datetime.now(UTC)
@@ -253,7 +257,7 @@ def report_text_from_snapshot(
     else:
         return "", ""
     result = _from_snapshot(
-        snapshot, owner, repo, window, None, include_benchmarks=include_benchmarks
+        snapshot, owner, repo, window, None, include_benchmarks=include_benchmarks, compact=True
     )
     if not result.get("success"):
         return "", ""
@@ -333,8 +337,13 @@ def _result(
     console: Any,
     *,
     include_benchmarks: bool = False,
+    compact: bool = False,
 ) -> dict[str, Any]:
-    """The tool's return for ``report``: painted in the shell, markdown elsewhere."""
+    """The tool's return for ``report``: painted in the shell, markdown elsewhere.
+
+    ``compact`` drops the counts appendix from the markdown; the shell painter
+    already drops it whenever the comparison table follows.
+    """
     summary = (
         f"{owner}/{repo}: {report.executions} runs in {window} days, "
         f"{report.pr_failures} of {report.pr_executions} PR runs failed, "
@@ -366,7 +375,7 @@ def _result(
         result = {
             **base,
             **report_payload(report),
-            "response_text": render_markdown(report, compact=include_benchmarks),
+            "response_text": render_markdown(report, compact=compact),
         }
     if include_benchmarks:
         result = _attach_benchmarks(result, report, window=window, console=console)

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -40,8 +40,8 @@ def _echo_answer(text: str) -> None:
     from rich.console import Console
 
     from infrastructure.safety.terminal_output import strip_terminal_controls
+    from infrastructure.terminal.markdown import ReplyMarkdown
     from infrastructure.terminal.theme import MARKDOWN_CODE_THEME, MARKDOWN_THEME
-    from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 
     console = Console()
     safe = strip_terminal_controls(text, keep_whitespace=True)

--- a/surfaces/interactive_shell/command_registry/session_cmds/resume_rendering.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/resume_rendering.py
@@ -34,9 +34,9 @@ def render_resumed_session_history(
     messages: list[tuple[str, str]],
 ) -> None:
     """Render prior session activity in REPL turn order, including slash commands."""
+    from infrastructure.terminal.markdown import ReplyMarkdown
     from infrastructure.terminal.theme import MARKDOWN_THEME
     from surfaces.interactive_shell.ui.streaming import render_response_header
-    from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 
     if not history and not messages:
         return

--- a/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
+++ b/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
@@ -22,6 +22,7 @@ from infrastructure.scheduling.scheduler.background_service import (
 )
 from infrastructure.scheduling.scheduler.local_delivery import get_loop_messages
 from infrastructure.scheduling.scheduler.loops import parse_loop_time
+from infrastructure.terminal.markdown import ReplyMarkdown
 from infrastructure.terminal.theme import WARNING
 from integrations.github import (
     DEFAULT_LOOP_TIME,
@@ -37,7 +38,6 @@ from surfaces.shared.terminal.components.choice_menu import (
     repl_choose_one,
 )
 from surfaces.shared.terminal.components.loaders import llm_loader
-from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 from tools.system.workspace_git_scan.render import snapshot_renderable
 from tools.system.workspace_git_scan.scan import RepoActivity, WorkspaceSnapshot, scan_workspace
 

--- a/surfaces/interactive_shell/ui/streaming/__init__.py
+++ b/surfaces/interactive_shell/ui/streaming/__init__.py
@@ -29,6 +29,10 @@ menus are not rendered until the harness flushes the canonical closer.
 
 from __future__ import annotations
 
+# Not part of __all__: exists so tests can substitute the renderer's Markdown
+# class via ``streaming.Markdown = ...`` — renderer._build_markdown_block reads
+# it back off this package rather than importing it directly.
+from infrastructure.terminal.markdown import ReplyMarkdown as Markdown  # noqa: F401
 from surfaces.interactive_shell.ui.streaming.closer import finish_deferred_closer
 from surfaces.interactive_shell.ui.streaming.console import StreamingConsole
 from surfaces.interactive_shell.ui.streaming.loop import (
@@ -44,11 +48,6 @@ from surfaces.interactive_shell.ui.streaming.renderer import (
     render_note_block,
     render_response_header,
 )
-
-# Not part of __all__: exists so tests can substitute the renderer's Markdown
-# class via ``streaming.Markdown = ...`` — renderer._build_markdown_block reads
-# it back off this package rather than importing it directly.
-from surfaces.shared.terminal.components.markdown import ReplyMarkdown as Markdown  # noqa: F401
 from surfaces.shared.terminal.components.token_format import (
     _CHARS_PER_TOKEN,  # noqa: F401  # not in __all__, but tests import it from this path directly
     format_token_count_short,

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -42,6 +42,7 @@ from surfaces.interactive_shell.ui.streaming.renderer import (
     _build_markdown_block,
     render_reply_block,
     reply_gutter,
+    reply_width,
 )
 
 # Throttle for the optional ``update_streaming_progress`` hook on the
@@ -244,6 +245,7 @@ def stream_to_console_state(
             console.print(
                 reply_gutter(markdown, lead=rendered_paragraphs == 0),
                 style=str(ui_theme.TEXT),
+                width=reply_width(console),
             )
         rendered_paragraphs += 1
 

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -142,6 +142,16 @@ _REPLY_MARKER = "Ω"
 # (Droid: one marker column, body text shares a left edge).
 _NOTE_MARKER = "·"
 _GUTTER_WIDTH = 2
+# Reply rows stop short of the last column: a row padded to the full terminal
+# width followed by a newline leaves a blank line and a shifted continuation
+# in Terminal.app. Cursor keeps a similar right margin.
+_RIGHT_MARGIN = 2
+_MIN_REPLY_WIDTH = 20
+
+
+def reply_width(console: Console) -> int:
+    """Render width for reply rows: the console width less the right margin."""
+    return max(_MIN_REPLY_WIDTH, console.width - _RIGHT_MARGIN)
 
 
 def render_note_block(console: Console, text: str) -> None:
@@ -165,6 +175,7 @@ def render_note_block(console: Console, text: str) -> None:
                 marker_style=ui_theme.reply_marker_style(),
             ),
             style=str(ui_theme.SECONDARY),
+            width=reply_width(console),
         )
 
 
@@ -207,6 +218,7 @@ def render_reply_block(console: Console, text: str, *, lead: bool = True) -> Non
         console.print(
             reply_gutter(_build_markdown_block(visible), lead=lead),
             style=str(ui_theme.TEXT),
+            width=reply_width(console),
         )
 
 

--- a/surfaces/shared/terminal/components/__init__.py
+++ b/surfaces/shared/terminal/components/__init__.py
@@ -7,7 +7,6 @@ from surfaces.shared.terminal.components.choice_menu import (
     repl_tty_interactive,
 )
 from surfaces.shared.terminal.components.loaders import DEFAULT_LOADER_LABEL, llm_loader
-from surfaces.shared.terminal.components.markdown import ReplyMarkdown
 from surfaces.shared.terminal.components.rendering import (
     print_repl_json,
     print_repl_table,
@@ -26,7 +25,6 @@ from surfaces.shared.terminal.components.token_format import (
 
 __all__ = [
     "DEFAULT_LOADER_LABEL",
-    "ReplyMarkdown",
     "_CHARS_PER_TOKEN",
     "format_repl_duration",
     "format_repl_timestamp",

--- a/surfaces/shared/terminal/components/rendering.py
+++ b/surfaces/shared/terminal/components/rendering.py
@@ -15,11 +15,12 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, Literal, cast
 
-from rich import box
 from rich.console import Console
 from rich.segment import Segment
 from rich.table import Table
 from rich.text import Text
+
+from infrastructure.terminal.markdown import REPLY_TABLE_BOX
 
 _REPL_OUTPUT_PREPARED = ContextVar("_REPL_OUTPUT_PREPARED", default=False)
 
@@ -286,7 +287,7 @@ def repl_clear_screen() -> None:
 def repl_table(**kwargs: Any) -> Table:
     """Minimal outer borders — closer to Claude Code than full ASCII grids."""
     opts: dict[str, Any] = {
-        "box": box.MINIMAL_HEAVY_HEAD,
+        "box": REPLY_TABLE_BOX,
         "show_edge": False,
         "pad_edge": False,
         "title_justify": "left",

--- a/surfaces/shared/terminal/output/live_display.py
+++ b/surfaces/shared/terminal/output/live_display.py
@@ -250,7 +250,7 @@ class _EventLogDisplay:
     def print_above(self, text: str) -> None:
         if not text.strip():
             return
-        from surfaces.shared.terminal.components.markdown import ReplyMarkdown
+        from infrastructure.terminal.markdown import ReplyMarkdown
 
         from infrastructure.terminal.theme import MARKDOWN_THEME
 

--- a/surfaces/shared/terminal/output/repl_display.py
+++ b/surfaces/shared/terminal/output/repl_display.py
@@ -158,7 +158,7 @@ class _ReplEventLogDisplay:
     def print_above(self, text: str) -> None:
         if not text.strip():
             return
-        from surfaces.shared.terminal.components.markdown import ReplyMarkdown
+        from infrastructure.terminal.markdown import ReplyMarkdown
 
         from infrastructure.terminal.theme import MARKDOWN_THEME
 

--- a/tests/core/agent_harness/test_action_turn_outcome.py
+++ b/tests/core/agent_harness/test_action_turn_outcome.py
@@ -110,3 +110,37 @@ def test_iteration_cap_is_preserved_on_turn_result() -> None:
     assert "repeated tool calls produced no new result" in result.response_text
     assert _console_text(harness).count("repeated tool calls produced no new result") == 1
     assert harness.llm.invocations == 5
+
+
+def test_a_menu_answered_this_turn_is_not_asked_again_through_the_real_turn() -> None:
+    """The scope must carry the turn's message, or the answered-menu guard is blind.
+
+    The guard lives in ``ask_user_choice`` but reads ``turn_user_message`` off
+    the tool scope. The driver built that scope without the message, so the
+    guard never fired in the shell while its own unit tests passed.
+    """
+    # Arrange: this turn's message is the answer; the model asks the same thing.
+    title = "When should it run?"
+    answer_turn = f"1. {title}\nWeekdays at 08:00 (recommended)"
+    harness = ActionExecutionHarness(
+        llm=FakeActionLLM(
+            [
+                tool_response(
+                    "ask_user_choice",
+                    {"title": title, "options": ["Weekdays at 08:00 (recommended)", "Every day"]},
+                ),
+                no_tool_response("Scheduling it for weekdays."),
+            ]
+        )
+    )
+    session = Session()
+
+    # Act: a TTY turn, so a menu would really queue if the guard did not refuse.
+    result = run_action_tool_turn(
+        answer_turn, session, harness.console, llm_factory=harness.llm_factory, is_tty=True
+    )
+
+    # Assert: the call ran and was refused, so no menu was queued for a
+    # question this turn's message already answered.
+    assert (result.executed_count, result.executed_success_count) == (1, 0)
+    assert session.pending_user_choice is None

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -176,6 +177,9 @@ def test_a_saved_report_round_trips_and_paints_like_a_live_one(tmp_path: Path, m
 
         def print(self, *args: Any, **_kwargs: Any) -> None:
             painted.append(args[0] if args else "")
+
+        def use_theme(self, _theme: Any) -> contextlib.AbstractContextManager[None]:
+            return contextlib.nullcontext()
 
     monkeypatch.setattr(tool_module, "_console", lambda _context: _Console())
 

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -1309,3 +1309,24 @@ class TestDeferWantMeToCloser:
         )
         assert paint.deferred_closer is True
         assert buf.getvalue() == ""
+
+
+def test_reply_rows_stop_short_of_the_last_column() -> None:
+    # Arrange: a wide terminal and a reply that wraps once at that width.
+    width = 210
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=True, width=width, highlight=False)
+    text = (
+        "Tracer-Cloud/opensre: 8151 runs in 30 days, 1174 of 5727 PR runs failed, 333 "
+        "CI-caused, 8.9d of developer downtime (43.4d wall clock) on merged PRs. Figures "
+        "as of 2026-09-09 17:01 UTC, from the saved snapshot."
+    )
+
+    # Act
+    publish_full_response(console, text)
+
+    # Assert: no rendered row reaches the terminal width, so the terminal never
+    # auto-wraps a padded row before the newline.
+    rows = [re.sub(r"\x1b\[[0-9;]*m", "", row) for row in buf.getvalue().split("\n")]
+    assert rows and max(len(row) for row in rows) < width
+    assert "snapshot." in "".join(rows)

--- a/tests/shared/terminal/test_reply_markdown.py
+++ b/tests/shared/terminal/test_reply_markdown.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.text import Text
 
 import infrastructure.terminal.theme as ui_theme
-from surfaces.shared.terminal.components.markdown import ReplyMarkdown
+from infrastructure.terminal.markdown import ReplyMarkdown
 
 _TABLE = "| File | Jobs |\n| --- | --- |\n| .github/workflows/celebrate-merged-pr.yml | 1 |\n"
 

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -342,3 +342,24 @@ def test_tool_uses_the_loops_seven_day_snapshot_when_no_thirty_day_one_exists(
     assert result["response_text"].index("Key results") < result["response_text"].index(
         "Scheduled:"
     )
+
+
+def test_analyze_markdown_keeps_details_when_benchmarks_are_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange: a non-terminal caller asks for the report with benchmarks.
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    _write_report_snapshot(tmp_path, window_days=30)
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+
+    # Act
+    result = tool_module.analyze_github_ci_reliability(
+        owner="acme", repo="app", days=30, include_benchmarks=True, context=None
+    )
+
+    # Assert: benchmarks add a section; they do not remove the analysis details.
+    text = result["response_text"]
+    assert "Key results" in text
+    assert "Compared with" in text
+    assert "Workflow" in text or "Failure classification" in text

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -1182,3 +1184,80 @@ class TestAnalyzeGithubCiReliabilityContract(BaseToolContract):
 
     def test_registered_name(self) -> None:
         assert self._tool().name == TOOL_NAME
+
+
+def test_a_pipe_in_a_workflow_name_does_not_shift_the_rendered_row() -> None:
+    """GitHub names are data, not markup.
+
+    A workflow literally named ``Build | Deploy`` used to split the table row,
+    moving ``Deploy`` into the Runs column and dropping the failure count.
+    """
+    # Arrange
+    from rich.console import Console
+
+    from integrations.github.tools.ci_analytics.render import render_report
+
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[_run(9, event="push", branch="main")],
+        pr_runs=[_run(1, workflow="Build | Deploy", conclusion="failure")],
+        merged_prs=_merged("A"),
+        now=_T0 + timedelta(days=1),
+    )
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=100)
+
+    # Act
+    render_report(console, report)
+
+    # Assert: the name survives whole and its counts stay in their columns.
+    row = next(line for line in buf.getvalue().splitlines() if "Build | Deploy" in line)
+    assert row.split("│")[1].strip() == "1"
+
+
+def test_the_painted_report_follows_a_theme_change() -> None:
+    """The painter reads the theme when it paints, not when the module loads."""
+    # Arrange
+    import infrastructure.terminal.theme as ui_theme
+    from integrations.github.tools.ci_analytics.render import render_report
+
+    themes: list[Any] = []
+
+    class _Console:
+        is_terminal = True
+
+        def use_theme(self, theme: Any) -> contextlib.AbstractContextManager[None]:
+            themes.append(theme)
+            return contextlib.nullcontext()
+
+        def print(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[_run(9, event="push", branch="main")],
+        pr_runs=[_run(1, conclusion="failure")],
+        merged_prs=_merged("A"),
+        now=_T0 + timedelta(days=1),
+    )
+
+    # Act: paint, switch theme, paint again.
+    original = ui_theme.get_active_theme().name
+    try:
+        ui_theme.set_active_theme("blue")
+        render_report(_Console(), report)
+        ui_theme.set_active_theme("green")
+        expected = ui_theme.MARKDOWN_THEME
+        render_report(_Console(), report)
+    finally:
+        ui_theme.set_active_theme(original)
+
+    # Assert: the second paint used the theme built for the new palette.
+    assert themes[1] is expected
+    assert themes[0] is not themes[1]

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -930,7 +930,7 @@ def test_collect_runs_reports_unavailable_attempt_history_instead_of_hiding_it()
 
     assert collected.pr_runs[0].retried_to_green is False
     assert any(
-        "attempt history was unavailable for 1 re-run" in n for n in collected.coverage_notices
+        "Re-run history could not be read for 1 re-run" in n for n in collected.coverage_notices
     )
 
 
@@ -952,7 +952,7 @@ def test_collect_runs_caps_attempt_lookups_and_says_so(monkeypatch: pytest.Monke
     collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
 
     assert sum(run.retried_to_green for run in collected.pr_runs) == 1
-    assert any("1 re-run count as plain successes" in n for n in collected.coverage_notices)
+    assert any("1 later re-run counted as passes" in n for n in collected.coverage_notices)
 
 
 def _iso(value: datetime) -> str:


### PR DESCRIPTION
Right margin. At 210 columns the closing reply showed a blank line inside a
wrapped paragraph and a one-space continuation. Reproduced: the reply row was
padded to exactly the terminal width, and a full-width row followed by a
newline makes Terminal.app wrap before the newline. Measured against the
other shells at 120 columns, Cursor wraps prose 7 columns short, Droid 1,
Claude Code 0; opensre wrapped at 113 in the streaming path but at the full
width in the closing path. Reply, note and streaming rows now render two
columns short of the console width (`reply_width` in the streaming renderer),
pinned by a 210-column test.

One look for the CI report. The CI analytics tool painted its report with its
own Rich objects: dim labels, dim table header, no column rules, a formula
footer. That is why the demo report looked like a second application next to
the Ω reply, and why the theme change alone did not remove the grey. The
painter now prints the tool's markdown twin through `ReplyMarkdown`, which
moved from surfaces to `infrastructure/terminal/markdown.py` so integrations
can use it (one canonical path; the surfaces module is removed; `repl_table`
shares the box constant). Dead painter helpers are gone. Painted output now
has the reply's body colour, bold headings, accent table header, dim rules
and the same two-cell indent as the Ω gutter. Coverage notices are reworded
in plain language.

Greptile P1 on #6159 (benchmarks truncated analysis details): the compact
markdown switch is separate from `include_benchmarks`. Only the schedule
closing asks for compact; a non-terminal caller asking for benchmarks keeps
the full analysis (test added).

Theme. The purple palette set body text to a 71% grey, so every reply element
was a grey shade with bold as the only structure. Purple body text is now
#D0D0D0, the same as the blue theme and Droid's body, secondary #B4B4BC, and
markdown table headers use the bold accent.