### PR TITLE
fix(scheduler): persist successful manual task runs

### DIFF
--- a/infrastructure/scheduling/scheduler/runner.py
+++ b/infrastructure/scheduling/scheduler/runner.py
@@ -35,6 +35,7 @@ from infrastructure.scheduling.scheduler.storage import (
     complete_run,
     default_task_store_path,
     get_recoverable_runs,
+    get_runs,
     get_task,
     list_tasks,
     record_task_success,
@@ -498,7 +499,9 @@ def run_task_now(task_id: str, runners: SchedulerRunners, *, only_failed: bool =
     fire_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     result = execute_task(task, fire_time, runners, target_filter=target_filter)
     if result:
-        record_task_success(task.id)
+        run = next((run for run in get_runs(task.id) if run.fire_time == fire_time), None)
+        if run is not None and all(outcome.ok for outcome in run.targets):
+            record_task_success(task.id)
     return result
 
 

--- a/infrastructure/scheduling/scheduler/runner.py
+++ b/infrastructure/scheduling/scheduler/runner.py
@@ -496,7 +496,10 @@ def run_task_now(task_id: str, runners: SchedulerRunners, *, only_failed: bool =
             return False
 
     fire_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    return execute_task(task, fire_time, runners, target_filter=target_filter)
+    result = execute_task(task, fire_time, runners, target_filter=target_filter)
+    if result:
+        record_task_success(task.id)
+    return result
 
 
 def failed_retry_scope(task_id: str) -> frozenset[tuple[Provider, str]] | None:

--- a/tests/scheduler/test_runner.py
+++ b/tests/scheduler/test_runner.py
@@ -526,12 +526,18 @@ class TestRunTaskNow:
             "infrastructure.scheduling.scheduler.runner.get_task", lambda _task_id: task
         )
 
-        with patch("infrastructure.scheduling.scheduler.runner.execute_task") as mock_exec:
+        with (
+            patch("infrastructure.scheduling.scheduler.runner.execute_task") as mock_exec,
+            patch(
+                "infrastructure.scheduling.scheduler.runner.record_task_success"
+            ) as record_success,
+        ):
             mock_exec.return_value = True
             result = run_task_now("run_now_test", real_runners())
 
         assert result is True
         mock_exec.assert_called_once()
+        record_success.assert_called_once_with(task.id)
         # Verify fire_time has seconds (ad-hoc format) and ends with Z
         call_args = mock_exec.call_args
         fire_time = call_args[0][1]

--- a/tests/scheduler/test_runner.py
+++ b/tests/scheduler/test_runner.py
@@ -514,7 +514,25 @@ class TestRunTaskNow:
         )
         assert run_task_now("nonexistent", real_runners()) is False
 
-    def test_runs_existing_task(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize(
+        ("targets", "records_completion"),
+        [
+            ((DeliveryOutcome(provider=Provider.TELEGRAM, ok=True),), True),
+            (
+                (
+                    DeliveryOutcome(provider=Provider.TELEGRAM, ok=True),
+                    DeliveryOutcome(provider=Provider.SLACK, ok=False),
+                ),
+                False,
+            ),
+        ],
+    )
+    def test_runs_existing_task(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        targets: tuple[DeliveryOutcome, ...],
+        records_completion: bool,
+    ) -> None:
         task = ScheduledTask(
             id="run_now_test",
             kind=TaskKind.MANUAL_LOOP,
@@ -528,16 +546,28 @@ class TestRunTaskNow:
 
         with (
             patch("infrastructure.scheduling.scheduler.runner.execute_task") as mock_exec,
+            patch("infrastructure.scheduling.scheduler.runner.get_runs") as mock_runs,
             patch(
                 "infrastructure.scheduling.scheduler.runner.record_task_success"
             ) as record_success,
         ):
             mock_exec.return_value = True
+            mock_runs.side_effect = lambda _task_id: [
+                TaskRun(
+                    task_id=task.id,
+                    fire_time=mock_exec.call_args.args[1],
+                    status=TaskStatus.SUCCESS,
+                    targets=targets,
+                )
+            ]
             result = run_task_now("run_now_test", real_runners())
 
         assert result is True
         mock_exec.assert_called_once()
-        record_success.assert_called_once_with(task.id)
+        if records_completion:
+            record_success.assert_called_once_with(task.id)
+        else:
+            record_success.assert_not_called()
         # Verify fire_time has seconds (ad-hoc format) and ends with Z
         call_args = mock_exec.call_args
         fire_time = call_args[0][1]


### PR DESCRIPTION
 Fixes #6170

  #### Describe the changes you have made in this PR -

  Manual `cron run` and `/loops run` executions now persist task completion state after a successful delivery.

  - Call `record_task_success(task.id)` after `run_task_now()` succeeds.
  - This updates `last_run` and honors `disable_after_success=true`, matching scheduled and recovered task execution.
  - Add a regression test confirming successful ad-hoc runs invoke the task-state updater.

  
  Explain your implementation approach:

  run_task_now() already delegates execution and delivery to execute_task(), but it returned immediately after success. Scheduled and recovery paths additionally call
  record_task_success(), which owns task-level state updates such as last_run and disable_after_success.

  I kept the behavior aligned with those existing paths: after a successful manual execution, call record_task_success(task.id) and return the execution result unchanged.
  Failed or refused manual runs do not update completion state.

  The regression test mocks a successful execution and asserts that the task-state updater is called with the correct task ID.

 