### PR TITLE
feat(scheduler): add scheduler DB indexes and recovery capacity baseline  

### DIFF
--- a/docs/benchmarks/scheduler-capacity-baseline.json
+++ b/docs/benchmarks/scheduler-capacity-baseline.json
@@ -1,0 +1,243 @@
+{
+  "generated_at": "2026-09-10T12:42:46.848526+00:00",
+  "git_revision": "1a9ce46eb3550028666c832fe12d7a351fa12368",
+  "machine": {
+    "cpu_count": 9,
+    "machine": "x86_64",
+    "platform": "Linux-6.18.35-x86_64-with-glibc2.39",
+    "processor": "x86_64",
+    "python": "3.12.14",
+    "python_implementation": "CPython",
+    "sqlite": "3.53.1"
+  },
+  "metrics": {
+    "burst": [
+      {
+        "admitted_runs": 10,
+        "burst_size": 10,
+        "completed_runs": 10,
+        "drain_seconds": 0.06061075600064214,
+        "peak_in_memory_callbacks": 10,
+        "pending_after_admission": {
+          "count": 10,
+          "oldest_admission_at": "2026-09-10T12:42:46.872090+00:00",
+          "oldest_pending_age_seconds": 0.007756
+        },
+        "rss": {
+          "current_rss_bytes": 31084544,
+          "peak_rss_bytes": 31084544
+        },
+        "sqlite_lock_failures": 0,
+        "throughput_per_second": 164.98721777854172
+      },
+      {
+        "admitted_runs": 100,
+        "burst_size": 100,
+        "completed_runs": 100,
+        "drain_seconds": 0.5803501650007092,
+        "peak_in_memory_callbacks": 100,
+        "pending_after_admission": {
+          "count": 100,
+          "oldest_admission_at": "2026-09-10T12:42:46.938954+00:00",
+          "oldest_pending_age_seconds": 0.048045
+        },
+        "rss": {
+          "current_rss_bytes": 31428608,
+          "peak_rss_bytes": 31428608
+        },
+        "sqlite_lock_failures": 0,
+        "throughput_per_second": 172.30976405404795
+      },
+      {
+        "admitted_runs": 1000,
+        "burst_size": 1000,
+        "completed_runs": 1000,
+        "drain_seconds": 5.993895582999357,
+        "peak_in_memory_callbacks": 1000,
+        "pending_after_admission": {
+          "count": 1000,
+          "oldest_admission_at": "2026-09-10T12:42:47.565416+00:00",
+          "oldest_pending_age_seconds": 0.445672
+        },
+        "rss": {
+          "current_rss_bytes": 33382400,
+          "peak_rss_bytes": 33382400
+        },
+        "sqlite_lock_failures": 0,
+        "throughput_per_second": 166.83640649936012
+      }
+    ],
+    "history": [
+      {
+        "completed_history_rows": 10000,
+        "expected_pending_task_id": "history-pending-10000-0",
+        "query_plan": [
+          "CO-ROUTINE recovery_candidates",
+          "COMPOUND QUERY",
+          "LEFT-MOST SUBQUERY",
+          "SCAN task_runs USING COVERING INDEX idx_task_runs_recovery_pending_order",
+          "LIST SUBQUERY 4",
+          "SCAN json_each VIRTUAL TABLE INDEX 1:",
+          "CREATE BLOOM FILTER",
+          "UNION ALL",
+          "SEARCH task_runs USING COVERING INDEX idx_task_runs_recovery_expired (lease_expires_at<?)",
+          "REUSE LIST SUBQUERY 4",
+          "SCAN current",
+          "REUSE LIST SUBQUERY 4",
+          "CORRELATED SCALAR SUBQUERY 3",
+          "SEARCH live USING COVERING INDEX idx_task_runs_live_owner (task_id=? AND lease_expires_at>?)",
+          "CORRELATED SCALAR SUBQUERY 5",
+          "SEARCH latest USING COVERING INDEX sqlite_autoindex_task_runs_1 (task_id=? AND fire_time=?)",
+          "USE TEMP B-TREE FOR ORDER BY"
+        ],
+        "recoverable_run_count": 2,
+        "recovery_query_seconds": 0.0008965700008047861,
+        "rss": {
+          "current_rss_bytes": 33480704,
+          "peak_rss_bytes": 34394112
+        }
+      },
+      {
+        "completed_history_rows": 100000,
+        "expected_pending_task_id": "history-pending-100000-0",
+        "query_plan": [
+          "CO-ROUTINE recovery_candidates",
+          "COMPOUND QUERY",
+          "LEFT-MOST SUBQUERY",
+          "SCAN task_runs USING COVERING INDEX idx_task_runs_recovery_pending_order",
+          "LIST SUBQUERY 4",
+          "SCAN json_each VIRTUAL TABLE INDEX 1:",
+          "CREATE BLOOM FILTER",
+          "UNION ALL",
+          "SEARCH task_runs USING COVERING INDEX idx_task_runs_recovery_expired (lease_expires_at<?)",
+          "REUSE LIST SUBQUERY 4",
+          "SCAN current",
+          "REUSE LIST SUBQUERY 4",
+          "CORRELATED SCALAR SUBQUERY 3",
+          "SEARCH live USING COVERING INDEX idx_task_runs_live_owner (task_id=? AND lease_expires_at>?)",
+          "CORRELATED SCALAR SUBQUERY 5",
+          "SEARCH latest USING COVERING INDEX sqlite_autoindex_task_runs_1 (task_id=? AND fire_time=?)",
+          "USE TEMP B-TREE FOR ORDER BY"
+        ],
+        "recoverable_run_count": 2,
+        "recovery_query_seconds": 0.0005864319991815137,
+        "rss": {
+          "current_rss_bytes": 33484800,
+          "peak_rss_bytes": 35057664
+        }
+      }
+    ],
+    "restart_recovery": {
+      "peak_in_memory_callbacks": 1,
+      "pending_before_restart_recovery": {
+        "count": 100,
+        "oldest_admission_at": "2026-09-10T12:42:58.619394+00:00",
+        "oldest_pending_age_seconds": 0.04558
+      },
+      "recovered_runs": 100,
+      "recovery_callback_count": 1,
+      "restart_recovery_drain_seconds": 1.146900015999563,
+      "restart_recovery_query_seconds": 0.0008375420002266765,
+      "restart_recovery_total_seconds": 1.1478088359999674,
+      "rss": {
+        "current_rss_bytes": 33484800,
+        "peak_rss_bytes": 35057664
+      },
+      "sqlite_lock_failures": 0,
+      "throughput_per_second": 87.19155864066018
+    },
+    "sustained": [
+      {
+        "admission_seconds": 0.9910689340003955,
+        "admitted_runs": 100,
+        "completed_runs": 100,
+        "drain_seconds": 0.011260401999606984,
+        "load": "below_capacity",
+        "observed_arrival_rate_per_second": 100.90115487361254,
+        "peak_in_memory_callbacks": 2,
+        "pending_after_admission": {
+          "count": 1,
+          "oldest_admission_at": "2026-09-10T12:42:54.988166+00:00",
+          "oldest_pending_age_seconds": 0.002933
+        },
+        "requested_arrival_rate_per_second": 100.0,
+        "rss": {
+          "current_rss_bytes": 33382400,
+          "peak_rss_bytes": 33382400
+        },
+        "sqlite_lock_failures": 0,
+        "sustained_duration_seconds": 1.0,
+        "throughput_per_second": 99.56932116550517,
+        "total_seconds": 1.004325417000473
+      },
+      {
+        "admission_seconds": 0.9956181099996684,
+        "admitted_runs": 200,
+        "completed_runs": 200,
+        "drain_seconds": 0.21487613000044803,
+        "load": "at_capacity",
+        "observed_arrival_rate_per_second": 200.8802350934201,
+        "peak_in_memory_callbacks": 36,
+        "pending_after_admission": {
+          "count": 34,
+          "oldest_admission_at": "2026-09-10T12:42:55.832735+00:00",
+          "oldest_pending_age_seconds": 0.165945
+        },
+        "requested_arrival_rate_per_second": 200.0,
+        "rss": {
+          "current_rss_bytes": 33382400,
+          "peak_rss_bytes": 33382400
+        },
+        "sqlite_lock_failures": 0,
+        "sustained_duration_seconds": 1.0,
+        "throughput_per_second": 165.16067465479256,
+        "total_seconds": 1.2109420139995564
+      },
+      {
+        "admission_seconds": 1.0004871990004176,
+        "admitted_runs": 300,
+        "completed_runs": 300,
+        "drain_seconds": 0.8799290340002699,
+        "load": "above_capacity",
+        "observed_arrival_rate_per_second": 299.8539114740585,
+        "peak_in_memory_callbacks": 142,
+        "pending_after_admission": {
+          "count": 140,
+          "oldest_admission_at": "2026-09-10T12:42:56.747411+00:00",
+          "oldest_pending_age_seconds": 0.467445
+        },
+        "requested_arrival_rate_per_second": 300.0,
+        "rss": {
+          "current_rss_bytes": 33382400,
+          "peak_rss_bytes": 33382400
+        },
+        "sqlite_lock_failures": 0,
+        "sustained_duration_seconds": 1.0,
+        "throughput_per_second": 159.5063896549912,
+        "total_seconds": 1.8808023970004797
+      }
+    ]
+  },
+  "scheduler_config": {
+    "ideal_fake_completion_capacity_per_second": 200.0,
+    "max_concurrent_runs": 2,
+    "shared_turn_gate": "not exercised by the fake runner"
+  },
+  "schema_version": 1,
+  "working_tree_dirty": false,
+  "workload": {
+    "burst_sizes": [
+      10,
+      100,
+      1000
+    ],
+    "concurrency": 2,
+    "fake_delivery_seconds": 0.01,
+    "history_sizes": [
+      10000,
+      100000
+    ],
+    "restart_backlog_size": 100,
+    "sustained_seconds": 1.0
+  }
+}

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -205,6 +205,58 @@ crashes. A crash after an external provider accepts a message but before the
 completion is recorded can still result in a duplicate on reclaim; preventing
 that case requires provider-specific idempotency support.
 
