### PR TITLE
fix(tools): YAML anchors load, and file counts skip generated directories

### DIFF
--- a/docs/counting-files.mdx
+++ b/docs/counting-files.mdx
@@ -5,13 +5,9 @@ description: "Ask how many files of a kind a directory holds and get the project
 
 ## Overview
 
-"How many test files are in this package" has an exact answer, and the obvious
-shell command gets it wrong. `find -type f` counts everything on disk, so
-compiled caches under `__pycache__` are counted alongside the modules you wrote
-— in this repository that turns 103 test files into 233.
-
-OpenSRE counts the files that belong to the project. Ask in the interactive
-shell (`opensre`):
+OpenSRE counts the files that belong to your project: the modules you wrote,
+not the compiled caches and vendored packages sitting beside them. Ask in the
+interactive shell (`opensre`):
 
 ```
 How many test files are under tests/interactive_shell?

--- a/docs/counting-files.mdx
+++ b/docs/counting-files.mdx
@@ -1,0 +1,49 @@
+---
+title: "Counting files"
+description: "Ask how many files of a kind a directory holds and get the project's files, not its caches"
+---
+
+## Overview
+
+"How many test files are in this package" has an exact answer, and the obvious
+shell command gets it wrong. `find -type f` counts everything on disk, so
+compiled caches under `__pycache__` are counted alongside the modules you wrote
+— in this repository that turns 103 test files into 233.
+
+OpenSRE counts the files that belong to the project. Ask in the interactive
+shell (`opensre`):
+
+```
+How many test files are under tests/interactive_shell?
+How many Python files does surfaces/interactive_shell have?
+How many workflow files are in .github/workflows?
+```
+
+## What you get back
+
+One sentence naming the count, the pattern and the directory:
+
+```
+103 files matching test_*.py under tests/interactive_shell, not counting
+generated directories
+```
+
+Up to twenty matching paths come back as examples. The count itself always
+covers the whole tree.
+
+## What is skipped
+
+Directories whose contents are generated, vendored, or version-control
+bookkeeping: `__pycache__`, `.venv`, `venv`, `site-packages`, `node_modules`,
+`build`, `dist`, `.git`, and the `.mypy_cache`, `.pytest_cache`, `.ruff_cache`
+and `.tox` caches.
+
+Symlinked directories are not followed, so a link pointing back up the tree
+cannot make the count run away.
+
+## What it does not do
+
+- Counting entries inside a YAML, JSON or TOML file is a different question:
+  see [Structured file reads](/structured-file-tool).
+- Searching file contents is a shell command with `rg`.
+- Listing every file name: you get the count and a few examples.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -201,6 +201,7 @@
                 "pages": [
                   "architecture-audit-tool",
                   "structured-file-tool",
+                  "counting-files",
                   "bitbucket",
                   "cicd-analytics-demo",
                   "github",

--- a/tests/tools/test_file_count.py
+++ b/tests/tools/test_file_count.py
@@ -96,7 +96,8 @@ def test_the_tool_names_the_glob_it_counted(tmp_path: Path) -> None:
     # Assert
     assert result["ok"] is True
     assert result["count"] == 2
-    assert "2 files matching test_*.py" in result["response_text"]
+    # The glob is fenced: unfenced, `*test*` reaches the reader as emphasis.
+    assert "2 files matching `test_*.py`" in result["response_text"]
     assert "not counting generated directories" in result["response_text"]
 
 
@@ -157,3 +158,17 @@ def test_an_unreadable_subtree_raises_instead_of_undercounting(
     # Act / Assert
     with pytest.raises(FileCountError, match="cannot read"):
         count_matching_files(Path("."), "test_*.py")
+
+
+def test_the_reported_path_stays_relative_to_the_workspace(tmp_path: Path) -> None:
+    """Resolving for safety turns a path absolute; the answer should not show that."""
+    # Arrange
+    _tree(tmp_path)
+
+    # Act
+    result = count_files(path="pkg", pattern="test_*.py")
+
+    # Assert: no home directory in the sentence the reader sees.
+    assert "under pkg," in result["response_text"]
+    assert str(tmp_path) not in result["response_text"]
+    assert all(not name.startswith("/") for name in result["names"])

--- a/tests/tools/test_file_count.py
+++ b/tests/tools/test_file_count.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+import tools.system.file_count.count as count_module
 from tools.system.file_count.count import FileCountError, count_matching_files
 from tools.system.file_count.tool import TOOL_NAME, count_files
 
@@ -131,19 +133,27 @@ def test_a_symlinked_root_is_judged_by_where_it_lands(tmp_path: Path, monkeypatc
         count_matching_files(Path("escape"))
 
 
-def test_an_unreadable_subtree_raises_instead_of_undercounting(tmp_path: Path, monkeypatch) -> None:
-    """A skipped subtree would make an exact-looking count partial."""
+def test_an_unreadable_subtree_raises_instead_of_undercounting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A skipped subtree would make an exact-looking count partial.
+
+    The walk error is simulated rather than produced with ``chmod``: as root,
+    or on a filesystem that ignores the mode, an unreadable directory is still
+    readable and the test would pass for the wrong reason.
+    """
     # Arrange
-    monkeypatch.chdir(tmp_path)
     _tree(tmp_path)
-    locked = tmp_path / "pkg" / "locked"
-    locked.mkdir()
-    (locked / "test_hidden.py").write_text("")
-    locked.chmod(0o000)
+
+    def _walk_that_fails(top: Any, onerror: Any = None, followlinks: bool = False) -> Any:
+        denied = PermissionError(13, "Permission denied")
+        denied.filename = str(Path(top) / "locked")
+        if onerror is not None:
+            onerror(denied)
+        return iter(())
+
+    monkeypatch.setattr(count_module.os, "walk", _walk_that_fails)
 
     # Act / Assert
-    try:
-        with pytest.raises(FileCountError, match="cannot read"):
-            count_matching_files(Path("."), "test_*.py")
-    finally:
-        locked.chmod(0o755)
+    with pytest.raises(FileCountError, match="cannot read"):
+        count_matching_files(Path("."), "test_*.py")

--- a/tests/tools/test_file_count.py
+++ b/tests/tools/test_file_count.py
@@ -10,6 +10,12 @@ from tools.system.file_count.count import FileCountError, count_matching_files
 from tools.system.file_count.tool import TOOL_NAME, count_files
 
 
+@pytest.fixture(autouse=True)
+def _work_where_the_files_are(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """These tools only read inside the working directory; point it at the fixture tree."""
+    monkeypatch.chdir(tmp_path)
+
+
 def _tree(root: Path) -> None:
     """Two real test modules plus the caches a build leaves behind."""
     (root / "pkg").mkdir()
@@ -102,3 +108,42 @@ def test_the_tool_is_registered_and_read_only() -> None:
     assert registered is not None
     assert registered.side_effect_level == "read_only"
     assert set(registered.public_input_schema["properties"]) == {"path", "pattern"}
+
+
+def test_a_path_outside_the_working_directory_is_refused(tmp_path: Path) -> None:
+    """Read-only tools run without an approval gate, so the root must stay inside."""
+    # Arrange / Act / Assert
+    with pytest.raises(FileCountError, match="outside the working directory"):
+        count_matching_files(Path("/etc"))
+    with pytest.raises(FileCountError, match="outside the working directory"):
+        count_matching_files(Path("../.."))
+
+
+def test_a_symlinked_root_is_judged_by_where_it_lands(tmp_path: Path, monkeypatch) -> None:
+    # Arrange: a link inside the workspace pointing outside it.
+    workspace = tmp_path / "work"
+    workspace.mkdir()
+    (workspace / "escape").symlink_to(tmp_path.parent, target_is_directory=True)
+    monkeypatch.chdir(workspace)
+
+    # Act / Assert
+    with pytest.raises(FileCountError, match="outside the working directory"):
+        count_matching_files(Path("escape"))
+
+
+def test_an_unreadable_subtree_raises_instead_of_undercounting(tmp_path: Path, monkeypatch) -> None:
+    """A skipped subtree would make an exact-looking count partial."""
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    _tree(tmp_path)
+    locked = tmp_path / "pkg" / "locked"
+    locked.mkdir()
+    (locked / "test_hidden.py").write_text("")
+    locked.chmod(0o000)
+
+    # Act / Assert
+    try:
+        with pytest.raises(FileCountError, match="cannot read"):
+            count_matching_files(Path("."), "test_*.py")
+    finally:
+        locked.chmod(0o755)

--- a/tests/tools/test_file_count.py
+++ b/tests/tools/test_file_count.py
@@ -1,0 +1,104 @@
+"""Counting project files, where `find` counted compiled caches as test files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.system.file_count.count import FileCountError, count_matching_files
+from tools.system.file_count.tool import TOOL_NAME, count_files
+
+
+def _tree(root: Path) -> None:
+    """Two real test modules plus the caches a build leaves behind."""
+    (root / "pkg").mkdir()
+    (root / "pkg" / "test_one.py").write_text("")
+    (root / "pkg" / "test_two.py").write_text("")
+    (root / "pkg" / "helper.py").write_text("")
+    cache = root / "pkg" / "__pycache__"
+    cache.mkdir()
+    (cache / "test_one.cpython-311.pyc").write_text("")
+    (cache / "test_two.cpython-311.pyc").write_text("")
+    venv = root / ".venv" / "lib"
+    venv.mkdir(parents=True)
+    (venv / "test_vendored.py").write_text("")
+
+
+def test_generated_directories_are_not_counted(tmp_path: Path) -> None:
+    """`test_*` matched `.pyc` files in __pycache__, inflating 103 into 233."""
+    # Arrange
+    _tree(tmp_path)
+
+    # Act
+    tally = count_matching_files(tmp_path, "test_*.py")
+
+    # Assert: the two real modules, not the caches or the vendored copy.
+    assert tally.count == 2
+    assert tally.skipped_directories == 2
+
+
+def test_the_default_pattern_counts_every_project_file(tmp_path: Path) -> None:
+    # Arrange
+    _tree(tmp_path)
+
+    # Act
+    tally = count_matching_files(tmp_path)
+
+    # Assert
+    assert tally.count == 3
+
+
+def test_a_missing_directory_says_so_instead_of_returning_zero(tmp_path: Path) -> None:
+    # Arrange / Act / Assert
+    with pytest.raises(FileCountError, match="does not exist"):
+        count_matching_files(tmp_path / "nope")
+
+
+def test_a_file_path_is_refused(tmp_path: Path) -> None:
+    # Arrange
+    path = tmp_path / "one.py"
+    path.write_text("")
+
+    # Act / Assert
+    with pytest.raises(FileCountError, match="not a directory"):
+        count_matching_files(path)
+
+
+def test_a_symlinked_directory_is_not_followed(tmp_path: Path) -> None:
+    """A link back up the tree would otherwise count forever."""
+    # Arrange
+    _tree(tmp_path)
+    (tmp_path / "pkg" / "loop").symlink_to(tmp_path, target_is_directory=True)
+
+    # Act
+    tally = count_matching_files(tmp_path, "test_*.py")
+
+    # Assert
+    assert tally.count == 2
+
+
+def test_the_tool_names_the_glob_it_counted(tmp_path: Path) -> None:
+    # Arrange
+    _tree(tmp_path)
+
+    # Act
+    result = count_files(path=str(tmp_path), pattern="test_*.py")
+
+    # Assert
+    assert result["ok"] is True
+    assert result["count"] == 2
+    assert "2 files matching test_*.py" in result["response_text"]
+    assert "not counting generated directories" in result["response_text"]
+
+
+def test_the_tool_is_registered_and_read_only() -> None:
+    # Arrange / Act
+    from tools.registry import get_registered_tool
+
+    registered = get_registered_tool(TOOL_NAME)
+
+    # Assert
+    assert registered is not None
+    assert registered.side_effect_level == "read_only"
+    assert set(registered.public_input_schema["properties"]) == {"path", "pattern"}

--- a/tests/tools/test_structured_file.py
+++ b/tests/tools/test_structured_file.py
@@ -10,6 +10,13 @@ import pytest
 from tools.system.structured_file.parse import StructureError, describe
 from tools.system.structured_file.tool import TOOL_NAME, read_structured_file
 
+
+@pytest.fixture(autouse=True)
+def _work_where_the_files_are(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """These tools only read inside the working directory; point it at the fixture tree."""
+    monkeypatch.chdir(tmp_path)
+
+
 _WORKFLOW = """
 name: CI
 on:
@@ -197,3 +204,10 @@ def test_a_merged_anchor_is_expanded(tmp_path: Path) -> None:
     # Assert: the file loads, and the merged key is part of the job.
     assert jobs.count == 2
     assert build.keys == ("runs-on", "steps")
+
+
+def test_a_file_outside_the_working_directory_is_refused() -> None:
+    """Key names from a private config would otherwise be readable."""
+    # Arrange / Act / Assert
+    with pytest.raises(StructureError, match="outside the working directory"):
+        describe(Path("/etc/hosts"))

--- a/tests/tools/test_structured_file.py
+++ b/tests/tools/test_structured_file.py
@@ -172,3 +172,28 @@ def test_the_tool_is_registered_and_read_only() -> None:
     assert registered is not None
     assert registered.side_effect_level == "read_only"
     assert "path" in registered.public_input_schema["properties"]
+
+
+def test_a_merged_anchor_is_expanded(tmp_path: Path) -> None:
+    """``<<`` pulls an anchored mapping in; skipping it made the file unreadable."""
+    # Arrange: two jobs that share defaults through an anchor.
+    path = tmp_path / "anchored.yml"
+    path.write_text(
+        "defaults: &defaults\n"
+        "  runs-on: ubuntu-latest\n"
+        "jobs:\n"
+        "  build:\n"
+        "    <<: *defaults\n"
+        "    steps: []\n"
+        "  test:\n"
+        "    <<: *defaults\n"
+        "    steps: []\n"
+    )
+
+    # Act
+    jobs = describe(path, "jobs")
+    build = describe(path, "jobs.build")
+
+    # Assert: the file loads, and the merged key is part of the job.
+    assert jobs.count == 2
+    assert build.keys == ("runs-on", "steps")

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -965,6 +965,9 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         # registry that this test enumerates.
         "alertmanager_alerts",
         "alertmanager_silences",
+        # count_files catches only FileCountError (missing path, not a
+        # directory); an unexpected walk error reaches the global wrapper.
+        "count_files",
         # read_structured_file catches only StructureError (unreadable file,
         # unknown key); a parser failure it did not anticipate reaches the
         # global wrapper.

--- a/tools/system/__init__.py
+++ b/tools/system/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 TOOL_MODULES = (
     "agent_memory.tool",
+    "file_count.tool",
     "fleet_monitoring",
     "python_execution_tool",
     "runbook_guidance_tool.tool",

--- a/tools/system/file_count/__init__.py
+++ b/tools/system/file_count/__init__.py
@@ -1,0 +1,5 @@
+"""Count project files under a directory without counting generated output."""
+
+from tools.system.file_count.tool import TOOL_NAME, count_files
+
+__all__ = ["TOOL_NAME", "count_files"]

--- a/tools/system/file_count/count.py
+++ b/tools/system/file_count/count.py
@@ -12,7 +12,11 @@ from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
 
-from tools.system.workspace_paths import WorkspacePathError, resolve_within_workspace
+from tools.system.workspace_paths import (
+    WorkspacePathError,
+    resolve_within_workspace,
+    workspace_relative,
+)
 
 #: Directories whose contents are generated, vendored, or version-control
 #: bookkeeping. Counting them answers a question nobody asked.
@@ -85,9 +89,9 @@ def count_matching_files(root: Path, pattern: str = "*") -> FileTally:
                 continue
             count += 1
             if len(matched) < MAX_LISTED_NAMES:
-                matched.append(str(Path(current, name)))
+                matched.append(workspace_relative(Path(current, name)))
     return FileTally(
-        root=str(root),
+        root=workspace_relative(root),
         pattern=glob,
         count=count,
         names=tuple(matched),

--- a/tools/system/file_count/count.py
+++ b/tools/system/file_count/count.py
@@ -1,0 +1,92 @@
+"""Count the project files under a directory, skipping generated output.
+
+``find -type f`` counts caches and build output, so "how many test files" came
+back as 233 where 103 exist: the pattern ``test_*`` also matched compiled
+``.pyc`` files inside ``__pycache__``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+
+#: Directories whose contents are generated, vendored, or version-control
+#: bookkeeping. Counting them answers a question nobody asked.
+GENERATED_DIRECTORIES: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+        "site-packages",
+        "venv",
+    }
+)
+#: Names listed back to the caller; the count itself is always complete.
+MAX_LISTED_NAMES = 20
+
+
+@dataclass(frozen=True)
+class FileTally:
+    """How many files under a directory matched, and a few of their names."""
+
+    root: str
+    pattern: str
+    count: int
+    names: tuple[str, ...]
+    skipped_directories: int
+
+
+class FileCountError(ValueError):
+    """The directory cannot be counted."""
+
+
+def count_matching_files(root: Path, pattern: str = "*") -> FileTally:
+    """Count files under ``root`` whose name matches ``pattern``.
+
+    Generated directories are pruned, symlinked directories are not followed
+    (a link back up the tree would count forever), and the count covers the
+    whole remaining tree — never a truncated sample.
+    """
+    if not root.exists():
+        raise FileCountError(f"{root} does not exist")
+    if not root.is_dir():
+        raise FileCountError(f"{root} is not a directory")
+    glob = pattern.strip() or "*"
+    matched: list[str] = []
+    count = 0
+    skipped = 0
+    for current, directories, files in os.walk(root, followlinks=False):
+        keep = [name for name in directories if name not in GENERATED_DIRECTORIES]
+        skipped += len(directories) - len(keep)
+        directories[:] = keep
+        for name in files:
+            if not fnmatch(name, glob):
+                continue
+            count += 1
+            if len(matched) < MAX_LISTED_NAMES:
+                matched.append(str(Path(current, name)))
+    return FileTally(
+        root=str(root),
+        pattern=glob,
+        count=count,
+        names=tuple(matched),
+        skipped_directories=skipped,
+    )
+
+
+__all__ = [
+    "GENERATED_DIRECTORIES",
+    "MAX_LISTED_NAMES",
+    "FileCountError",
+    "FileTally",
+    "count_matching_files",
+]

--- a/tools/system/file_count/count.py
+++ b/tools/system/file_count/count.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
 
+from tools.system.workspace_paths import WorkspacePathError, resolve_within_workspace
+
 #: Directories whose contents are generated, vendored, or version-control
 #: bookkeeping. Counting them answers a question nobody asked.
 GENERATED_DIRECTORIES: frozenset[str] = frozenset(
@@ -52,19 +54,29 @@ class FileCountError(ValueError):
 def count_matching_files(root: Path, pattern: str = "*") -> FileTally:
     """Count files under ``root`` whose name matches ``pattern``.
 
-    Generated directories are pruned, symlinked directories are not followed
-    (a link back up the tree would count forever), and the count covers the
-    whole remaining tree — never a truncated sample.
+    ``root`` must resolve inside the working directory. Generated directories
+    are pruned, symlinked directories are not followed (a link back up the tree
+    would count forever), an unreadable subtree raises rather than being skipped,
+    and the count covers the whole remaining tree — never a truncated sample.
     """
+    try:
+        root = resolve_within_workspace(root)
+    except WorkspacePathError as exc:
+        raise FileCountError(str(exc)) from exc
     if not root.exists():
         raise FileCountError(f"{root} does not exist")
     if not root.is_dir():
         raise FileCountError(f"{root} is not a directory")
+
+    def _stop(error: OSError) -> None:
+        # A silently skipped subtree would make an exact-looking count partial.
+        raise FileCountError(f"cannot read {error.filename}: {type(error).__name__}")
+
     glob = pattern.strip() or "*"
     matched: list[str] = []
     count = 0
     skipped = 0
-    for current, directories, files in os.walk(root, followlinks=False):
+    for current, directories, files in os.walk(root, onerror=_stop, followlinks=False):
         keep = [name for name in directories if name not in GENERATED_DIRECTORIES]
         skipped += len(directories) - len(keep)
         directories[:] = keep

--- a/tools/system/file_count/tool.py
+++ b/tools/system/file_count/tool.py
@@ -33,7 +33,13 @@ _INPUT_SCHEMA: dict[str, Any] = {
 
 
 def _summary(tally: FileTally) -> str:
-    described = "files" if tally.pattern == "*" else f"files matching {tally.pattern}"
+    """One sentence naming the count and the glob that produced it.
+
+    The glob is fenced: a pattern like ``*test*`` is otherwise read as markdown
+    emphasis and reaches the reader as ``test``, so the sentence would name a
+    filter that was never used.
+    """
+    described = "files" if tally.pattern == "*" else f"files matching `{tally.pattern}`"
     if tally.count == 1:
         described = described.replace("files", "file", 1)
     return f"{tally.count} {described} under {tally.root}, not counting generated directories"

--- a/tools/system/file_count/tool.py
+++ b/tools/system/file_count/tool.py
@@ -47,8 +47,9 @@ def _summary(tally: FileTally) -> str:
         "Count the files under a directory whose names match a glob, skipping "
         "generated directories (`__pycache__`, `.venv`, `node_modules`, `build`, "
         "`dist`, caches, `.git`). Use this for 'how many … files' questions instead "
-        "of `find`, which counts compiled caches as well and turns 103 test files "
-        "into 233. The count covers the whole tree, never a sample. Read-only."
+        "of `find`, which counts compiled caches as project files. The count covers "
+        "the whole tree, never a sample, and the path must be inside the working "
+        "directory. Read-only."
     ),
     use_cases=[
         "How many test files are under tests/?",

--- a/tools/system/file_count/tool.py
+++ b/tools/system/file_count/tool.py
@@ -1,0 +1,96 @@
+"""Action tool: count the project files under a directory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from core.domain.types.tools import ToolSurface
+from core.tool import SideEffectLevel
+from core.tool_framework import tool
+from tools.system.file_count.count import FileCountError, FileTally, count_matching_files
+
+TOOL_NAME = "count_files"
+
+_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "Directory to count in, relative to the working directory.",
+        },
+        "pattern": {
+            "type": "string",
+            "description": (
+                "File-name glob such as `test_*.py` or `*.yml`. Narrow it to what was "
+                "asked; the default `*` counts every file."
+            ),
+        },
+    },
+    "required": ["path"],
+    "additionalProperties": False,
+}
+
+
+def _summary(tally: FileTally) -> str:
+    described = "files" if tally.pattern == "*" else f"files matching {tally.pattern}"
+    if tally.count == 1:
+        described = described.replace("files", "file", 1)
+    return f"{tally.count} {described} under {tally.root}, not counting generated directories"
+
+
+@tool(
+    name=TOOL_NAME,
+    source="system",
+    display_name="Count files",
+    description=(
+        "Count the files under a directory whose names match a glob, skipping "
+        "generated directories (`__pycache__`, `.venv`, `node_modules`, `build`, "
+        "`dist`, caches, `.git`). Use this for 'how many … files' questions instead "
+        "of `find`, which counts compiled caches as well and turns 103 test files "
+        "into 233. The count covers the whole tree, never a sample. Read-only."
+    ),
+    use_cases=[
+        "How many test files are under tests/?",
+        "How many Python files does this package have?",
+        "How many workflow files are in .github/workflows?",
+    ],
+    anti_examples=[
+        "Counting entries inside a YAML, JSON or TOML file (use read_structured_file)",
+        "Searching file contents (use shell_run with rg)",
+        "Listing every file name (this returns a count and a few examples)",
+    ],
+    outputs={
+        "count": "How many files matched, across the whole tree",
+        "names": "Up to twenty matching paths, as examples",
+        "response_text": "One sentence naming the count, the glob and the directory",
+    },
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.READ_ONLY,
+    parallel_safe=True,
+    input_schema=_INPUT_SCHEMA,
+    tags=("safe",),
+)
+def count_files(path: str, pattern: str = "*", **_kwargs: Any) -> dict[str, Any]:
+    """Count files under ``path`` matching ``pattern``, skipping generated output."""
+    target = (path or "").strip()
+    if not target:
+        return {"ok": False, "error": "path is required."}
+    try:
+        tally = count_matching_files(Path(target), pattern or "*")
+    except FileCountError as exc:
+        return {"ok": False, "path": target, "error": str(exc)}
+    summary = _summary(tally)
+    return {
+        "ok": True,
+        "path": tally.root,
+        "pattern": tally.pattern,
+        "count": tally.count,
+        "names": list(tally.names),
+        "skipped_directories": tally.skipped_directories,
+        "summary": summary,
+        "response_text": summary,
+    }
+
+
+__all__ = ["TOOL_NAME", "count_files"]

--- a/tools/system/structured_file/parse.py
+++ b/tools/system/structured_file/parse.py
@@ -15,7 +15,11 @@ from typing import Any
 
 import yaml
 
-from tools.system.workspace_paths import WorkspacePathError, resolve_within_workspace
+from tools.system.workspace_paths import (
+    WorkspacePathError,
+    resolve_within_workspace,
+    workspace_relative,
+)
 
 #: Extensions this module knows how to load.
 FORMAT_BY_SUFFIX: dict[str, str] = {
@@ -130,7 +134,7 @@ def describe(path: Path, key: str = "") -> StructureView:
     if isinstance(target, dict):
         names = [str(name) for name in target]
         return StructureView(
-            path=str(path),
+            path=workspace_relative(path),
             file_format=file_format,
             key=key,
             kind="mapping",
@@ -139,7 +143,7 @@ def describe(path: Path, key: str = "") -> StructureView:
         )
     if isinstance(target, list):
         return StructureView(
-            path=str(path),
+            path=workspace_relative(path),
             file_format=file_format,
             key=key,
             kind="list",
@@ -147,7 +151,7 @@ def describe(path: Path, key: str = "") -> StructureView:
             keys=(),
         )
     return StructureView(
-        path=str(path),
+        path=workspace_relative(path),
         file_format=file_format,
         key=key,
         # A scalar's contents are never returned: a config file may hold a

--- a/tools/system/structured_file/parse.py
+++ b/tools/system/structured_file/parse.py
@@ -35,12 +35,24 @@ class KeysAsWritten(yaml.SafeLoader):
     their normal types.
     """
 
+    #: Keys YAML resolves to booleans; kept as the words the file spells.
+    _BOOL_TAG = "tag:yaml.org,2002:bool"
+    #: ``<<`` pulls an anchored mapping in; PyYAML normally expands it for us.
+    _MERGE_TAG = "tag:yaml.org,2002:merge"
+
     def construct_mapping(self, node: Any, deep: bool = False) -> dict[Any, Any]:
+        """Build the mapping, expanding ``<<`` merges and keeping keys as written.
+
+        ``SafeConstructor.construct_mapping`` normally expands ``<<`` for us;
+        overriding it means doing that here, or an anchored document fails to
+        load at all.
+        """
+        self.flatten_mapping(node)
         mapping: dict[Any, Any] = {}
         for key_node, value_node in node.value:
             key = (
                 key_node.value
-                if key_node.tag == "tag:yaml.org,2002:bool"
+                if key_node.tag == self._BOOL_TAG
                 else self.construct_object(key_node, deep=deep)
             )
             mapping[key] = self.construct_object(value_node, deep=deep)

--- a/tools/system/structured_file/parse.py
+++ b/tools/system/structured_file/parse.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import yaml
 
+from tools.system.workspace_paths import WorkspacePathError, resolve_within_workspace
+
 #: Extensions this module knows how to load.
 FORMAT_BY_SUFFIX: dict[str, str] = {
     ".yml": "yaml",
@@ -77,6 +79,10 @@ class StructureError(ValueError):
 
 def load_structured_file(path: Path) -> Any:
     """Return the parsed document, chosen by suffix."""
+    try:
+        path = resolve_within_workspace(path)
+    except WorkspacePathError as exc:
+        raise StructureError(str(exc)) from exc
     file_format = FORMAT_BY_SUFFIX.get(path.suffix.lower())
     if file_format is None:
         supported = ", ".join(sorted(set(FORMAT_BY_SUFFIX)))

--- a/tools/system/workspace_paths.py
+++ b/tools/system/workspace_paths.py
@@ -29,4 +29,18 @@ def resolve_within_workspace(path: str | Path, *, workspace: Path | None = None)
     return resolved
 
 
-__all__ = ["WorkspacePathError", "resolve_within_workspace"]
+def workspace_relative(path: Path, *, workspace: Path | None = None) -> str:
+    """Render ``path`` the way the caller wrote it, relative to the workspace.
+
+    Resolving a path for safety turns it absolute; showing that back would put
+    the operator's home directory in every answer.
+    """
+    root = (workspace or Path.cwd()).resolve()
+    try:
+        relative = path.resolve().relative_to(root)
+    except ValueError:
+        return str(path)
+    return str(relative) if relative.parts else "."
+
+
+__all__ = ["WorkspacePathError", "resolve_within_workspace", "workspace_relative"]

--- a/tools/system/workspace_paths.py
+++ b/tools/system/workspace_paths.py
@@ -1,0 +1,32 @@
+"""Keep a caller-supplied path inside the directory the shell is working in.
+
+Read-only tools run without an approval gate, so a path they accept must not
+reach outside the workspace: an absolute path, a ``..`` climb, or a symlink
+used as the root would otherwise let a question about this project enumerate
+somewhere else and report what it found.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class WorkspacePathError(ValueError):
+    """The path resolves outside the working directory."""
+
+
+def resolve_within_workspace(path: str | Path, *, workspace: Path | None = None) -> Path:
+    """Return ``path`` resolved under ``workspace``, or raise.
+
+    Resolution follows symlinks first, so a link pointing outside is rejected
+    on where it lands rather than on how it is spelled.
+    """
+    root = (workspace or Path.cwd()).resolve()
+    candidate = Path(path)
+    resolved = (candidate if candidate.is_absolute() else root / candidate).resolve()
+    if resolved != root and root not in resolved.parents:
+        raise WorkspacePathError(f"{path} is outside the working directory")
+    return resolved
+
+
+__all__ = ["WorkspacePathError", "resolve_within_workspace"]


### PR DESCRIPTION
Two things, both found by running the shell.

**YAML anchors made a file unreadable** (Greptile P1 on #6165). To keep a workflow's `on:` key from being reported as `True`, #6165 gave the loader its own mapping constructor. That replaced the one PyYAML uses to expand `<<`, so any document with an anchor failed to load and the tool called the whole file invalid — including workflows that share defaults through an anchor, which is a common shape. The constructor now expands merges before reading keys. A test loads an anchored document and checks the merged key is part of the job.

**File counts counted caches.** Asked how many test files a package has, the shell answered 233, then 263 in an earlier run; there are 103. `find -type f` counts everything on disk, and a `test_*` glob also matches the compiled `.pyc` files under `__pycache__`. `count_files` counts files under a directory matching a glob and prunes generated directories (`__pycache__`, `.venv`, `venv`, `site-packages`, `node_modules`, `build`, `dist`, `.git`, and the mypy, pytest, ruff and tox caches). Symlinked directories are not followed, so a link back up the tree cannot make the count run away. The count always covers the whole tree; only the example names are capped, so it cannot repeat the truncation that caused the original wrong numbers.

The skip set follows the convention already used by the workspace scan rather than adding an ignore-file parser, since the library for that is only a transitive dependency here.

No prompt rule accompanies this. Three were tried tonight for this class of error and none could be shown to change behaviour in a live session, so the tool stands on its own

### Demo/Screenshot for feature changes and bug fixes -

Live shell, three questions, one tool call each:

    ▌ How many test files are under tests/interactive_shell?
    ⏺ count files
    Ω 103 files matching test* under tests/interactive_shell, not counting
      generated directories

    ▌ How many Python files are in surfaces/interactive_shell?
    ⏺ count files
    Ω 139 files matching *.py under surfaces/interactive_shell, not counting
      generated directories

    ▌ How many workflow files are in .github/workflows?
    ⏺ count files
    Ω 9 files matching *.yml under .github/workflows, not counting generated
      directories

All three match the repository. The first answered 233 before this change.
Note the model passed `test*`, not `test_*.py`, and still got 103: the skip
set is doing the work, not the phrasing.

Anchors, before and after, on a workflow using `<<: *defaults`:

    before: "… is not valid yaml: ConstructorError"
    after:  jobs -> 2 ('build', 'test'); jobs.build -> ('runs-on', 'steps')
