### PR TITLE
fix(shell): a plan update no longer rescues a restated closing

### DIFF
--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -51,6 +51,7 @@ from core.agent_harness.turns.conversation_recording import record_conversation_
 from core.agent_harness.turns.display_text import (
     cap_for_display,
     format_generic_tool_payload,
+    host_rendered,
     looks_like_json,
     preferred_tool_response_text,
     split_output_truncation_markers,
@@ -229,15 +230,19 @@ def _has_preferred_tool_response_text(result: Any) -> bool:
 
 
 def _painted_results_only(result: Any) -> bool:
-    """True when every executed tool painted its own output to the console."""
-    results = list(getattr(result, "tool_results", []))
-    if not results:
-        return False
-    return all(
-        isinstance(getattr(tool_result, "details", None), dict)
-        and tool_result.details.get("rendered_in_shell") is True
-        for _tool_call, tool_result in results
-    )
+    """True when the turn's content came from tools that painted it themselves.
+
+    ``update_plan`` and the menu tools carry no content of their own — the host
+    draws them — so a turn that also updates its plan still counts.
+    """
+    painted = 0
+    for tool_call, tool_result in getattr(result, "tool_results", []):
+        details = getattr(tool_result, "details", None)
+        if isinstance(details, dict) and details.get("rendered_in_shell") is True:
+            painted += 1
+        elif not host_rendered(tool_call, tool_result):
+            return False
+    return painted > 0
 
 
 #: How many of the painted figures a closing must repeat to count as a restatement.

--- a/core/agent_harness/turns/display_text.py
+++ b/core/agent_harness/turns/display_text.py
@@ -29,7 +29,7 @@ _HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset(
 )
 
 
-def _host_rendered(tool_call: ToolCall, tool_result: Any) -> bool:
+def host_rendered(tool_call: ToolCall, tool_result: Any) -> bool:
     """True when the console already shows this result, so it is not re-shown."""
     if tool_call.name in _HOST_RENDERED_TOOL_NAMES:
         return True
@@ -120,7 +120,7 @@ def _visible_stdout(stdout: str) -> str:
 
 def format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
     """Build a user-visible summary for one non-self-recording tool result."""
-    if _host_rendered(tool_call, tool_result) and not getattr(tool_result, "is_error", False):
+    if host_rendered(tool_call, tool_result) and not getattr(tool_result, "is_error", False):
         return ""
     preferred_response = preferred_tool_response_text(tool_result)
     if preferred_response:
@@ -195,6 +195,7 @@ def preferred_tool_response_text(tool_result: Any) -> str:
 
 __all__ = [
     "DISPLAY_OUTPUT_MAX_CHARS",
+    "host_rendered",
     "DISPLAY_OUTPUT_MAX_LINES",
     "cap_for_display",
     "format_generic_tool_payload",

--- a/tests/core/agent_harness/test_action_turn_outcome.py
+++ b/tests/core/agent_harness/test_action_turn_outcome.py
@@ -271,3 +271,55 @@ def test_an_interpretation_of_a_painted_report_is_kept() -> None:
 
     # Assert
     assert chunks == [judgement]
+
+
+def test_a_plan_update_does_not_rescue_a_restated_closing() -> None:
+    """The real demo turn updates its plan and paints the report in one go.
+
+    Requiring every result to be painted let that turn keep a closing that
+    repeated the figures, because ``update_plan`` is not a painted result.
+    """
+    # Arrange
+    from core.agent_harness.turns.action_driver import _compose_response, _TurnCounts
+    from core.llm.types import ToolCall
+
+    class _Painted:
+        details = {
+            "rendered_in_shell": True,
+            "key_results": [
+                {"label": "main branch red", "value": "36.4h of 30 days (5.1%)"},
+                {"label": "CI-caused failures", "value": "333 of 1174 failed PR runs"},
+                {"label": "Mean time back to green", "value": "1.0h"},
+            ],
+        }
+        content = "{}"
+        is_error = False
+
+    class _Plan:
+        details = {"ok": True, "steps": []}
+        content = "{}"
+        is_error = False
+
+    plan_call = ToolCall(id="1", name="update_plan", input={})
+    report_call = ToolCall(id="2", name="analyze_github_ci_reliability", input={})
+
+    class _Result:
+        tool_results = [(plan_call, _Plan()), (report_call, _Painted())]
+        executed = tool_results
+        planned = [plan_call, report_call]
+        final_text = "Main was red 36.4h (5.1%), with 333 of 1174 PR runs CI-caused; 1.0h to green."
+
+    counts = _TurnCounts(
+        executed_entries=[],
+        executed_count=2,
+        executed_success_count=2,
+        generic_success_count=1,
+        planned_count=2,
+        handled=True,
+    )
+
+    # Act
+    _text, chunks, _use_final = _compose_response(_Result(), Session(), counts)
+
+    # Assert
+    assert chunks == []


### PR DESCRIPTION
Follow-up to #6161 and #6162, found by a live sweep of the shell rather than
by a test.

#6161 drops a closing that restates a report the tool already painted, the
same way the shell has long dropped a closing written over a shell command's
output. The predicate required *every* tool result in the turn to be painted.
Real turns are not shaped that way: the analytics skill calls `update_plan`
alongside the analysis, and `update_plan` is not a painted result, so the
rule never fired on the path that matters.

Two live captures show the damage. One closing restated the report as six
bullets. Another added "I skipped the benchmark comparison as requested" with
the comparison table sitting directly above it. A turn that ran the analysis
alone suppressed correctly, which is why earlier spot checks passed.

`update_plan` and the menu tools carry no content of their own — the host
draws them — so they are now ignored when deciding, and at least one painted
result is required. The "is this already on screen" predicate moves from
private to shared in `display_text` so the driver and the transcript
formatter answer the question the same way instead of each keeping a copy.

### Demo/Screenshot for feature changes and bug fixes -

Same prompt, before and after, in a real shell with a warm snapshot.

Before ("Analyze CI/CD reliability for Tracer-Cloud/opensre, but skip the
benchmark comparison"):

    ...comparison table...
    Ω Good news: Tracer-Cloud/opensre had 8,151 runs in the last 30 days.
       • PR health: 1,174 of 5,727 PR runs failed; 333 were CI-caused.
       • Main branch: red for 36.4h total, with 41 breakages.
       • I skipped the benchmark comparison as requested.

After:

    ...comparison table...
     • Coverage notice: attempt history was checked for the first 500 requests only...
     • fastapi/fastapi: default branch stayed green in this window.
    (next-step menu)