### PR TITLE
fix(shell): Ask User card for single picks; one-line skill activation

### DIFF
--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -123,7 +123,7 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         session.terminal.awaiting_handoff_answer = False
         session.terminal.set_auto_command(command)
         return True
-    render_choice_selection(console, items[0].title, picked_one, options=items[0].options)
+    render_choice_selection(console, items[0].title, picked_one)
     # The answer travels with its question, as the batched wizard's does: a bare
     # label such as "owner/repo (757 commits, CI configured)" reads to the
     # planner like a fresh request and gets re-asked or re-routed.

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -27,7 +27,7 @@ from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import (
     BOLD_SKILL,
-    DIM,
+    ERROR,
     TEXT,
 )
 from infrastructure.text import is_data_blob
@@ -368,8 +368,8 @@ class ActionRenderObserver:
 
     Self-recording tools (``slash_invoke``, ``shell_run``, etc.) append their own
     history row; chat turns are recorded later by turn accounting when the
-    assistant runs. ``skill_view`` gets a dedicated live event: the skill name
-    on ``tool_start`` and an activation/failure child line on ``tool_end``.
+    assistant runs. ``skill_view`` gets a dedicated live event: one
+    ``Skill activated <name>`` (or ``failed to load``) line on ``tool_end``.
     """
 
     def __init__(self, *, session: Session, console: Console, message: str) -> None:
@@ -378,7 +378,6 @@ class ActionRenderObserver:
         self.message = message
         self.planned_count = 0
         self._pending_skill_calls: dict[str, str] = {}
-        self._last_skill_header: str = ""
         self._pending_result_tools: set[str] = set()
 
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
@@ -516,19 +515,11 @@ class ActionRenderObserver:
         render_note_block(self.console, content)
 
     def _render_skill_start(self, data: dict[str, Any]) -> None:
-        """Print ``Skill <name>`` when the agent starts loading a skill."""
+        """Remember the skill slug for its ``tool_end``; nothing prints yet."""
         args = data.get("input")
         raw_name = str(args.get("name", "")).strip() if isinstance(args, dict) else ""
         slug = strip_terminal_controls(raw_name.replace("_", "-").lower()) or "skill"
         self._pending_skill_calls[str(data.get("id") or "")] = slug
-        self._last_skill_header = slug
-        # ``Text`` renders the (model-supplied) skill name literally — never
-        # through Rich markup.
-        line = Text()
-        line.append("Skill ", style=BOLD_SKILL)
-        line.append(slug, style=str(TEXT))
-        self.console.print()
-        self.console.print(line)
 
     def _render_tool_invocation(self, name: str, data: dict[str, Any]) -> None:
         """Buffer the running tool for the grouped action log — no inline args.
@@ -573,22 +564,27 @@ class ActionRenderObserver:
         self.session.terminal.inline_tool_results = True
 
     def _render_skill_end(self, data: dict[str, Any]) -> None:
-        """Print the ``↳`` child line under the skill's ``tool_start`` parent.
+        """Print one ``Skill activated <name>`` line once the skill has loaded.
 
-        The next block (another call, a note, or the ``Ω`` reply) opens with
-        its own blank line — do not add one here or the gap doubles.
+        Opens with its own blank line like every other block; the next block
+        (another call, a note, or the ``Ω`` reply) adds its own — do not add a
+        trailing one here or the gap doubles.
         """
         slug = self._pending_skill_calls.pop(str(data.get("id") or ""), None)
         if slug is None:
             return
         output = data.get("output")
         activated = isinstance(output, dict) and bool(output.get("ok"))
-        # Several skills loading in one batch print their headers first and
-        # their results after; name the skill whenever the line would land
-        # under another skill's header.
-        subject = "Skill" if slug == self._last_skill_header else slug
-        label = f"{subject} activated" if activated else f"{subject} failed to load"
-        self.console.print(Text(f"  ↳ {label}", style=DIM))
+        # ``Text`` renders the (model-supplied) skill name literally — never
+        # through Rich markup.
+        line = Text()
+        if activated:
+            line.append("Skill activated ", style=BOLD_SKILL)
+        else:
+            line.append("Skill failed to load ", style=ERROR)
+        line.append(slug, style=str(TEXT))
+        self.console.print()
+        self.console.print(line)
 
 
 __all__ = [

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -20,53 +20,27 @@ def _display_safe(text: str) -> str:
     return "\n".join(strip_terminal_controls(line) for line in text.splitlines())
 
 
-def render_choice_selection(
-    console: Console,
-    title: str,
-    answer: str,
-    *,
-    options: tuple[str, ...] = (),
-) -> None:
-    """Persist the pick after the menu closes, as an answer line rather than a repeated question.
+def render_choice_selection(console: Console, title: str, answer: str) -> None:
+    """Persist a single pick after its menu closes, as a one-question Ask User card.
 
     The menu itself is erased, so this is the transcript's only record of the
-    choice. It must read as "answered", not as the question asked again: no
-    header, the question dim on one line with a single answer after it, and a
-    multi-select listed underneath. Must not use the plan-step ``✓`` glyph.
-    Leading blank separates it from Plan complete / reply text above.
-    ``options`` are the rows that were offered; they follow on one dim line so
-    a reader of the transcript sees what the choice was made against.
+    choice. It uses the same card as the batched wizard (header, numbered bold
+    question, answer beneath) so every hand-off answer reads alike. Must not use
+    the plan-step ``✓`` glyph. The leading blank replaces the section gap the
+    erased menu took with it.
     """
     console.print()