+## Capacity and overload
+
+Each admitted cron tick is first written as a durable `pending` row in
+`scheduler.db`. It is not silently dropped because workers are busy. The
+default scheduler concurrency remains **2**; a scheduled agent turn also needs
+a permit from the shared process turn gate, so the effective agent-turn
+concurrency can be lower.
+
+The current scheduler bounds active workers, but its executor can still retain
+more submitted callbacks in memory while those workers are busy. A large burst
+therefore remains recoverable from SQLite, but is not yet a bounded in-memory
+queue. Use the baseline below to size an installation rather than raising the
+default to absorb a burst. A later scheduler change will move overflow to the
+durable pending store and reserve recovery control work from user execution.
+
+| Boundary | Owns | Does not own |
+| --- | --- | --- |
+| Task store | Task definitions and enabled state | Execution history |
+| Run store | Durable admissions, claims, leases, recovery candidates, and completion fencing | Worker scheduling |
+| Scheduler runner | Cron submission, recovery sweep, and task lookup | LLM or provider delivery |
+| Scheduler executor | The currently submitted worker callbacks | Durable recovery state |
+| Shared turn gate | Process-wide concurrent agent turns | Scheduler admission or persistence |
+
+The capacity baseline records these terms consistently:
+
+- **Durable pending count** and **oldest pending age**: `pending` rows and the
+  elapsed time since their durable admission. The benchmark reads this directly
+  until `opensre cron status` exposes it.
+- **In-memory callbacks**: callbacks submitted to the current worker executor
+  that have not completed. This is the current overload signal, not a durable
+  queue limit.
+- **Throughput and drain time**: successful fake deliveries per second and the
+  elapsed time to finish admitted work.
+- **Recovery query latency and plan**: time and SQLite plan used to find
+  pending or expired work. Completed history must not expand the candidate
+  scan.
+- **SQLite lock failures** and **RSS**: lock errors plus current and peak
+  process resident memory sampled by the benchmark host.
+
+Run the deterministic baseline before changing
+`OPENSRE_SCHEDULER_MAX_CONCURRENT_RUNS`:
+
+```bash
+uv run python -m tests.benchmarks.scheduler.capacity_benchmark
+```
+
+It makes no LLM, provider, or network calls. The checked-in JSON report at
+`docs/benchmarks/scheduler-capacity-baseline.json` records the exact workload,
+host metadata, SQLite version, and observed values. Restart recovery uses the
+production shape: one recovery callback iterates its durable candidates
+serially.
+
 ## Credential Resolution
 
 Credentials are resolved lazily at delivery time in this priority order:

--- a/infrastructure/scheduling/scheduler/storage/migrations.py
+++ b/infrastructure/scheduling/scheduler/storage/migrations.py
@@ -30,6 +30,29 @@ _TASK_RUNS_SCHEMA = """
     )
 """
 
