### PR TITLE
fix(shell): drop a painted tool's log row and its restated closing

### DIFF
--- a/core/agent_harness/turns/display_text.py
+++ b/core/agent_harness/turns/display_text.py
@@ -22,10 +22,20 @@ from infrastructure.terminal.peek import (
 from infrastructure.text import is_data_blob
 
 # Tools whose result the host already rendered to the console; their payload is
-# not re-shown in the transcript.
+# not re-shown in the transcript. A tool outside this set says so per call with
+# ``rendered_in_shell`` in its payload (it paints only on a terminal surface).
 _HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset(
     {"ask_user_choice", "skill_view", "update_plan"}
 )
+
+
+def _host_rendered(tool_call: ToolCall, tool_result: Any) -> bool:
+    """True when the console already shows this result, so it is not re-shown."""
+    if tool_call.name in _HOST_RENDERED_TOOL_NAMES:
+        return True
+    details = getattr(tool_result, "details", None)
+    return isinstance(details, dict) and details.get("rendered_in_shell") is True
+
 
 _EXPAND_MARKER_RE = re.compile(r"^… \d+ more, Ctrl\+O to view$")
 _PLAN_SNAPSHOT_RE = re.compile(r"Plan\s*[·.]\s*\d+\s*/\s*\d+(?:\s*[✓●○][^✓●○\n]*)*")
@@ -110,7 +120,7 @@ def _visible_stdout(stdout: str) -> str:
 
 def format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
     """Build a user-visible summary for one non-self-recording tool result."""
-    if tool_call.name in _HOST_RENDERED_TOOL_NAMES and not getattr(tool_result, "is_error", False):
+    if _host_rendered(tool_call, tool_result) and not getattr(tool_result, "is_error", False):
         return ""
     preferred_response = preferred_tool_response_text(tool_result)
     if preferred_response:

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -209,8 +209,6 @@ def _from_snapshot(
         )
         result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
         result["from_snapshot"] = snapshot.get("generated_at")
-        if console is not None:
-            result["response_text"] = result["summary"]
         return result
     # An older snapshot without the report object: the figures only.
     figures = {
@@ -365,12 +363,10 @@ def _result(
         "rendered_in_shell": console is not None,
     }
     if console is not None:
+        # The painted report is the turn's output; a reply restating its figures
+        # would print them twice.
         render_report(console, report, compact=include_benchmarks)
-        result = {
-            **base,
-            "coverage_notices": list(report.coverage_notices),
-            "response_text": summary,
-        }
+        result = {**base, "coverage_notices": list(report.coverage_notices)}
     else:
         result = {
             **base,

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -275,6 +275,16 @@ class TerminalSession:
                 entry.detail = f"{entry.detail}\n{result}" if entry.detail else result
                 return
 
+    def drop_action_log(self, call_id: str) -> None:
+        """Forget the buffered call ``call_id`` (if present).
+
+        A tool that painted its own output needs no row: the buffer flushes at
+        the end of the turn, so its label would land under that output.
+        """
+        self.action_log_entries = [
+            entry for entry in self.action_log_entries if entry.call_id != call_id
+        ]
+
     def has_action_log(self) -> bool:
         """True when at least one action is buffered for the current turn."""
         return bool(self.action_log_entries)

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -555,9 +555,16 @@ class ActionRenderObserver:
     def _render_tool_result(self, data: dict[str, Any]) -> None:
         """Fold the user-facing result under its buffered call (Ctrl+O detail).
 
-        JSON blobs stay hidden — the closing reply summarizes those.
+        JSON blobs stay hidden — the closing reply summarizes those. A tool that
+        painted its own output during execution loses its buffered row: the
+        buffer flushes at the end of the turn, so the row would print under the
+        output it labels.
         """
-        preview = _tool_result_preview(data.get("output"))
+        output = data.get("output")
+        if isinstance(output, dict) and output.get("rendered_in_shell") is True:
+            self.session.terminal.drop_action_log(_tool_event_id(data))
+            return
+        preview = _tool_result_preview(output)
         if not preview:
             return
         rows = preview.splitlines() or [preview]

--- a/tests/core/agent_harness/test_action_turn_outcome.py
+++ b/tests/core/agent_harness/test_action_turn_outcome.py
@@ -144,3 +144,27 @@ def test_a_menu_answered_this_turn_is_not_asked_again_through_the_real_turn() ->
     # question this turn's message already answered.
     assert (result.executed_count, result.executed_success_count) == (1, 0)
     assert session.pending_user_choice is None
+
+
+def test_a_painted_tool_result_is_not_restated_in_the_closing() -> None:
+    """A report painted during execution must not be printed a second time."""
+    # Arrange: a tool result that says the console already shows it.
+    from core.agent_harness.turns.display_text import format_generic_tool_payload
+    from core.llm.types import ToolCall
+
+    class _Result:
+        details = {
+            "rendered_in_shell": True,
+            "summary": "acme/app: 8151 runs in 30 days, 1174 of 5727 PR runs failed.",
+            "response_text": "acme/app: 8151 runs in 30 days.",
+        }
+        content = ""
+        is_error = False
+
+    call = ToolCall(id="1", name="analyze_github_ci_reliability", input={})
+
+    # Act
+    shown = format_generic_tool_payload(call, _Result())
+
+    # Assert
+    assert shown == ""

--- a/tests/interactive_shell/ui/test_action_log.py
+++ b/tests/interactive_shell/ui/test_action_log.py
@@ -231,3 +231,25 @@ def test_a_window_too_narrow_for_any_box_prints_plain_rows(monkeypatch) -> None:
     plain = [Text.from_ansi(line).plain for line in buffer.getvalue().splitlines() if line.strip()]
     assert not any(row[0] in "╭│╰" for row in plain)
     assert len(plain) == 2 and all(len(row) <= 13 for row in plain), plain
+
+
+def test_a_tool_that_painted_its_own_output_leaves_no_row() -> None:
+    """The buffer flushes at the end of the turn.
+
+    A tool that painted during execution would get its label printed under the
+    output it labels, so the row is dropped when the result says so.
+    """
+    # Arrange: two calls buffered; the second painted its own report.
+    session = Session()
+    session.terminal.push_action_log(
+        ActionLogEntry(call_id="a", kind="GitHub CLI", concise="gh run list", detail="")
+    )
+    session.terminal.push_action_log(
+        ActionLogEntry(call_id="b", kind="Analyze CI reliability", concise="", detail="")
+    )
+
+    # Act
+    session.terminal.drop_action_log("b")
+
+    # Assert
+    assert [entry.call_id for entry in session.terminal.take_action_log()] == ["a"]


### PR DESCRIPTION
The tool row printed under its own output. Tool rows are buffered during a
turn and flushed once at the end so consecutive calls can group into a box.
The analytics tool paints its report while it runs, so the row
"analyze github ci reliability" always arrived after the tables it names.
Droid and Cursor put the label first.

The figures printed twice. On a terminal the tool returned its summary
sentence as the turn's reply, so "8151 runs in 30 days, 1174 of 5727 PR runs
failed, 333 CI-caused" appeared again under a report whose key results had
just shown those numbers. The skill already tells the model not to restate
figures; this duplicate came from the tool, not the model.

The result payload already carried `rendered_in_shell`, true only when the
tool painted to a terminal. Two consumers now honour it:

- the shell's observer withdraws the buffered row for that call, using a new
  `TerminalSession.drop_action_log`;
- `format_generic_tool_payload` treats such a result as already shown, so
  nothing re-prints it. This guard is needed on its own: without it the
  formatter falls through to the payload's `summary` field and prints the
  figures anyway.

The analytics tool's painted path stops returning a reply text, in both the
live and the saved-snapshot branch. The report is the output.

A name list was the alternative and was rejected: it would have put a GitHub
tool name inside both the shell surface and core, and it would have silently
stopped working if the tool were renamed. A tool now says for itself that it
painted.