-    question = _display_safe(title.strip())
-    answers = [line for line in _display_safe(answer.strip()).splitlines() if line.strip()]
-    line = Text()
-    line.append("  ↳ ", style=str(ui_theme.DIM))
-    line.append(question, style=str(ui_theme.DIM))
-    if len(answers) == 1:
-        line.append("  ", style=str(ui_theme.DIM))
-        line.append(answers[0], style=str(ui_theme.BRAND))
-        console.print(line)
-    else:
-        console.print(line)
-        for item in answers:
-            aline = Text()
-            aline.append("      ", style=str(ui_theme.DIM))
-            aline.append(item, style=str(ui_theme.BRAND))
-            console.print(aline)
-    offered = [_display_safe(item.strip()) for item in options if item.strip()]
-    if len(offered) > 1:
-        console.print(Text("    offered: " + " · ".join(offered), style=str(ui_theme.DIM)))
+    render_ask_user_qa(console, [(title.strip(), answer.strip())])
 
 
 def render_ask_user_qa(console: Console, pairs: list[tuple[str, str]]) -> None:
     """Print Ask User Q→A: accent header, bold numbered questions, brand answers.
 
-    Each pair is a two-line block — a bold question, then its answer in the brand
-    colour indented beneath it — with a blank row after the header and between
-    items so the filled-in recap is scannable and the answer reads apart from the
-    question. No extra blank above or below the card (the stream / prompt
-    already own that margin).
+    Each pair is a block — a bold question, then its answer in the brand colour
+    indented beneath it, one row per selected option for a multi-select — with a
+    blank row after the header and between items so the filled-in recap is
+    scannable and the answer reads apart from the question. No extra blank above
+    or below the card (the stream / prompt already own that margin).
     """
     console.print(Text("Ask User", style=f"bold {ui_theme.HIGHLIGHT}"))
     console.print()
@@ -77,10 +51,13 @@ def render_ask_user_qa(console: Console, pairs: list[tuple[str, str]]) -> None:
         qline.append(f"  {index + 1}.  ", style=str(ui_theme.DIM))
         qline.append(_display_safe(question), style=f"bold {ui_theme.TEXT}")
         console.print(qline)
-        aline = Text()
-        aline.append("      ", style=str(ui_theme.DIM))
-        aline.append(_display_safe(answer), style=str(ui_theme.BRAND))
-        console.print(aline)
+        for item in _display_safe(answer).splitlines():
+            if not item.strip():
+                continue
+            aline = Text()
+            aline.append("      ", style=str(ui_theme.DIM))
+            aline.append(item, style=str(ui_theme.BRAND))
+            console.print(aline)
 
 
 def try_render_ask_user_submission(console: Console, text: str) -> bool:

--- a/tests/core/agent_harness/turns/test_skill_view_display.py
+++ b/tests/core/agent_harness/turns/test_skill_view_display.py
@@ -1,7 +1,7 @@
 """Loading a skill must not print anything through the generic formatter.
 
 ``skill_view`` returns the full recipe so the *model* can follow it. The
-user-facing event ("Skill <name>" / "↳ Skill activated") is rendered live by
+user-facing event ("Skill activated <name>") is rendered live by
 the surface's tool-event observer, so the end-of-turn generic formatter must
 stay silent: any output here would double-print the activation, and falling
 through to the payload would dump the entire 5k-character skill body —

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -116,7 +116,8 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
     # The whole boot-to-pick sequence painted exactly one thing besides the
     # picker itself: the selection recap. No work-turn marker, no skill tree.
     painted = buffer.getvalue()
-    assert painted.strip().startswith(f"↳ {_TITLE}"), painted
+    assert painted.strip().startswith("Ask User"), painted
+    assert f"1.  {_TITLE}" in painted, painted
     for chrome in ("/goal", "Skill ", "activated", "skill_view", "[1]"):
         assert chrome not in painted, painted
     assert len(picker_calls) == 1

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -57,10 +57,11 @@ def test_selection_is_auto_submitted_as_next_user_message(
     )
     assert session.terminal.pending_prompt_autosubmit is True
     output = buf.getvalue()
-    # Single-pick recap is one answered line — not an Ask User card and not a
-    # plan-step ``✓`` (that glued picks into Plan complete).
-    assert "Ask User" not in output
-    assert "↳" in output
+    # Single-pick recap is the one-question Ask User card — not a ``↳`` line and
+    # not a plan-step ``✓`` (that glued picks into Plan complete).
+    assert "Ask User" in output
+    assert "↳" not in output
+    assert "offered:" not in output
     assert "✓" not in output
     assert _CHOICE.title in output
     assert "Commit the changes" in output

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -137,14 +137,29 @@ def _skill_observer() -> tuple[ActionRenderObserver, io.StringIO]:
     return observer, buffer
 
 
-def test_skill_view_renders_activation_event() -> None:
-    """Loading a skill shows the two-line activation tree, nothing else."""
+def _load_skill(observer: ActionRenderObserver, call_id: str, name: str) -> None:
+    observer("tool_start", {"id": call_id, "name": "skill_view", "input": {"name": name}})
+    observer(
+        "tool_end",
+        {
+            "id": call_id,
+            "name": "skill_view",
+            "input": {"name": name},
+            "output": {"ok": True, "name": name, "content": "<CDATA body>"},
+        },
+    )
+
+
+def test_skill_view_renders_single_activation_line() -> None:
+    """Loading a skill shows one ``Skill activated <name>`` line, nothing underneath."""
     observer, buffer = _skill_observer()
 
     observer(
         "tool_start",
         {"id": "t1", "name": "skill_view", "input": {"name": "install_code_review"}},
     )
+    assert buffer.getvalue() == ""
+
     observer(
         "tool_end",
         {
@@ -155,21 +170,16 @@ def test_skill_view_renders_activation_event() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nSkill install-code-review\n  ↳ Skill activated\n"
+    assert buffer.getvalue() == "\nSkill activated install-code-review\n"
 
 
-def test_two_skills_in_one_batch_name_the_skill_on_each_activation_line() -> None:
-    """Headers print first, results after; the first skill's line must say which skill."""
+def test_two_skills_in_one_batch_each_get_their_own_line() -> None:
+    """Starts print nothing, so interleaved batches cannot mislabel a result."""
     observer, buffer = _skill_observer()
-    for call_id, name in (
-        ("t1", "reporting-github-ci-failures"),
-        ("t2", "github-ci-fix-onboarding"),
-    ):
+    names = ("reporting-github-ci-failures", "github-ci-fix-onboarding")
+    for call_id, name in zip(("t1", "t2"), names, strict=True):
         observer("tool_start", {"id": call_id, "name": "skill_view", "input": {"name": name}})
