### PR TITLE
fix(skills): the scheduled-agent demo asks one declared question

### DIFF
--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
@@ -11,7 +11,7 @@ getting_started: Set up an agent that improves CI/CD reliability over time
 demo_order: 2
 metadata:
   owner: Vincent
-  last_changed_by: Vincent
+  last_changed_by: Yauhen
   last_changed_at: 2026-09-09
   usecases:
     - First-experience demo: schedule a weekday CI/CD reliability agent for one repo
@@ -28,6 +28,14 @@ tools:
   - ask_user_choice
 references:
   - common/ask_once.md
+after_tool:
+  - after: scan_local_git_workspace
+    tool: ask_user_choice
+    args:
+      title: Which repository should the agent watch?
+    options_from: local_git_scan_repos
+    options_extra:
+      - Use the open-source example repository (Tracer-Cloud/opensre)
 ---
 
 # CI/CD reliability agent
@@ -51,8 +59,7 @@ Track progress with the `update_plan` tool, not with headers or prose:
 - On entry, before the first workflow tool call, call `update_plan` with the
   steps below verbatim, the first step `in_progress`, and a one-line
   `explanation` (this is not a diagnosis; no hypothesis table):
-  `Scan this machine` / `Pick the repository` / `Pick when it runs` /
-  `Schedule the loop`.
+  `Scan this machine` / `Pick the repository` / `Schedule the loop`.
 - When the request already names the repository, omit the first two steps
   from the plan instead of renumbering.
 - After a step's tool results, call `update_plan` marking it `completed` and
@@ -71,30 +78,15 @@ what was found, using `summary` from the result.
 
 ### 2. Pick the repository
 
-From the scan result, candidates are repositories with a `github` name and
-`has_workflows` true, ordered by `commits`. Then call `ask_user_choice`
-with title `Which repository should the agent watch?` and options, in this
-order:
+The menu opens by itself after the scan: it is declared in this skill's
+frontmatter and the host runs it. Do not call `ask_user_choice` for this
+question, and do not write your own version of it. End the turn and wait; the
+answer arrives as the next user message.
 
-- up to three candidates as `<owner/repo> (<commits> commits, CI configured)`
-- `Use the open-source example repository (Tracer-Cloud/opensre)`
-
-If there are no candidates, offer only the example repository and say why.
-Wait for the answer.
-
-### 3. Pick when it runs
-
-Call `ask_user_choice` with title `When should it run?` and options:
-
-- `Weekdays at 08:00 (recommended)`
-- `Every day at 08:00`
-
-Wait for the answer.
-
-### 4. Schedule the loop
+### 3. Schedule the loop
 
 Call `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>",
-include_report=true)` for weekdays, or pass `weekdays=false` when they
-chose every day. Output `response_text` verbatim and stop. When a same-day
-report exists it comes first, then the schedule card; otherwise the card
-alone.
+include_report=true)`. The loop runs weekdays at 08:00 local time; the card
+says so and tells the user how to change it, so do not ask about the cadence.
+Output `response_text` verbatim and stop. When a same-day report exists it
+comes first, then the schedule card; otherwise the card alone.

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
@@ -87,6 +87,7 @@ answer arrives as the next user message.
 
 Call `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>",
 include_report=true)`. The loop runs weekdays at 08:00 local time; the card
-says so and tells the user how to change it, so do not ask about the cadence.
+states the schedule and how to run it at another time, so do not ask about the
+cadence.
 Output `response_text` verbatim and stop. When a same-day report exists it
 comes first, then the schedule card; otherwise the card alone.

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -181,6 +181,7 @@ def loop_card(scheduled: ScheduledLoop) -> list[str]:
         f"Runs {cadence} at {when} {task.timezone}; next run {scheduled.loop.next_run or 'pending'}.",
         "Each report lands in this shell's inbox: /loops messages. "
         f"Manage it with /loops list, /loops stop {task.id}, /loops delete {task.id}.",
+        f"To run it at another time, /loops delete {task.id} and schedule it again.",
         "It runs while the shell is open, or under `opensre cron start` when it is not.",
     ]
     return lines

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -363,3 +363,24 @@ def test_analyze_markdown_keeps_details_when_benchmarks_are_requested(
     assert "Key results" in text
     assert "Compared with" in text
     assert "Workflow" in text or "Failure classification" in text
+
+
+def test_the_card_says_how_to_run_the_loop_at_another_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The demo no longer asks about cadence, so the card has to carry it.
+
+    Listing, stopping and deleting were there; changing when it runs was not,
+    and there is no reschedule command to point at.
+    """
+    # Arrange
+    monkeypatch.setattr(
+        ci_loop, "schedule_ci_reliability_loop", lambda *_a, **_k: _scheduled_stub("acme", "app")
+    )
+
+    # Act
+    result = loop_tool.schedule_ci_reliability_loop(owner="acme", repo="app")
+
+    # Assert
+    assert "to run it at another time" in result["response_text"].lower()
+    assert "/loops delete task1" in result["response_text"]


### PR DESCRIPTION
Running all four onboarding demos on main showed demo B drifting from its own
script. The skill says to ask "When should it run?" with two options, weekdays
or daily. The live run asked:

    When should the recurring CI/CD reliability loop run for
    `deepseek-ai/deepseek-harness`?
    Weekdays at 08:00 · Weekdays at 09:00 · Daily at 08:00 · Use a custom time

The schedule that followed was correct, so nothing failed — but the demo shows
a different question each run, and a title built from the repository name is
unique every time, which defeats the guard added in #6168 that stops a question
being asked twice. That guard compares titles.

The cause is the shape of the skill: it describes its menus in prose and asks
the model to reproduce them exactly. Skill A does not — it declares both menus
in frontmatter and the host runs them, which is why the demo menu is identical
every time. Demo B now does the same:

- The repository question becomes an `after_tool` hook on
  `scan_local_git_workspace`, with `options_from: local_git_scan_repos` so the
  candidate list still comes from the scan, plus the example repository.
- The cadence question is removed. The loop schedules weekdays at 08:00, and
  the schedule card already states that and tells the user how to change it
  with `/loops`. One less step, and nothing left for the model to invent.

The body now tells the model not to call `ask_user_choice` for the repository
question and not to ask about cadence at all; the plan steps drop from four to
three to match.

### Demo/Screenshot for feature changes and bug fixes -

Live run after the change, answering the startup menu with B:

    ↳ Which repository should the agent watch?  deepseek-ai/deepseek-harness (822 commits, CI configured)
      offered: Tracer-Cloud/opensre (1588 commits, CI configured) ·
      deepseek-ai/deepseek-harness (822 commits, CI configured) ·
      YauhenBichel/py-harness (496 commits, CI configured) ·
      Use the open-source example repository (Tracer-Cloud/opensre)
    ...
    Scheduled: CI reliability check · deepseek-ai/deepseek-harness
    Runs weekdays at 08:00 Europe/London; next run 2026-09-10T07:00:00+00:00.

Cadence menus in the transcript: 1 → 0. Model-authored menus: 2 → 0.