### PR TITLE
fix(demo): the CI comparison is always built; the model chooses brevity instead

### DIFF
--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -127,7 +127,7 @@ the answer.
 ### 3. Analyze CI/CD reliability
 
 Call
-`analyze_github_ci_reliability(owner="<owner>", repo="<repo>", include_benchmarks=true)`
+`analyze_github_ci_reliability(owner="<owner>", repo="<repo>", compact=true)`
 for the chosen repository. The tool paints the report (key results first)
 and the comparison table itself. Do not restate figures, do not output
 `headline`, and do not call the tool again for benchmarks. A peer without

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
@@ -1,8 +1,8 @@
 # Comparing a repository's CI/CD metrics to public benchmarks
 
 Phase 2 of the analytics demo (metric definitions in `metrics.md`): the
-analyze call with `include_benchmarks=true` already paints one comparison
-table next to apache/airflow and fastapi/fastapi over the same window. Load
+analyze call already paints one comparison table next to apache/airflow and
+fastapi/fastapi over the same window. Load
 this reference only when the user asks what a compared figure means.
 
 ## Rules
@@ -23,7 +23,7 @@ this reference only when the user asks what a compared figure means.
 
 ## Default benchmarks
 
-The tool always uses these two when `include_benchmarks` is true:
+The tool always uses these two, from same-day snapshots:
 
 | Repository | Why it works as a benchmark |
 |------------|-----------------------------|

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -229,13 +229,7 @@ def _has_preferred_tool_response_text(result: Any) -> bool:
 
 
 def _painted_results_only(result: Any) -> bool:
-    """True when every executed tool painted its own output to the console.
-
-    Same hazard as a self-recording tool: the closing is written over output
-    the model did not see, so it restates the figures already on screen or
-    contradicts them (claiming a comparison was skipped while its table sits
-    above the reply).
-    """
+    """True when every executed tool painted its own output to the console."""
     results = list(getattr(result, "tool_results", []))
     if not results:
         return False
@@ -244,6 +238,37 @@ def _painted_results_only(result: Any) -> bool:
         and tool_result.details.get("rendered_in_shell") is True
         for _tool_call, tool_result in results
     )
+
+
+#: How many of the painted figures a closing must repeat to count as a restatement.
+_RESTATED_FIGURE_COUNT = 3
+_FIGURE_RE = re.compile(r"\d+(?:\.\d+)?")
+
+
+def _painted_figures(result: Any) -> set[str]:
+    """Numbers the painted report already put on screen, from its key results."""
+    figures: set[str] = set()
+    for _tool_call, tool_result in getattr(result, "tool_results", []):
+        details = getattr(tool_result, "details", None)
+        if not isinstance(details, dict) or details.get("rendered_in_shell") is not True:
+            continue
+        for row in details.get("key_results") or []:
+            if isinstance(row, dict):
+                figures.update(_FIGURE_RE.findall(str(row.get("value", ""))))
+    return figures
+
+
+def _restates_painted_figures(result: Any, final_text: str) -> bool:
+    """True when the closing repeats figures the painted report already showed.
+
+    Only the duplicate is dropped. A closing that interprets the report, warns
+    about something, or offers a next step carries information the table does
+    not, so it survives.
+    """
+    painted = _painted_figures(result)
+    if not painted:
+        return False
+    return len(painted & set(_FIGURE_RE.findall(final_text))) >= _RESTATED_FIGURE_COUNT
 
 
 def _self_recording_tools_only(result: Any) -> bool:
@@ -715,7 +740,11 @@ def _compose_response(
         (waiting_for_choice and _is_redundant_choice_invitation(result, final_text))
         or _is_choice_acknowledgement(final_text, selected_choice)
         or prefer_tool_response_text
-        or (_painted_results_only(result) and not _asks_the_user(final_text))
+        or (
+            _painted_results_only(result)
+            and _restates_painted_figures(result, final_text)
+            and not _asks_the_user(final_text)
+        )
         or (
             _self_recording_tools_only(result)
             and not _grounded_output_tools_only(result)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -228,6 +228,24 @@ def _has_preferred_tool_response_text(result: Any) -> bool:
     )
 
 
+def _painted_results_only(result: Any) -> bool:
+    """True when every executed tool painted its own output to the console.
+
+    Same hazard as a self-recording tool: the closing is written over output
+    the model did not see, so it restates the figures already on screen or
+    contradicts them (claiming a comparison was skipped while its table sits
+    above the reply).
+    """
+    results = list(getattr(result, "tool_results", []))
+    if not results:
+        return False
+    return all(
+        isinstance(getattr(tool_result, "details", None), dict)
+        and tool_result.details.get("rendered_in_shell") is True
+        for _tool_call, tool_result in results
+    )
+
+
 def _self_recording_tools_only(result: Any) -> bool:
     """True when every executed tool already printed to the console.
 
@@ -697,6 +715,7 @@ def _compose_response(
         (waiting_for_choice and _is_redundant_choice_invitation(result, final_text))
         or _is_choice_acknowledgement(final_text, selected_choice)
         or prefer_tool_response_text
+        or (_painted_results_only(result) and not _asks_the_user(final_text))
         or (
             _self_recording_tools_only(result)
             and not _grounded_output_tools_only(result)

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -162,7 +162,10 @@ def render_comparison(
     skipped: list[str] | None = None,
 ) -> None:
     """One table: the user's repo first, then the benchmark columns."""
-    _paint(console, "\n".join(["", comparison_markdown(user, peers, skipped=skipped)]))
+    # A markdown leading newline is dropped, so the heading would sit on the
+    # report's last bullet; separate the two sections here.
+    console.print()
+    _paint(console, comparison_markdown(user, peers, skipped=skipped))
 
 
 def comparison_markdown(

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -184,7 +184,7 @@ def _from_snapshot(
     window: int,
     console: Any,
     *,
-    include_benchmarks: bool = False,
+    include_benchmarks: bool = True,
     compact: bool = False,
 ) -> dict[str, Any]:
     """Answer from a same-day snapshot with the same renderer as a live analysis."""
@@ -334,13 +334,12 @@ def _result(
     window: int,
     console: Any,
     *,
-    include_benchmarks: bool = False,
+    include_benchmarks: bool = True,
     compact: bool = False,
 ) -> dict[str, Any]:
     """The tool's return for ``report``: painted in the shell, markdown elsewhere.
 
-    ``compact`` drops the counts appendix from the markdown; the shell painter
-    already drops it whenever the comparison table follows.
+    ``compact`` drops the counts appendix from both forms.
     """
     summary = (
         f"{owner}/{repo}: {report.executions} runs in {window} days, "
@@ -365,7 +364,7 @@ def _result(
     if console is not None:
         # The painted report is the turn's output; a reply restating its figures
         # would print them twice.
-        render_report(console, report, compact=include_benchmarks)
+        render_report(console, report, compact=compact)
         result = {**base, "coverage_notices": list(report.coverage_notices)}
     else:
         result = {
@@ -412,7 +411,7 @@ def _result(
         "headline": "One sentence naming the biggest cost (already painted; do not repeat)",
         "key_results": "The five takeaway rows, red time first, even when the shell painted the report",
         "response_text": "The rendered report, or a one-line summary when the shell painted it",
-        "benchmarks": "When include_benchmarks is true: Airflow and FastAPI rows from the same window",
+        "benchmarks": "Airflow and FastAPI rows from the same window, when a snapshot exists",
     },
     surfaces=(ToolSurface.CHAT, ToolSurface.ACTION),
     side_effect_level=SideEffectLevel.READ_ONLY,
@@ -439,11 +438,12 @@ def _result(
                 "type": "string",
                 "description": "Local checkout used to detect owner/repo when not given.",
             },
-            "include_benchmarks": {
+            "compact": {
                 "type": "boolean",
                 "description": (
-                    "Also compare this repository with apache/airflow and fastapi/fastapi "
-                    "over the same window. Default false."
+                    "Key results and the comparison only, without the counts appendix "
+                    "(executions, failure classification, blocked time, workflows). "
+                    "Use for a first-look report. Default false."
                 ),
             },
             "github_token": {"type": "string"},
@@ -460,7 +460,7 @@ def analyze_github_ci_reliability(
     repo: str | None = None,
     days: int | None = None,
     workspace: str | None = None,
-    include_benchmarks: bool = False,
+    compact: bool = False,
     github_token: str | None = None,
     context: Any = None,
     **_kwargs: Any,
@@ -470,11 +470,13 @@ def analyze_github_ci_reliability(
     In the interactive shell the report is painted straight to the console so
     every figure the user sees is the computed one; the returned
     ``response_text`` then only summarizes. Other surfaces get the markdown.
-    When ``include_benchmarks`` is true the same call also paints one comparison
-    table against apache/airflow and fastapi/fastapi (snapshots first).
+    The same call also paints one comparison table against apache/airflow and
+    fastapi/fastapi, built from same-day snapshots only — never a live fetch. The
+    comparison is not the model's choice to make; ``compact`` drops the counts
+    appendix.
     """
     window = min(max(int(days or _DEFAULT_WINDOW_DAYS), _MIN_WINDOW_DAYS), _MAX_WINDOW_DAYS)
-    compare = _flag(include_benchmarks)
+    brief = _flag(compact)
     repo_owner = (owner or "").strip()
     repo_name = (repo or "").strip().removesuffix(".git")
     if not repo_owner or not repo_name:
@@ -500,7 +502,7 @@ def analyze_github_ci_reliability(
             repo_name,
             window,
             console,
-            include_benchmarks=compare,
+            compact=brief,
         )
     if not token:
         message = (
@@ -567,7 +569,7 @@ def analyze_github_ci_reliability(
         repo_name,
         window,
         console,
-        include_benchmarks=compare,
+        compact=brief,
     )
 
 

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -387,7 +387,10 @@ def _result(
         "CI-caused (same commit passed later) versus source-code, developer time "
         "blocked by unreliable CI on merged PRs, and default-branch red time. "
         "Read-only. A same-day snapshot answers without a token; a live GitHub "
-        "read needs a token."
+        "read needs a token. Every report also carries a comparison with "
+        "apache/airflow and fastapi/fastapi built from same-day snapshots: it "
+        "costs no extra request and cannot be turned off, so never offer to skip "
+        "it. The report is painted on screen — do not restate its figures."
     ),
     use_cases=[
         "Analyze a repository's CI/CD performance and reliability",

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -186,55 +186,35 @@ def _from_snapshot(
     *,
     include_benchmarks: bool = True,
     compact: bool = False,
-) -> dict[str, Any]:
-    """Answer from a same-day snapshot with the same renderer as a live analysis."""
-    generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
+) -> dict[str, Any] | None:
+    """Answer from a same-day snapshot, or ``None`` when it holds no usable report.
+
+    A snapshot written before the report object was saved cannot produce the
+    comparison, so it counts as a miss and the caller reads GitHub instead.
+    """
     saved = snapshot.get("report")
     report = report_from_dict(saved) if isinstance(saved, dict) else None
+    if report is None:
+        return None
+    generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
     if console is not None:
         console.print(
             f"  [dim]Using the CI reliability snapshot of {escape(f'{owner}/{repo}')} "
             f"from {generated} UTC (same {window}-day window).[/dim]"
         )
         console.print()
-    if report is not None:
-        result = _result(
-            report,
-            owner,
-            repo,
-            window,
-            console,
-            include_benchmarks=include_benchmarks,
-            compact=compact,
-        )
-        result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
-        result["from_snapshot"] = snapshot.get("generated_at")
-        return result
-    # An older snapshot without the report object: the figures only.
-    figures = {
-        key: value
-        for key, value in snapshot.items()
-        if key not in {"generated_at", "headline", "snapshot_path", "window_days", "markdown"}
-    }
-    summary = (
-        f"{owner}/{repo}: {snapshot.get('executions')} runs in {window} days, "
-        f"{snapshot.get('pr_failures')} of {snapshot.get('pr_executions')} PR runs failed, "
-        f"{snapshot.get('reliability_failures')} CI-caused. "
-        f"Figures as of {generated} UTC, from the saved snapshot."
+    result = _result(
+        report,
+        owner,
+        repo,
+        window,
+        console,
+        include_benchmarks=include_benchmarks,
+        compact=compact,
     )
-    return {
-        "source": _SOURCE,
-        "success": True,
-        "owner": owner,
-        "repo": repo,
-        "window_days": window,
-        "summary": summary,
-        "headline": str(snapshot.get("headline", "")),
-        "from_snapshot": snapshot.get("generated_at"),
-        "rendered_in_shell": False,
-        **figures,
-        "response_text": summary,
-    }
+    result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
+    result["from_snapshot"] = snapshot.get("generated_at")
+    return result
 
 
 def report_text_from_snapshot(
@@ -257,7 +237,7 @@ def report_text_from_snapshot(
     result = _from_snapshot(
         snapshot, owner, repo, window, None, include_benchmarks=include_benchmarks, compact=True
     )
-    if not result.get("success"):
+    if result is None or not result.get("success"):
         return "", ""
     return str(result.get("response_text") or "").strip(), str(snapshot.get("generated_at", ""))
 
@@ -499,7 +479,7 @@ def analyze_github_ci_reliability(
     )
     token = resolve_github_token(github_token)
     if snapshot is not None:
-        return _from_snapshot(
+        answered = _from_snapshot(
             snapshot,
             repo_owner,
             repo_name,
@@ -507,6 +487,8 @@ def analyze_github_ci_reliability(
             console,
             compact=brief,
         )
+        if answered is not None:
+            return answered
     if not token:
         message = (
             f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -63,7 +63,9 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
         "Exit demo",
     )
     body = loader.load_skill_body("cicd-analytics-demo")
-    assert "include_benchmarks=true" in body
+    # The comparison is the tool's job, not a flag the model can forget.
+    assert "include_benchmarks" not in body
+    assert "compact=true" in body
     assert "Compare these numbers" not in body
     assert "Output its `headline`" not in body
     assert menu["allow_custom"] is False

--- a/tests/core/agent_harness/test_action_turn_outcome.py
+++ b/tests/core/agent_harness/test_action_turn_outcome.py
@@ -168,3 +168,74 @@ def test_a_painted_tool_result_is_not_restated_in_the_closing() -> None:
 
     # Assert
     assert shown == ""
+
+
+def _painted_result(*, final_text: str) -> Any:
+    """A turn whose only tool painted its report straight to the console."""
+    from core.llm.types import ToolCall
+
+    class _ToolResult:
+        details = {"rendered_in_shell": True, "summary": "acme/app: 8151 runs in 30 days."}
+        content = "{}"
+        is_error = False
+
+    call = ToolCall(id="1", name="analyze_github_ci_reliability", input={})
+
+    class _Result:
+        tool_results = [(call, _ToolResult())]
+        executed = tool_results
+        planned = [call]
+
+    result = _Result()
+    result.final_text = final_text  # type: ignore[attr-defined]
+    return result
+
+
+def test_a_closing_written_over_a_painted_report_is_dropped() -> None:
+    """The model restates the figures, or contradicts them, without having seen them."""
+    # Arrange
+    from core.agent_harness.turns.action_driver import _compose_response, _TurnCounts
+
+    session = Session()
+    counts = _TurnCounts(
+        executed_entries=[],
+        executed_count=1,
+        executed_success_count=1,
+        generic_success_count=1,
+        planned_count=1,
+        handled=True,
+    )
+
+    # Act
+    _text, chunks, _use_final = _compose_response(
+        _painted_result(final_text="8151 runs total. Comparison skipped, as requested."),
+        session,
+        counts,
+    )
+
+    # Assert: the console already shows the report; nothing is added over it.
+    assert chunks == []
+
+
+def test_a_closing_question_survives_a_painted_report() -> None:
+    """A question seeks direction; dropping it would leave the user with dead air."""
+    # Arrange
+    from core.agent_harness.turns.action_driver import _compose_response, _TurnCounts
+
+    session = Session()
+    counts = _TurnCounts(
+        executed_entries=[],
+        executed_count=1,
+        executed_success_count=1,
+        generic_success_count=1,
+        planned_count=1,
+        handled=True,
+    )
+
+    # Act
+    _text, chunks, _use_final = _compose_response(
+        _painted_result(final_text="Want me to break this down by workflow?"), session, counts
+    )
+
+    # Assert
+    assert chunks == ["Want me to break this down by workflow?"]

--- a/tests/core/agent_harness/test_action_turn_outcome.py
+++ b/tests/core/agent_harness/test_action_turn_outcome.py
@@ -175,7 +175,15 @@ def _painted_result(*, final_text: str) -> Any:
     from core.llm.types import ToolCall
 
     class _ToolResult:
-        details = {"rendered_in_shell": True, "summary": "acme/app: 8151 runs in 30 days."}
+        details = {
+            "rendered_in_shell": True,
+            "summary": "acme/app: 8151 runs in 30 days.",
+            "key_results": [
+                {"label": "main branch red", "value": "36.4h of 30 days (5.1%)"},
+                {"label": "CI-caused failures", "value": "333 of 1174 failed PR runs"},
+                {"label": "Mean time back to green", "value": "1.0h"},
+            ],
+        }
         content = "{}"
         is_error = False
 
@@ -207,10 +215,9 @@ def test_a_closing_written_over_a_painted_report_is_dropped() -> None:
     )
 
     # Act
+    restatement = "36.4h red over 30 days, 333 of 1174 PR runs CI-caused, 1.0h back to green."
     _text, chunks, _use_final = _compose_response(
-        _painted_result(final_text="8151 runs total. Comparison skipped, as requested."),
-        session,
-        counts,
+        _painted_result(final_text=restatement), session, counts
     )
 
     # Assert: the console already shows the report; nothing is added over it.
@@ -239,3 +246,28 @@ def test_a_closing_question_survives_a_painted_report() -> None:
 
     # Assert
     assert chunks == ["Want me to break this down by workflow?"]
+
+
+def test_an_interpretation_of_a_painted_report_is_kept() -> None:
+    """Only the duplicate goes: a judgement the table does not carry survives."""
+    # Arrange
+    from core.agent_harness.turns.action_driver import _compose_response, _TurnCounts
+
+    session = Session()
+    counts = _TurnCounts(
+        executed_entries=[],
+        executed_count=1,
+        executed_success_count=1,
+        generic_success_count=1,
+        planned_count=1,
+        handled=True,
+    )
+    judgement = "The Windows label job is your worst offender; I would quarantine it first."
+
+    # Act
+    _text, chunks, _use_final = _compose_response(
+        _painted_result(final_text=judgement), session, counts
+    )
+
+    # Assert
+    assert chunks == [judgement]

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -61,20 +61,7 @@ def test_the_tool_answers_from_a_fresh_snapshot_without_reading_github(
 
     # Arrange: a snapshot exists; GitHub must not be read.
     now = datetime.now(UTC)
-    write_snapshot(
-        tmp_path,
-        "apache",
-        "airflow",
-        now - timedelta(minutes=5),
-        _payload(
-            generated_at=(now - timedelta(minutes=5)).isoformat(),
-            headline="Red for 24.5h on main",
-            markdown="# CI/CD reliability for apache/airflow\n| a | b |",
-            pr_failures=1168,
-            pr_executions=5722,
-            reliability_failures=333,
-        ),
-    )
+    _write_report_snapshot(tmp_path, _report(), now)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
 
@@ -88,11 +75,13 @@ def test_the_tool_answers_from_a_fresh_snapshot_without_reading_github(
         owner="apache", repo="airflow", days=30, github_token="tok"
     )
 
-    # Assert: figures and provenance come from the snapshot.
+    # Assert: figures and provenance come from the saved report, not a fetch.
+    from integrations.github.tools.ci_analytics.render import headline
+
     assert result["success"] is True
     assert result["from_snapshot"]
     assert result["red_hours"] == 24.5
-    assert result["headline"] == "Red for 24.5h on main"
+    assert result["headline"] == headline(_report())
     assert "as of" in result["summary"]
 
 
@@ -258,7 +247,6 @@ def test_include_benchmarks_builds_the_comparison_from_snapshots(
         owner="acme",
         repo="app",
         days=30,
-        include_benchmarks=True,
         github_token="tok",
     )
 
@@ -295,7 +283,6 @@ def test_include_benchmarks_skips_a_peer_that_cannot_be_fetched(
         owner="acme",
         repo="app",
         days=30,
-        include_benchmarks=True,
     )
 
     assert result["benchmarks_skipped"] == ["fastapi/fastapi (no same-day snapshot)"]
@@ -321,9 +308,7 @@ def test_include_benchmarks_says_when_every_peer_snapshot_is_missing(
 
     monkeypatch.setattr(tool_module, "analyze_repository", _boom)
 
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="acme", repo="app", days=30, include_benchmarks=True
-    )
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(owner="acme", repo="app", days=30)
 
     assert result["success"] is True
     assert result["benchmarks"] == []
@@ -349,12 +334,52 @@ def test_a_fresh_snapshot_answers_without_a_github_token(tmp_path: Path, monkeyp
 
     monkeypatch.setattr(tool_module, "analyze_repository", _boom)
 
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="acme", repo="app", days=30, include_benchmarks=True
-    )
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(owner="acme", repo="app", days=30)
 
     assert result["success"] is True
     assert result["from_snapshot"]
     assert "Compared with apache/airflow and fastapi/fastapi" in result["response_text"]
     assert "fastapi/fastapi: default branch stayed green in this window." in result["response_text"]
     assert "opensre integrations setup github" not in result.get("response_text", "")
+
+
+def test_a_snapshot_without_a_saved_report_is_a_miss_not_a_lesser_answer(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A snapshot written before the report object cannot build the comparison.
+
+    Answering from it would drop the comparison the report always carries, so
+    it counts as a cache miss and GitHub is read instead.
+    """
+    # Arrange: a fresh snapshot in the old shape, and a token to read with.
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    now = datetime.now(UTC)
+    write_snapshot(
+        tmp_path,
+        "apache",
+        "airflow",
+        now - timedelta(minutes=5),
+        _payload(generated_at=(now - timedelta(minutes=5)).isoformat(), headline="old shape"),
+    )
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+    reads: list[str] = []
+
+    def _analyze(owner: str, repo: str, **_kwargs: Any) -> Any:
+        reads.append(f"{owner}/{repo}")
+        return type("A", (), {"report": _report(), "runs_read": 1})()
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
+
+    # Act
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="apache", repo="airflow", days=30, github_token="tok"
+    )
+
+    # Assert
+    assert reads == ["apache/airflow"]
+    assert result["success"] is True
+    assert not result.get("from_snapshot")

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -355,7 +355,7 @@ def test_analyze_markdown_keeps_details_when_benchmarks_are_requested(
 
     # Act
     result = tool_module.analyze_github_ci_reliability(
-        owner="acme", repo="app", days=30, include_benchmarks=True, context=None
+        owner="acme", repo="app", days=30, context=None
     )
 
     # Assert: benchmarks add a section; they do not remove the analysis details.

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1309,3 +1309,16 @@ def test_the_comparison_starts_on_its_own_line() -> None:
     lines = buf.getvalue().splitlines()
     heading = next(i for i, line in enumerate(lines) if "Compared with" in line)
     assert not lines[heading - 1].strip()
+
+
+def test_the_description_tells_the_model_the_comparison_cannot_be_skipped() -> None:
+    """Without this the model promised to skip a comparison it cannot turn off."""
+    # Arrange / Act
+    from tools.registry import get_registered_tool
+
+    registered = get_registered_tool(TOOL_NAME)
+
+    # Assert
+    assert registered is not None
+    assert "cannot be turned off" in registered.description
+    assert "never offer to skip" in registered.description

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1261,3 +1261,51 @@ def test_the_painted_report_follows_a_theme_change() -> None:
     # Assert: the second paint used the theme built for the new palette.
     assert themes[1] is expected
     assert themes[0] is not themes[1]
+
+
+def test_the_comparison_is_not_a_choice_the_model_can_forget() -> None:
+    """The model chooses brevity, never whether to compare.
+
+    A flag advertising "Default false" led the demo to call the tool with
+    benchmarks off, so the comparison table Vincent asked for was missing.
+    """
+    # Arrange / Act
+    from tools.registry import get_registered_tool
+
+    registered = get_registered_tool(TOOL_NAME)
+
+    # Assert
+    assert registered is not None
+    properties = registered.public_input_schema["properties"]
+    assert "include_benchmarks" not in properties
+    assert "compact" in properties
+
+
+def test_the_comparison_starts_on_its_own_line() -> None:
+    """A markdown leading newline is dropped, gluing the heading to a bullet."""
+    # Arrange
+    from rich.console import Console
+
+    from integrations.github.tools.ci_analytics.render import render_comparison, render_report
+
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[_run(9, event="push", branch="main")],
+        pr_runs=[_run(1, conclusion="failure")],
+        merged_prs=_merged("A"),
+        now=_T0 + timedelta(days=1),
+    )
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=100)
+
+    # Act
+    render_report(console, report, compact=True)
+    render_comparison(console, report, [report])
+
+    # Assert: a blank line separates the report from the comparison heading.
+    lines = buf.getvalue().splitlines()
+    heading = next(i for i, line in enumerate(lines) if "Compared with" in line)
+    assert not lines[heading - 1].strip()


### PR DESCRIPTION
Demo A ran without the benchmark comparison. The cause was a contradiction
the model resolved the wrong way: the skill says to call the analysis with
`include_benchmarks=true`, while the tool's own schema described the flag as
"Default false". The model followed the schema and passed false, so the
comparison against apache/airflow and fastapi/fastapi was missing and the
long counts appendix printed instead.

The flag conflated two different decisions:

- whether to compare, which reads same-day snapshots only and never fetches,
  so it costs nothing and is not a judgement call;
- how long the report is, which is a real choice.

`include_benchmarks` is gone from the public schema, so the model can no
longer turn the comparison off, and the comparison always runs. The schema
offers `compact` instead, which drops the counts appendix (executions,
failure classification, blocked time, workflows). The analysis skill now
calls the tool with `compact=true`; the benchmarks reference no longer
mentions a flag.

The failure mode is now safe in both directions: if the model forgets
`compact`, the reader gets the comparison plus more detail, instead of
losing the section the demo exists to show.

### Demo/Screenshot for feature changes and bug fixes -

Live demo A on this branch, warm snapshots. The comparison is present:

    Metric                 │ Tracer-Cloud/opensre │ apache/airflow │ fastapi/fastapi
    Red time on main       │                 5.1% │           3.4% │            0.0%

On main, the same run called the tool with `include_benchmarks: false` and
produced no comparison at all. On this branch the model still passed
`compact: false` against the skill, and the only consequence is the extra
appendix: the table is there either way.