-    for call_id, name in (
-        ("t1", "reporting-github-ci-failures"),
-        ("t2", "github-ci-fix-onboarding"),
-    ):
+    for call_id, name in zip(("t1", "t2"), names, strict=True):
         observer(
             "tool_end",
             {
@@ -181,23 +191,20 @@ def test_two_skills_in_one_batch_name_the_skill_on_each_activation_line() -> Non
         )
 
     assert buffer.getvalue() == (
-        "\nSkill reporting-github-ci-failures\n\nSkill github-ci-fix-onboarding\n"
-        "  ↳ reporting-github-ci-failures activated\n  ↳ Skill activated\n"
+        "\nSkill activated reporting-github-ci-failures\n"
+        "\nSkill activated github-ci-fix-onboarding\n"
     )
 
 
-def test_skill_view_renders_bold_green_skill_label() -> None:
+def test_skill_view_renders_bold_green_activation_label() -> None:
     console = Mock(spec=Console)
     observer = ActionRenderObserver(session=Session(), console=console, message="run code review")
 
-    observer(
-        "tool_start",
-        {"id": "t1", "name": "skill_view", "input": {"name": "install_code_review"}},
-    )
+    _load_skill(observer, "t1", "install_code_review")
 
     heading = console.print.call_args_list[1].args[0]
     assert isinstance(heading, Text)
-    assert heading.plain == "Skill install-code-review"
+    assert heading.plain == "Skill activated install-code-review"
     assert len(heading.spans) == 2
     assert str(heading.spans[0].style) == BOLD_SKILL
     assert str(heading.spans[1].style) == str(TEXT)
@@ -209,12 +216,9 @@ def test_skill_view_strips_terminal_controls_from_model_name() -> None:
     observer = ActionRenderObserver(session=Session(), console=console, message="run code review")
 
     # Act
-    observer(
-        "tool_start",
-        {"id": "t1", "name": "skill_view", "input": {"name": "code\x1b[2Kreview\x07"}},
-    )
+    _load_skill(observer, "t1", "code\x1b[2Kreview\x07")
 
-    # Assert: the rendered skill heading carries no C0/C1/DEL controls
+    # Assert: the rendered skill line carries no C0/C1/DEL controls
     heading = console.print.call_args_list[1].args[0]
     assert isinstance(heading, Text)
     assert "\x1b" not in heading.plain
@@ -416,7 +420,7 @@ def test_skill_view_failure_renders_failure_child() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nSkill no-such-skill\n  ↳ Skill failed to load\n"
+    assert buffer.getvalue() == "\nSkill failed to load no-such-skill\n"
 
 
 def test_skill_view_tool_end_without_start_prints_nothing() -> None:
@@ -572,7 +576,7 @@ def test_skill_block_renders_live_not_buffered() -> None:
     )
 
     out = buffer.getvalue()
-    assert "\nSkill install-code-review\n  ↳ Skill activated\n" in out
+    assert "\nSkill activated install-code-review\n" in out
     assert "\n\n\n" not in out
     # The github call is buffered for the grouped log, not printed inline yet.
     assert any(e.kind == "GitHub CLI" for e in observer.session.terminal.action_log_entries)

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -170,12 +170,9 @@ def test_choice_selection_strips_terminal_controls() -> None:
     output = buffer.getvalue()
     assert "\x1b" not in output
     assert "\x07" not in output
-    # One answered line, not the question asked again under a new header.
-    assert "Ask User" not in output
     assert "Deploy?" in output and "Canary" in output
-    assert output.strip().count("\n") == 0
     assert "✓" not in output
-    # Section gap above the line so it does not join Plan complete.
+    # Section gap above the card so it does not join Plan complete.
     assert output.startswith("\n")
 
 
@@ -188,31 +185,43 @@ def test_multi_select_choice_indents_every_selected_line() -> None:
     # Act
     render_choice_selection(console, "Select Complex Demos", answer)
 
-    # Assert: the question once, then every option indented under it.
+    # Assert: the question once, then every option on its own row under it.
     lines = [line.rstrip() for line in buffer.getvalue().splitlines() if line.strip()]
-    assert lines[0].endswith("Select Complex Demos")
-    for label in ("Audit the architecture", "Find failing PRs", "Remediate alerts"):
-        assert any(label in line and line.startswith(" ") for line in lines)
-        assert label not in lines
+    assert lines[0] == "Ask User"
+    assert lines[1].endswith("Select Complex Demos")
+    assert lines[2:] == [
+        "      Audit the architecture",
+        "      Find failing PRs",
+        "      Remediate alerts",
+    ]
     assert "✓" not in buffer.getvalue()
 
 
-def test_choice_selection_is_not_a_plan_step() -> None:
-    """Single-pick recap must not look like another Plan complete checklist row."""
+def test_choice_selection_is_the_ask_user_card() -> None:
+    """Single-pick recap is the one-question Ask User card, not a ``↳`` line or plan row.
+
+    Header, numbered bold question, the answer on the row beneath — the same
+    shape the batched wizard leaves — and no ``offered:`` list of the other rows.
+    """
     buffer = io.StringIO()