+_REQUIRED_COLUMNS = frozenset({"attempt", "targets", "target_filter"})
+
+# Recovery only considers pending work and expired running attempts. Keeping the
+# indexes partial prevents completed history from growing either candidate set.
+_RECOVERY_INDEX_STATEMENTS = (
+    "CREATE INDEX IF NOT EXISTS idx_task_runs_recovery_pending_order "
+    "ON task_runs (started_at, task_id, fire_time, attempt) "
+    "WHERE status = 'pending'",
+    "CREATE INDEX IF NOT EXISTS idx_task_runs_recovery_expired "
+    "ON task_runs (lease_expires_at, started_at, task_id, fire_time, attempt) "
+    "WHERE status = 'running' AND lease_expires_at != ''",
+    "CREATE INDEX IF NOT EXISTS idx_task_runs_live_owner "
+    "ON task_runs (task_id, lease_expires_at) "
+    "WHERE status = 'running'",
+)
+_RECOVERY_INDEX_NAMES = frozenset(
+    {
+        "idx_task_runs_recovery_pending_order",
+        "idx_task_runs_recovery_expired",
+        "idx_task_runs_live_owner",
+    }
+)
+
 
 def _table_columns(conn: sqlite3.Connection, table: str = "task_runs") -> set[str]:
     return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
