### PR TITLE
fix(prompt): a count taken from a truncated read is wrong, not approximate

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -347,6 +347,7 @@ When using the shell, you must adhere to the following guidelines:
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
 - Do not use python scripts to attempt to output larger chunks of a file.
 - When a read-only measurement fails (a missing module, a non-zero exit, a traceback), fix it and run it again before answering; in this checkout `uv run python` has the project's libraries. Do not rerun a command that may already have written files or changed state. Never replace a failed measurement with a regex, a guess or a rough count presented as the measured figure. If you must estimate, say it is an estimate and why.
+- Counting or measuring from a file means reading all of it. A range read (`sed -n '1,220p'`, `head`) silently drops everything past the cut, so a count taken from it is wrong rather than approximate — check the length first (`wc -l`) or parse the whole file. The same applies to output your own command truncated.
 - `quiet=true` on `shell_run` hides the output only; the command line still shows dimmed, so quiet is never a way to hide what ran.
 - Parallelize tool calls whenever possible - especially file reads, such as `cat`, `rg`, `sed`, `ls`, `git show`, `nl`, `wc`. Use `multi_tool_use.parallel` to parallelize tool calls and only this.
 

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -95,3 +95,12 @@ def test_failed_commands_are_rerun_not_estimated() -> None:
     assert "Do not rerun a command that may already have written files" in shell_section
     assert "Never replace a failed measurement" in shell_section
     assert "the command line still shows dimmed" in shell_section
+
+
+def test_counts_come_from_the_whole_file() -> None:
+    # Arrange / Act: the shell guidelines carry the rule as one bullet.
+    shell_section = _SYSTEM_PROMPT_BASE.split("## Shell commands", 1)[1]
+
+    # Assert: a range read undercounts silently, which is a wrong answer.
+    assert "Counting or measuring from a file means reading all of it" in shell_section
+    assert "wrong rather than approximate" in shell_section


### PR DESCRIPTION
Found by a live sweep of the shell, not by a test.

Asked for a table of the workflows with their job counts, the shell reported
3 jobs for ci.yml and 4 for release.yml. Both have 7. The transcript shows
why: it ran `sed -n '1,260p' .github/workflows/ci.yml` against a file of 868
lines, and `sed -n '1,240p' release.yml` against 854 lines, then counted the
jobs it could see. The reply presented those numbers as measured.

This is not the failure #6158 already covers. That rule fires when a command
fails; here every command succeeded and the answer was still wrong.

This is not the failure #6158 already covers. That rule fires when a command
fails; here every command succeeded and the answer was still wrong.

The existing guidance pushes in this direction. "Do not use python scripts to
attempt to output larger chunks of a file" steers away from parsing, and
`sed` appears in the list of reads to parallelise, while nothing warns that a
range read drops everything past the cut. The shell section now says that
counting or measuring from a file means reading all of it, that a range read
makes a count wrong rather than approximate, and that the length should be
checked first or the whole file parsed.

This one is prompt guidance rather than a guard, deliberately. Code cannot
tell that a model truncated its own input, and inspecting commands for range
reads is exactly the fragile pattern matching the codebase forbids.

### Demo/Screenshot for feature changes and bug fixes -

Ground truth, by parsing the files:

    ci.yml       868 lines, 7 jobs   (model read to line 260, reported 3)
    release.yml  854 lines, 7 jobs   (model read to line 240, reported 4)

The same prompt in a session where the model parsed with the project's Python
gave all nine counts correctly, so the numbers are reachable; the reading
method was the difference.

A live rerun of the failing prompt at the same terminal width is in progress
and is not included in this description yet.