-    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=120)
 
     render_choice_selection(
         console,
-        "Choose a Demo",
+        "Which demo would you like me to run? (Esc to skip)",
         "Explore a repo and analyze its CI/CD performance (recommended)",
     )
 
     output = buffer.getvalue()
-    assert "Ask User" not in output
-    assert "Choose a Demo" in output
-    assert "Explore a repo" in output
-    assert "✓ Choose a Demo" not in output
+    assert output.startswith("\n")
+    lines = [line.rstrip() for line in output.splitlines() if line.strip()]
+    assert lines == [
+        "Ask User",
+        "  1.  Which demo would you like me to run? (Esc to skip)",
+        "      Explore a repo and analyze its CI/CD performance (recommended)",
+    ]
+    assert "↳" not in output
+    assert "offered:" not in output
     assert "✓" not in output
 
 
@@ -240,23 +249,3 @@ def test_plain_assistant_question_does_not_tag_the_next_turn() -> None:
     output = buffer.getvalue()
     assert "↗ answer" not in output
     assert "how many open PRs in opensre?" in output
-
-
-def test_selection_recap_lists_the_offered_rows() -> None:
-    """The picker erases itself; the recap keeps what the choice was made against."""
-    import io
-
-    from rich.console import Console
-
-    console = Console(file=io.StringIO(), force_terminal=False, width=120)
-
-    render_choice_selection(
-        console,
-        "What would you like to do next?",
-        "Exit demo",
-        options=("Set up an agent", "Connect to Slack", "Exit demo"),
-    )
-
-    out = console.file.getvalue()  # type: ignore[union-attr]
-    assert "↳ What would you like to do next?  Exit demo" in out
-    assert "offered: Set up an agent · Connect to Slack · Exit demo" in out


### PR DESCRIPTION
Fixes #

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Two transcript cleanups in the interactive shell, both about what stays in the scrollback after a transient element leaves the screen.

**1. A single pick leaves the Ask User card, not a `↳` line** (`surfaces/interactive_shell/ui/handoff_questions.py`, `command_registry/choice_prompt.py`)

The `/choose` recap for a one-question picker painted `↳ question  answer` plus a dim `offered: A · B · C` list of the other rows, while the batched wizard leaves the Ask User card. `render_choice_selection` now delegates to `render_ask_user_qa`, so every hand-off answer reads alike: `Ask User` header, numbered bold question, the answer on the row beneath. The `offered:` list and its `options=` parameter are removed. `render_ask_user_qa` prints one brand-coloured row per answer line so a multi-select pick lists each option.

**2. One `Skill activated <name>` line replaces the header + `↳` child** (`surfaces/interactive_shell/ui/action_rendering.py`)

Loading a skill painted `Skill <name>` on `tool_start` and `  ↳ Skill activated` on `tool_end`. Nothing prints at start now; one bold `Skill activated <name>` line prints at end (`Skill failed to load <name>` in the error colour on failure). The two-line tree read like a nested work log, and interleaved batches had to name the skill on the child line to stay unambiguous.

### Demo/Screenshot for feature changes and bug fixes -

Before (scrollback after picking the recommended demo):

```
  ↳ Which demo would you like me to run? (Esc to skip)  Explore a repo and analyze its CI/CD performance (recommended)
    offered: Explore a repo and analyze its CI/CD performance (recommended) · Set up an agent that improves CI/CD reliability over time · Run CI/CD improvements with
a managed service (coming soon) · Connect OpenSRE to Slack and hand off DevOps chores for your team · Skip the demo and open the shell
```

After (captured live from `uv run opensre` in a pty, pressing `A` on the startup menu):

```
Ask User

  1.  Which demo would you like me to run? (Esc to skip)
      Explore a repo and analyze its CI/CD performance (recommended)
```

Skill load, before / after:

```
Skill cicd-analytics-demo
  ↳ Skill activated
```

```
Skill activated cicd-analytics-demo
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The recap is drawn by the shell after `repl_choose_one` erases the menu; the model never sees it, so this had to be a TUI change rather than a prompt change. Rather than add a second card renderer, the single-pick path reuses the existing `render_ask_user_qa` (already used by the batched wizard's recap), which keeps one source of truth for the card shape. The only extension to that helper is per-line answers, needed because a multi-select pick arrives newline-joined. The skill-row change moves the print from `tool_start` to `tool_end` so the line can carry the outcome and name together, which also removes the `_last_skill_header` bookkeeping that existed only to disambiguate interleaved batches.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