@@ -37,6 +60,15 @@ def _table_columns(conn: sqlite3.Connection, table: str = "task_runs") -> set[st
 
 def _has_targets_column(conn: sqlite3.Connection) -> bool:
     return "targets" in _table_columns(conn)
+
+
+def _index_names(conn: sqlite3.Connection, table: str = "task_runs") -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA index_list({table})")}
+
+
+def _schema_is_current(conn: sqlite3.Connection) -> bool:
+    """Whether columns and recovery indexes already meet the current contract."""
+    return _table_columns(conn) >= _REQUIRED_COLUMNS and _index_names(conn) >= _RECOVERY_INDEX_NAMES
 
 
 def _migrate_legacy_claim_table(conn: sqlite3.Connection, legacy_columns: set[str]) -> None:
@@ -89,14 +121,52 @@ def _add_missing_columns(conn: sqlite3.Connection) -> None:
             return
 
 
+def _add_recovery_indexes(conn: sqlite3.Connection) -> None:
+    """Create the partial indexes used by recovery and live-owner lookups."""
+    for statement in _RECOVERY_INDEX_STATEMENTS:
+        conn.execute(statement)
+
+
+def _begin_migration_transaction(conn: sqlite3.Connection) -> bool:
+    """Acquire the migration write lock, tolerating a competing index build.
+
+    Creating an index can take longer than SQLite's regular ``busy_timeout``
+    on a database with substantial completed-run history. A second scheduler
+    process must wait for that migration to commit, then recheck the schema,
+    rather than failing its startup just because its first ``BEGIN IMMEDIATE``
+    timed out.
+
+    Returns ``False`` when the competing process completed the migration while
+    this process was waiting, so the caller has no transaction to commit.
+    """
+    deadline = time.monotonic() + _MIGRATION_TIMEOUT_SECONDS
+    while True:
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError as exc:
+            error = str(exc).lower()
+            if "locked" not in error and "busy" not in error:
+                raise
+            if _schema_is_current(conn):
+                return False
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(_MIGRATION_RETRY_DELAY_SECONDS)
+        else:
+            return True
+
+
 def apply_migrations(conn: sqlite3.Connection) -> None:
     """Create or migrate the task-runs schema under one SQLite write lock."""
-    columns = _table_columns(conn)
-    if {"attempt", "targets", "target_filter"} <= columns:
+    if _schema_is_current(conn):
         return
 
-    conn.execute("BEGIN IMMEDIATE")
+    if not _begin_migration_transaction(conn):
+        return
     try:
+        if _schema_is_current(conn):
+            conn.commit()
+            return
         columns = _table_columns(conn)
         if not columns:
             conn.execute(_TASK_RUNS_SCHEMA)
@@ -109,6 +179,7 @@ def apply_migrations(conn: sqlite3.Connection) -> None:
             conn.execute(
                 "ALTER TABLE task_runs ADD COLUMN target_filter TEXT NOT NULL DEFAULT '[]'"
             )
+        _add_recovery_indexes(conn)
         conn.commit()
     except Exception:
         conn.rollback()

--- a/infrastructure/scheduling/scheduler/storage/run_store.py
+++ b/infrastructure/scheduling/scheduler/storage/run_store.py
@@ -28,6 +28,35 @@ _RUN_COLUMNS = (
     "task_id, fire_time, started_at, finished_at, status, posted_message_id, "
     "error, provider, targets, attempt"
 )
+_RECOVERABLE_RUNS_QUERY = """
+    WITH recovery_candidates AS (
+        SELECT task_id, fire_time, attempt, started_at
+        FROM task_runs
+        WHERE status = ?
+        UNION ALL
+        SELECT task_id, fire_time, attempt, started_at
+        FROM task_runs
+        WHERE status = ? AND lease_expires_at != '' AND lease_expires_at < ?
+    )
+    SELECT current.task_id, current.fire_time
+    FROM recovery_candidates AS current
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM task_runs AS live
+        WHERE live.task_id = current.task_id
+        AND live.status = ?
+        AND live.lease_expires_at >= ?
+    )
+    AND (? IS NULL OR current.task_id IN (SELECT value FROM json_each(?)))
+    AND current.attempt = (
+        SELECT MAX(latest.attempt)
+        FROM task_runs AS latest
+        WHERE latest.task_id = current.task_id
+        AND latest.fire_time = current.fire_time
+    )
+    ORDER BY current.started_at, current.task_id, current.fire_time
+    LIMIT ?
+"""
 
 
 @dataclass(frozen=True, slots=True)
@@ -226,17 +255,7 @@ def get_recoverable_runs(
     with database.connection(db_path) as conn:
         now_text = datetime.now(UTC).isoformat()
         rows = conn.execute(
-            "SELECT task_id, fire_time FROM task_runs AS current "
-            "WHERE (current.status = ? OR (current.status = ? "
-            "AND current.lease_expires_at != '' AND current.lease_expires_at < ?)) "
-            "AND NOT EXISTS (SELECT 1 FROM task_runs AS live "
-            "WHERE live.task_id = current.task_id AND live.status = ? "
-            "AND live.lease_expires_at >= ?) "
-            "AND (? IS NULL OR current.task_id IN (SELECT value FROM json_each(?))) "
-            "AND current.attempt = (SELECT MAX(latest.attempt) FROM task_runs AS latest "
-            "WHERE latest.task_id = current.task_id "
-            "AND latest.fire_time = current.fire_time) "
-            "ORDER BY current.started_at, current.task_id, current.fire_time LIMIT ?",
+            _RECOVERABLE_RUNS_QUERY,
             (
                 TaskStatus.PENDING.value,
                 TaskStatus.RUNNING.value,

--- a/tests/benchmarks/scheduler/__init__.py
+++ b/tests/benchmarks/scheduler/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic scheduler capacity benchmark scenarios."""
+
+# This package only provides an executable benchmark module; it has no stable
+# package-level API to export.
+__all__: list[str] = []

--- a/tests/benchmarks/scheduler/capacity_benchmark.py
+++ b/tests/benchmarks/scheduler/capacity_benchmark.py
@@ -1,0 +1,588 @@
+"""Measure the scheduler's durable-run and executor-queue capacity baseline.
+
+Run from the repository root:
+
+    uv run python -m tests.benchmarks.scheduler.capacity_benchmark
+
+The workload uses a fake task runner and delivery sink. It deliberately makes
+no LLM, network, or provider calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import Event, Lock
+from typing import Any
+
+import infrastructure.scheduling.scheduler.storage.run_store as run_store
+from config.constants import DEFAULT_SCHEDULED_RUN_CONCURRENCY
+from infrastructure.scheduling.scheduler.storage import (
+    complete_run,
+    database,
+    get_recoverable_runs,
+    try_claim,
+    try_queue_run,
+)
+from infrastructure.scheduling.scheduler.types import TaskStatus
+
+REPORT_SCHEMA_VERSION = 1
+DEFAULT_REPORT_PATH = Path("docs/benchmarks/scheduler-capacity-baseline.json")
+_REFERENCE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
+_EXPIRED_LEASE = "2020-01-01T00:00:00+00:00"
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkConfig:
+    """Fixed workload parameters for one capacity-baseline run."""
+
+    concurrency: int = DEFAULT_SCHEDULED_RUN_CONCURRENCY
+    fake_delivery_seconds: float = 0.01
+    burst_sizes: tuple[int, ...] = (10, 100, 1_000)
+    sustained_seconds: float = 1.0
+    history_sizes: tuple[int, ...] = (10_000, 100_000)
+    restart_backlog_size: int = 100
+
+    @property
+    def completion_capacity_per_second(self) -> float:
+        """The fake runner's ideal completion capacity before storage overhead."""
+        return self.concurrency / self.fake_delivery_seconds
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkItem:
+    task_id: str
+    fire_time: str
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingSnapshot:
+    count: int
+    oldest_admission_at: str | None
+    oldest_pending_age_seconds: float | None
+
+
+class _CallbackTracker:
+    """Account for submitted callbacks without reading executor internals."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._submitted = 0
+        self._finished = 0
+        self._peak_in_memory_callbacks = 0
+
+    def submitted(self) -> None:
+        """Record an executor callback admitted by the harness."""
+        with self._lock:
+            self._submitted += 1
+            self._peak_in_memory_callbacks = max(
+                self._peak_in_memory_callbacks,
+                self._submitted - self._finished,
+            )
+
+    def finished(self) -> None:
+        """Record a callback that left the executor queue or worker."""
+        with self._lock:
+            self._finished += 1
+
+    def peak_in_memory_callbacks(self) -> int:
+        """Return the largest submitted-but-unfinished callback count."""
+        with self._lock:
+            return self._peak_in_memory_callbacks
+
+
+class _FakeDelivery:
+    """A deterministic delivery sink that represents no external provider."""
+
+    def __init__(self, duration_seconds: float, start_gate: Event | None = None) -> None:
+        self._duration_seconds = duration_seconds
+        self._start_gate = start_gate
+
+    def deliver(self) -> None:
+        """Wait for the optional burst gate, then consume a fixed duration."""
+        if self._start_gate is not None:
+            self._start_gate.wait()
+        time.sleep(self._duration_seconds)
+
+
+class _FakeRunner:
+    """Exercise durable claims and completion around the fake delivery sink."""
+
+    def __init__(self, db_path: Path, delivery: _FakeDelivery) -> None:
+        self._db_path = db_path
+        self._delivery = delivery
+        self._lock = Lock()
+        self._sqlite_lock_failures = 0
+
+    def run(self, item: _WorkItem) -> bool:
+        """Claim, fake-deliver, and fence-complete one distinct scheduled tick."""
+        try:
+            claim = try_claim(item.task_id, item.fire_time, db_path=self._db_path)
+            if claim is None:
+                return False
+            self._delivery.deliver()
+            return complete_run(claim, status=TaskStatus.SUCCESS, db_path=self._db_path)
+        except sqlite3.OperationalError as exc:
+            if "locked" in str(exc).lower():
+                with self._lock:
+                    self._sqlite_lock_failures += 1
+            raise
+
+    def sqlite_lock_failures(self) -> int:
+        """Return lock errors observed while claiming or completing fake work."""
+        with self._lock:
+            return self._sqlite_lock_failures
+
+
+def _current_rss_bytes() -> int | None:
+    """Return process RSS when the host exposes it without a new dependency."""
+    if sys.platform.startswith("linux"):
+        try:
+            resident_pages = int((Path("/proc/self/statm").read_text().split())[1])
+            return resident_pages * os.sysconf("SC_PAGE_SIZE")
+        except (IndexError, OSError, ValueError):
+            return None
+    if sys.platform == "darwin":
+        result = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(os.getpid())],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        try:
+            return int(result.stdout.strip()) * 1024
+        except ValueError:
+            return None
+    return None
+
+
+def _peak_rss_bytes() -> int | None:
+    """Return peak RSS when supported by the standard library."""
+    try:
+        import resource
+    except ImportError:
+        return None
+    maximum = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return int(maximum) if sys.platform == "darwin" else int(maximum) * 1024
+
+
+def _rss_sample() -> dict[str, int | None]:
+    current = _current_rss_bytes()
+    peak = _peak_rss_bytes()
+    if current is not None:
+        peak = current if peak is None else max(current, peak)
+    return {
+        "current_rss_bytes": current,
+        "peak_rss_bytes": peak,
+    }
+
+
+def _pending_snapshot(db_path: Path) -> _PendingSnapshot:
+    with database.connection(db_path) as conn:
+        count, oldest = conn.execute(
+            "SELECT COUNT(*), MIN(started_at) FROM task_runs WHERE status = ?",
+            (TaskStatus.PENDING.value,),
+        ).fetchone()
+    oldest_text = str(oldest) if oldest else None
+    if oldest_text is None:
+        return _PendingSnapshot(
+            count=int(count), oldest_admission_at=None, oldest_pending_age_seconds=None
+        )
+    oldest_at = datetime.fromisoformat(oldest_text)
+    if oldest_at.tzinfo is None:
+        oldest_at = oldest_at.replace(tzinfo=UTC)
+    age = max(0.0, (datetime.now(UTC) - oldest_at.astimezone(UTC)).total_seconds())
+    return _PendingSnapshot(
+        count=int(count),
+        oldest_admission_at=oldest_text,
+        oldest_pending_age_seconds=age,
+    )
+
+
+def _queue_items(db_path: Path, prefix: str, count: int) -> list[_WorkItem]:
+    items: list[_WorkItem] = []
+    for index in range(count):
+        item = _WorkItem(task_id=f"{prefix}-{index}", fire_time="2026-01-01T00:00Z")
+        if not try_queue_run(item.task_id, item.fire_time, db_path=db_path):
+            raise RuntimeError(f"benchmark tick unexpectedly already exists: {item.task_id}")
+        items.append(item)
+    return items
+
+
+def _submit_batch(
+    items: Sequence[_WorkItem],
+    *,
+    db_path: Path,
+    config: BenchmarkConfig,
+    hold_until_submitted: bool,
+) -> dict[str, Any]:
+    tracker = _CallbackTracker()
+    release = Event() if hold_until_submitted else None
+    runner = _FakeRunner(
+        db_path,
+        _FakeDelivery(config.fake_delivery_seconds, start_gate=release),
+    )
+    started_at = time.perf_counter()
+
+    def _run_and_track(item: _WorkItem) -> bool:
+        try:
+            return runner.run(item)
+        finally:
+            tracker.finished()
+
+    with ThreadPoolExecutor(max_workers=config.concurrency) as executor:
+        futures: list[Future[bool]] = []
+        for item in items:
+            tracker.submitted()
+            futures.append(executor.submit(_run_and_track, item))
+        pending_after_admission = _pending_snapshot(db_path)
+        if release is not None:
+            release.set()
+        completed = sum(future.result() for future in futures)
+
+    elapsed = time.perf_counter() - started_at
+    return {
+        "admitted_runs": len(items),
+        "completed_runs": completed,
+        "peak_in_memory_callbacks": tracker.peak_in_memory_callbacks(),
+        "pending_after_admission": asdict(pending_after_admission),
+        "drain_seconds": elapsed,
+        "throughput_per_second": completed / elapsed if elapsed else 0.0,
+        "sqlite_lock_failures": runner.sqlite_lock_failures(),
+        "rss": _rss_sample(),
+    }
+
+
+def _run_bursts(db_path: Path, config: BenchmarkConfig) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for size in config.burst_sizes:
+        items = _queue_items(db_path, f"burst-{size}", size)
+        result = _submit_batch(
+            items,
+            db_path=db_path,
+            config=config,
+            hold_until_submitted=True,
+        )
+        result["burst_size"] = size
+        results.append(result)
+    return results
+
+
+def _run_sustained_loads(db_path: Path, config: BenchmarkConfig) -> list[dict[str, Any]]:
+    rates = (
+        ("below_capacity", config.completion_capacity_per_second * 0.5),
+        ("at_capacity", config.completion_capacity_per_second),
+        ("above_capacity", config.completion_capacity_per_second * 1.5),
+    )
+    results: list[dict[str, Any]] = []
+    for label, rate in rates:
+        count = max(1, round(rate * config.sustained_seconds))
+        result = _submit_sustained(
+            prefix=f"sustained-{label}",
+            count=count,
+            arrival_rate_per_second=rate,
+            db_path=db_path,
+            config=config,
+        )
+        result.update(
+            {
+                "load": label,
+                "requested_arrival_rate_per_second": rate,
+                "sustained_duration_seconds": config.sustained_seconds,
+            }
+        )
+        results.append(result)
+    return results
+
+
+def _submit_sustained(
+    *,
+    prefix: str,
+    count: int,
+    arrival_rate_per_second: float,
+    db_path: Path,
+    config: BenchmarkConfig,
+) -> dict[str, Any]:
+    """Admit a fixed-rate stream while the fake workers continue draining it."""
+    tracker = _CallbackTracker()
+    runner = _FakeRunner(db_path, _FakeDelivery(config.fake_delivery_seconds))
+    started_at = time.perf_counter()
+
+    def _run_and_track(item: _WorkItem) -> bool:
+        try:
+            return runner.run(item)
+        finally:
+            tracker.finished()
+
+    with ThreadPoolExecutor(max_workers=config.concurrency) as executor:
+        futures: list[Future[bool]] = []
+        for index in range(count):
+            target_admission_at = started_at + (index / arrival_rate_per_second)
+            sleep_seconds = target_admission_at - time.perf_counter()
+            if sleep_seconds > 0:
+                time.sleep(sleep_seconds)
+            item = _WorkItem(task_id=f"{prefix}-{index}", fire_time="2026-01-01T00:00Z")
+            if not try_queue_run(item.task_id, item.fire_time, db_path=db_path):
+                raise RuntimeError(f"benchmark tick unexpectedly already exists: {item.task_id}")
+            tracker.submitted()
+            futures.append(executor.submit(_run_and_track, item))
+        admission_seconds = time.perf_counter() - started_at
+        pending_after_admission = _pending_snapshot(db_path)
+        drain_started_at = time.perf_counter()
+        completed = sum(future.result() for future in futures)
+
+    drain_seconds = time.perf_counter() - drain_started_at
+    total_seconds = time.perf_counter() - started_at
+    return {
+        "admitted_runs": count,
+        "completed_runs": completed,
+        "admission_seconds": admission_seconds,
+        "observed_arrival_rate_per_second": count / admission_seconds if admission_seconds else 0.0,
+        "peak_in_memory_callbacks": tracker.peak_in_memory_callbacks(),
+        "pending_after_admission": asdict(pending_after_admission),
+        "drain_seconds": drain_seconds,
+        "total_seconds": total_seconds,
+        "throughput_per_second": completed / total_seconds if total_seconds else 0.0,
+        "sqlite_lock_failures": runner.sqlite_lock_failures(),
+        "rss": _rss_sample(),
+    }
+
+
+def _seed_completed_history(db_path: Path, size: int) -> None:
+    rows = (
+        (
+            f"history-{size}-{index}",
+            "2026-01-01T00:00Z",
+            (_REFERENCE_TIME + (index * (datetime.resolution * 1_000))).isoformat(),
+            TaskStatus.SUCCESS.value,
+        )
+        for index in range(size)
+    )
+    with database.transaction(db_path, immediate=True) as conn:
+        conn.executemany(
+            "INSERT INTO task_runs (task_id, fire_time, started_at, status) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _recovery_query_arguments(now: str, limit: int) -> tuple[str | None | int, ...]:
+    return (
+        TaskStatus.PENDING.value,
+        TaskStatus.RUNNING.value,
+        now,
+        TaskStatus.RUNNING.value,
+        now,
+        None,
+        None,
+        limit,
+    )
+
+
+def _run_history_query_benchmarks(config: BenchmarkConfig) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for size in config.history_sizes:
+        with tempfile.TemporaryDirectory(prefix="opensre-scheduler-history-") as directory:
+            db_path = Path(directory) / "scheduler.db"
+            _seed_completed_history(db_path, size)
+            pending = _queue_items(db_path, f"history-pending-{size}", 1)
+            with database.transaction(db_path, immediate=True) as conn:
+                conn.execute(
+                    "INSERT INTO task_runs "
+                    "(task_id, fire_time, started_at, status, lease_expires_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        f"history-expired-{size}",
+                        "2026-01-01T00:00Z",
+                        _REFERENCE_TIME.isoformat(),
+                        TaskStatus.RUNNING.value,
+                        _EXPIRED_LEASE,
+                    ),
+                )
+            now = datetime.now(UTC).isoformat()
+            query_started_at = time.perf_counter()
+            recoverable = get_recoverable_runs(db_path=db_path)
+            query_seconds = time.perf_counter() - query_started_at
+            with database.connection(db_path) as conn:
+                query_plan = [
+                    str(row[3])
+                    for row in conn.execute(
+                        f"EXPLAIN QUERY PLAN {run_store._RECOVERABLE_RUNS_QUERY}",
+                        _recovery_query_arguments(now, limit=100),
+                    )
+                ]
+            results.append(
+                {
+                    "completed_history_rows": size,
+                    "recovery_query_seconds": query_seconds,
+                    "recoverable_run_count": len(recoverable),
+                    "expected_pending_task_id": pending[0].task_id,
+                    "query_plan": query_plan,
+                    "rss": _rss_sample(),
+                }
+            )
+    return results
+
+
+def _run_restart_recovery(db_path: Path, config: BenchmarkConfig) -> dict[str, Any]:
+    _queue_items(db_path, "restart", config.restart_backlog_size)
+    before_recovery = _pending_snapshot(db_path)
+    started_at = time.perf_counter()
+    recoverable = get_recoverable_runs(limit=config.restart_backlog_size, db_path=db_path)
+    query_seconds = time.perf_counter() - started_at
+    recovered_items = [
+        _WorkItem(task_id=run.task_id, fire_time=run.fire_time) for run in recoverable
+    ]
+    drain = _run_serial_recovery(
+        recovered_items,
+        db_path=db_path,
+        config=config,
+    )
+    return {
+        "pending_before_restart_recovery": asdict(before_recovery),
+        "restart_recovery_query_seconds": query_seconds,
+        "restart_recovery_drain_seconds": drain["drain_seconds"],
+        "restart_recovery_total_seconds": time.perf_counter() - started_at,
+        "recovered_runs": len(recovered_items),
+        "recovery_callback_count": drain["callback_count"],
+        "peak_in_memory_callbacks": drain["peak_in_memory_callbacks"],
+        "throughput_per_second": drain["throughput_per_second"],
+        "sqlite_lock_failures": drain["sqlite_lock_failures"],
+        "rss": _rss_sample(),
+    }
+
+
+def _run_serial_recovery(
+    items: Sequence[_WorkItem],
+    *,
+    db_path: Path,
+    config: BenchmarkConfig,
+) -> dict[str, Any]:
+    """Mirror the runner's one-callback, serial restart recovery loop."""
+    tracker = _CallbackTracker()
+    runner = _FakeRunner(db_path, _FakeDelivery(config.fake_delivery_seconds))
+    started_at = time.perf_counter()
+    tracker.submitted()
+    try:
+        completed = sum(runner.run(item) for item in items)
+    finally:
+        tracker.finished()
+    elapsed = time.perf_counter() - started_at
+    return {
+        "callback_count": 1,
+        "completed_runs": completed,
+        "peak_in_memory_callbacks": tracker.peak_in_memory_callbacks(),
+        "drain_seconds": elapsed,
+        "throughput_per_second": completed / elapsed if elapsed else 0.0,
+        "sqlite_lock_failures": runner.sqlite_lock_failures(),
+    }
+
+
+def _git_revision() -> str | None:
+    root = Path(__file__).resolve().parents[3]
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=2,
+        cwd=root,
+    )
+    revision = result.stdout.strip()
+    return revision or None
+
+
+def _working_tree_dirty() -> bool | None:
+    root = Path(__file__).resolve().parents[3]
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=2,
+        cwd=root,
+    )
+    return bool(result.stdout) if result.returncode == 0 else None
+
+
+def _machine_metadata() -> dict[str, str | int | None]:
+    return {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor() or None,
+        "python": sys.version.split()[0],
+        "python_implementation": platform.python_implementation(),
+        "sqlite": sqlite3.sqlite_version,
+        "cpu_count": os.cpu_count(),
+    }
+
+
+def run_benchmark(config: BenchmarkConfig = BenchmarkConfig()) -> dict[str, Any]:
+    """Run the fixed scheduler workloads and return a versioned report payload."""
+    if config.concurrency < 1:
+        raise ValueError("concurrency must be positive")
+    if config.fake_delivery_seconds <= 0:
+        raise ValueError("fake_delivery_seconds must be positive")
+
+    with tempfile.TemporaryDirectory(prefix="opensre-scheduler-capacity-") as directory:
+        db_path = Path(directory) / "scheduler.db"
+        return {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "git_revision": _git_revision(),
+            "working_tree_dirty": _working_tree_dirty(),
+            "machine": _machine_metadata(),
+            "scheduler_config": {
+                "max_concurrent_runs": config.concurrency,
+                "shared_turn_gate": "not exercised by the fake runner",
+                "ideal_fake_completion_capacity_per_second": config.completion_capacity_per_second,
+            },
+            "workload": asdict(config),
+            "metrics": {
+                "burst": _run_bursts(db_path, config),
+                "sustained": _run_sustained_loads(db_path, config),
+                "history": _run_history_query_benchmarks(config),
+                "restart_recovery": _run_restart_recovery(db_path, config),
+            },
+        }
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    """Write one stable, readable benchmark report for review in version control."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_REPORT_PATH,
+        help=f"report path (default: {DEFAULT_REPORT_PATH})",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the baseline and write its JSON report."""
+    args = _parse_args()
+    report = run_benchmark()
+    write_report(report, args.output)
+    print(f"Wrote scheduler capacity baseline to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/scheduler/test_capacity_benchmark.py
+++ b/tests/benchmarks/scheduler/test_capacity_benchmark.py
@@ -1,0 +1,41 @@
+"""Contract tests for the deterministic scheduler capacity benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.benchmarks.scheduler.capacity_benchmark import (
+    BenchmarkConfig,
+    run_benchmark,
+    write_report,
+)
+
+
+def test_benchmark_records_every_m1_workload_and_writes_a_versioned_report(
+    tmp_path: Path,
+) -> None:
+    report = run_benchmark(
+        BenchmarkConfig(
+            fake_delivery_seconds=0.002,
+            burst_sizes=(3,),
+            sustained_seconds=0.02,
+            history_sizes=(10,),
+            restart_backlog_size=3,
+        )
+    )
+    output_path = tmp_path / "scheduler-capacity.json"
+    write_report(report, output_path)
+
+    assert output_path.exists()
+    assert report["schema_version"] == 1
+    assert report["scheduler_config"]["max_concurrent_runs"] == 2
+    assert report["metrics"]["burst"][0]["peak_in_memory_callbacks"] == 3
+    assert [result["load"] for result in report["metrics"]["sustained"]] == [
+        "below_capacity",
+        "at_capacity",
+        "above_capacity",
+    ]
+    assert report["metrics"]["history"][0]["completed_history_rows"] == 10
+    assert report["metrics"]["restart_recovery"]["recovered_runs"] == 3
+    assert report["metrics"]["restart_recovery"]["recovery_callback_count"] == 1
+    assert report["metrics"]["restart_recovery"]["peak_in_memory_callbacks"] == 1

--- a/tests/scheduler/test_run_store.py
+++ b/tests/scheduler/test_run_store.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+import infrastructure.scheduling.scheduler.storage.run_store as run_store
 from infrastructure.scheduling.scheduler.storage import database, migrations
 from infrastructure.scheduling.scheduler.storage.run_store import (
     ExecutionClaim,
@@ -24,6 +27,47 @@ from infrastructure.scheduling.scheduler.storage.run_store import (
     try_queue_run,
 )
 from infrastructure.scheduling.scheduler.types import DeliveryOutcome, Provider, TaskStatus
+
+_RECOVERY_REFERENCE_QUERY = """
+    SELECT task_id, fire_time
+    FROM task_runs AS current
+    WHERE (current.status = ? OR (
+        current.status = ? AND current.lease_expires_at != '' AND current.lease_expires_at < ?
+    ))
+    AND NOT EXISTS (
+        SELECT 1
+        FROM task_runs AS live
+        WHERE live.task_id = current.task_id
+        AND live.status = ?
+        AND live.lease_expires_at >= ?
+    )
+    AND (? IS NULL OR current.task_id IN (SELECT value FROM json_each(?)))
+    AND current.attempt = (
+        SELECT MAX(latest.attempt)
+        FROM task_runs AS latest
+        WHERE latest.task_id = current.task_id
+        AND latest.fire_time = current.fire_time
+    )
+    ORDER BY current.started_at, current.task_id, current.fire_time
+    LIMIT ?
+"""
+
+
+def _recovery_query_arguments(now: str, limit: int) -> tuple[str | None | int, ...]:
+    return (
+        TaskStatus.PENDING.value,
+        TaskStatus.RUNNING.value,
+        now,
+        TaskStatus.RUNNING.value,
+        now,
+        None,
+        None,
+        limit,
+    )
+
+
+def _recovery_index_names(conn: sqlite3.Connection) -> set[str]:
+    return {str(row[1]) for row in conn.execute("PRAGMA index_list(task_runs)")}
 
 
 @pytest.fixture()
@@ -783,3 +827,187 @@ def test_pending_claim_keeps_explicit_delivery_scope_through_recovery(db_path: P
     _expire_claim(db_path, "task", "tick")
     recovered = _claimed(db_path, "task", "tick")
     assert recovered.target_filter == scope
+
+
+def test_recovery_query_matches_the_pre_index_semantics(db_path: Path) -> None:
+    now = datetime.now(UTC).isoformat()
+    started = datetime(2026, 1, 1, tzinfo=UTC)
+    with database.connection(db_path) as conn:
+        conn.executemany(
+            "INSERT INTO task_runs "
+            "(task_id, fire_time, attempt, started_at, status, lease_expires_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                ("pending-old", "tick", 1, started.isoformat(), TaskStatus.PENDING.value, ""),
+                (
+                    "pending-new",
+                    "tick",
+                    1,
+                    (started + timedelta(minutes=1)).isoformat(),
+                    TaskStatus.PENDING.value,
+                    "",
+                ),
+                (
+                    "expired",
+                    "tick",
+                    1,
+                    (started + timedelta(minutes=2)).isoformat(),
+                    TaskStatus.RUNNING.value,
+                    "2020-01-01T00:00:00+00:00",
+                ),
+                (
+                    "superseded",
+                    "tick",
+                    1,
+                    (started + timedelta(minutes=3)).isoformat(),
+                    TaskStatus.PENDING.value,
+                    "",
+                ),
+                (
+                    "superseded",
+                    "tick",
+                    2,
+                    (started + timedelta(minutes=4)).isoformat(),
+                    TaskStatus.SUCCESS.value,
+                    "",
+                ),
+                (
+                    "owned",
+                    "pending-tick",
+                    1,
+                    (started + timedelta(minutes=5)).isoformat(),
+                    TaskStatus.PENDING.value,
+                    "",
+                ),
+                (
+                    "owned",
+                    "running-tick",
+                    1,
+                    (started + timedelta(minutes=6)).isoformat(),
+                    TaskStatus.RUNNING.value,
+                    "2099-01-01T00:00:00+00:00",
+                ),
+            ),
+        )
+        expected = conn.execute(
+            _RECOVERY_REFERENCE_QUERY,
+            _recovery_query_arguments(now, limit=100),
+        ).fetchall()
+        conn.commit()
+
+    actual = get_recoverable_runs(limit=100, db_path=db_path)
+
+    assert [(run.task_id, run.fire_time) for run in actual] == expected
+
+
+def test_recovery_query_uses_partial_indexes_without_scanning_completed_history(
+    db_path: Path,
+) -> None:
+    started = datetime(2026, 1, 1, tzinfo=UTC)
+    with database.connection(db_path) as conn:
+        completed = tuple(
+            (
+                f"completed-{index}",
+                "tick",
+                (started + timedelta(seconds=index)).isoformat(),
+                TaskStatus.SUCCESS.value,
+            )
+            for index in range(10_000)
+        )
+        conn.executemany(
+            "INSERT INTO task_runs (task_id, fire_time, started_at, status) VALUES (?, ?, ?, ?)",
+            completed,
+        )
+        conn.executemany(
+            "INSERT INTO task_runs "
+            "(task_id, fire_time, started_at, status, lease_expires_at) VALUES (?, ?, ?, ?, ?)",
+            (
+                (
+                    "pending",
+                    "tick",
+                    started.isoformat(),
+                    TaskStatus.PENDING.value,
+                    "",
+                ),
+                (
+                    "expired",
+                    "tick",
+                    (started + timedelta(seconds=1)).isoformat(),
+                    TaskStatus.RUNNING.value,
+                    "2020-01-01T00:00:00+00:00",
+                ),
+            ),
+        )
+        details = [
+            str(row[3])
+            for row in conn.execute(
+                f"EXPLAIN QUERY PLAN {run_store._RECOVERABLE_RUNS_QUERY}",
+                _recovery_query_arguments(datetime.now(UTC).isoformat(), limit=100),
+            )
+        ]
+        conn.commit()
+
+    assert any("idx_task_runs_recovery_pending_order" in detail for detail in details)
+    assert any("idx_task_runs_recovery_expired" in detail for detail in details)
+    assert any("idx_task_runs_live_owner" in detail for detail in details)
+    assert not any(
+        detail.startswith("SCAN task_runs") and "USING" not in detail for detail in details
+    )
+
+
+def test_missing_recovery_indexes_are_added_once_under_concurrent_startup(db_path: Path) -> None:
+    with database.connection(db_path) as conn:
+        for index_name in migrations._RECOVERY_INDEX_NAMES:
+            conn.execute(f"DROP INDEX {index_name}")
+        conn.commit()
+
+    ready = threading.Barrier(3)
+
+    def _migrate() -> None:
+        with sqlite3.connect(db_path, timeout=5) as conn:
+            ready.wait(timeout=5)
+            migrations.apply_migrations(conn)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(_migrate) for _ in range(2)]
+        ready.wait(timeout=5)
+        for future in futures:
+            future.result()
+
+    with sqlite3.connect(db_path) as conn:
+        assert _recovery_index_names(conn) >= migrations._RECOVERY_INDEX_NAMES
+
+
+def test_recovery_index_migration_retries_a_lock_longer_than_busy_timeout(db_path: Path) -> None:
+    """A losing startup waits for an in-flight index build to finish."""
+    with database.connection(db_path) as conn:
+        for index_name in migrations._RECOVERY_INDEX_NAMES:
+            conn.execute(f"DROP INDEX {index_name}")
+        conn.commit()
+
+    holder = sqlite3.connect(db_path)
+    holder.execute("BEGIN IMMEDIATE")
+    started = threading.Event()
+
+    def _migrate_after_lock() -> None:
+        with sqlite3.connect(db_path, timeout=0.001) as conn:
+            conn.execute("PRAGMA busy_timeout = 1")
+            started.set()
+            migrations.apply_migrations(conn)
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_migrate_after_lock)
+            assert started.wait(timeout=5)
+            # This exceeds the contender's 1ms SQLite busy timeout, forcing
+            # the migration-level retry that covers a slow index build.
+            time.sleep(0.05)
+            holder.commit()
+            future.result(timeout=5)
+    finally:
+        if holder.in_transaction:
+            holder.rollback()
+        holder.close()
+
+    with sqlite3.connect(db_path) as conn:
+        assert _recovery_index_names(conn) >= migrations._RECOVERY_INDEX_NAMES


### PR DESCRIPTION
Part of #6135

#### Describe the changes you have made in this PR -

Delivers the completed M1/M2 portions of the scheduler-scale plan:

- Documents the scheduler capacity and overload contract, including the current two-worker default and the distinction between durable pending work and the executor's unbounded submitted-callback queue.
- Adds a deterministic scheduler benchmark using fake runner/delivery components only—no LLM, provider, or network calls—and checks in its baseline report for burst, sustained-load, completed-history, and restart-recovery scenarios.
- Adds idempotent, concurrent-safe SQLite partial indexes for pending recovery ordering, expired-running candidates, and live-owner checks.
- Rewrites recovery candidate selection into indexed pending and expired branches while retaining latest-attempt selection, eligible-task filtering, and live-owner fencing.
- Adds result-equivalence, query-plan, and concurrent-index-migration coverage.

### Scope and follow-up

This PR validates recovery-query behavior and performance after the schema migration. It does not complete M3–M5 from #6135: backlog visibility, bounded dispatch/recovery liveness, and calibrated rollout guidance remain follow-up work. Measuring first-time index-build duration on a populated legacy database and making optional macOS RSS sampling failure-tolerant are also deferred follow-ups.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make test-scope
50 passed in 1.94s

$ make lint && make format-check && make typecheck
All checks passed
3206 files already formatted
Success: no issues found in 1852 source files
```

The checked-in baseline records 1,000 submitted-but-unfinished callbacks for a 1,000-task burst at the current two-worker default. At 100k completed-history rows, the recovery plan uses the pending, expired, and live-owner indexes; no lock failures were recorded.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The benchmark uses durable scheduler claims around a fixed fake delivery duration, so it measures persistence/recovery and the current executor queue without changing production behavior. It records host/config metadata for reproducible comparison.

The SQLite migration retains the existing one-entry-point and `BEGIN IMMEDIATE` concurrency pattern. Partial indexes exclude completed history. The recovery query has two candidate branches so SQLite can use the pending, expired, and live-owner indexes; its outer clauses retain the existing latest-attempt selection, eligible-task filtering, and live-owner exclusion. Tests compare the old and new result sets, assert the intended query plan, and exercise concurrent startup while indexes are absent.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
