### PR TITLE
fix(shell): the schedule card is a list, not a paragraph

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -267,6 +267,8 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 - Keep bullets to one line unless breaking for clarity is unavoidable.
 - Group into short lists (4–6 bullets) ordered by importance.
 - Use consistent keyword phrasing and formatting across sections.
+- Three or more things the user can act on — a schedule, the commands that manage it, where output lands, what to do next — are one bullet each, never a run of sentences. Consecutive lines render as a single paragraph, and a paragraph of commands does not get read.
+- Repeat a card or list a tool already rendered line for line. Never re-flow it into prose or re-order it.
 
 **Monospace**
 

--- a/integrations/github/__init__.py
+++ b/integrations/github/__init__.py
@@ -42,6 +42,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "ci_report_headline": "integrations.github.tools.ci_analytics.render",
     "render_ci_report": "integrations.github.tools.ci_analytics.render",
     "DEFAULT_LOOP_TIME": "integrations.github.tools.ci_analytics.loop",
+    "LoopCard": "integrations.github.tools.ci_analytics.loop",
     "ScheduledLoop": "integrations.github.tools.ci_analytics.loop",
     "local_timezone": "integrations.github.tools.ci_analytics.loop",
     "loop_card": "integrations.github.tools.ci_analytics.loop",
@@ -93,6 +94,7 @@ if TYPE_CHECKING:
     from integrations.github.tools.ci_analytics.analysis import Analysis, analyze_repository
     from integrations.github.tools.ci_analytics.loop import (
         DEFAULT_LOOP_TIME,
+        LoopCard,
         ScheduledLoop,
         local_timezone,
         loop_card,
@@ -116,6 +118,7 @@ __all__ = [
     "GitHubMcpDisplayDetailLevel",
     "GitHubPullRequestError",
     "GitHubRestClient",
+    "LoopCard",
     "PullRequest",
     "ScheduledLoop",
     "analyze_repository",

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_PROMPT_PARAM,
@@ -50,6 +51,19 @@ class ScheduledLoop:
     @property
     def task_id(self) -> str:
         return self.loop.task.id
+
+
+@dataclass(frozen=True)
+class LoopCard:
+    """The scheduled loop as the user reads it: a headline and short facts."""
+
+    headline: str
+    details: tuple[str, ...]
+
+    def markdown(self) -> str:
+        """The card as markdown: bold headline, one bullet per fact."""
+        bullets = "\n".join(f"- {detail}" for detail in self.details)
+        return f"**{self.headline}**\n\n{bullets}"
 
 
 def loop_name(owner: str, repo: str) -> str:
@@ -170,26 +184,46 @@ def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -
     return "\n".join([render_markdown(report), "", headline(report), "", f"Raw data: {snapshot}"])
 
 
-def loop_card(scheduled: ScheduledLoop) -> list[str]:
-    """Plain lines describing the loop: schedule, next run, where reports land."""
+def loop_card(scheduled: ScheduledLoop) -> LoopCard:
+    """What the user is told about the loop: one headline and one fact per line."""
     task = scheduled.loop.task
     verb = "Already scheduled" if scheduled.reused else "Scheduled"
     when = loop_time_label(task.cron) or task.cron
     cadence = "weekdays" if task.cron.split()[-1] == "1-5" else "every day"
-    lines = [
-        f"{verb}: {task.name}",
-        f"Runs {cadence} at {when} {task.timezone}; next run {scheduled.loop.next_run or 'pending'}.",
-        "Each report lands in this shell's inbox: /loops messages. "
-        f"Manage it with /loops list, /loops stop {task.id}, /loops delete {task.id}.",
-        f"To run it at another time, /loops delete {task.id} and schedule it again.",
-        "It runs while the shell is open, or under `opensre cron start` when it is not.",
-    ]
-    return lines
+    return LoopCard(
+        headline=f"{verb}: {task.name}",
+        details=(
+            f"Runs {cadence} at {when} {task.timezone}, next {_next_run_label(scheduled)}",
+            "Reports arrive in this shell's inbox: `/loops messages`",
+            f"Manage: `/loops list`, `/loops stop {task.id}`, "
+            f"`/loops delete {task.id}` (delete to reschedule)",
+            "Runs while the shell is open; `opensre cron start` keeps it running when it is not",
+        ),
+    )
+
+
+def _next_run_label(scheduled: ScheduledLoop) -> str:
+    """The next run in the schedule's own timezone, so it matches the time asked for."""
+    raw = scheduled.loop.next_run
+    if not raw:
+        return "pending"
+    try:
+        when = datetime.fromisoformat(raw)
+    except ValueError:
+        return raw
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    try:
+        when = when.astimezone(ZoneInfo(scheduled.loop.task.timezone))
+    except (ZoneInfoNotFoundError, ValueError):
+        when = when.astimezone()
+    return when.strftime("%a %d %b %H:%M")
 
 
 __all__ = [
     "DEFAULT_LOOP_TIME",
     "LOOP_WINDOW_DAYS",
+    "LoopCard",
     "REPORT_NAME",
     "SNAPSHOT_DIRNAME",
     "ScheduledLoop",

--- a/integrations/github/tools/ci_analytics/loop_tool.py
+++ b/integrations/github/tools/ci_analytics/loop_tool.py
@@ -97,7 +97,7 @@ def schedule_ci_reliability_loop(
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
     task = scheduled.loop.task
-    card = "\n".join(ci_loop.loop_card(scheduled))
+    card = ci_loop.loop_card(scheduled).markdown()
     report, report_as_of = report_text_from_snapshot(owner, repo) if include_report else ("", "")
     return {
         "ok": True,

--- a/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
+++ b/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
@@ -146,10 +146,11 @@ def start_ci_agent_demo(
         return False
     reload_loop_scheduler()
     if console is not None:
-        headline, *details = loop_card(scheduled)
+        card = loop_card(scheduled)
         console.print()
-        render_note_block(console, headline)
-        console.print(reply_gutter(Text("\n".join(details)), lead=False))
+        render_note_block(console, card.headline)
+        bullets = "\n".join(f"- {detail}" for detail in card.details)
+        console.print(reply_gutter(ReplyMarkdown(bullets), lead=False))
         console.print()
     _record(OPTION_CI_AGENT)
     _run_first_pass(console, scheduled.task_id, owner=owner, repo=repo)

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -33,6 +33,14 @@ def test_system_prompt_runs_explicit_commands_without_repository_probe() -> None
     )
 
 
+def test_actionable_results_are_bullets_not_a_paragraph() -> None:
+    """A schedule card read as one dense block; nobody reached the commands in it."""
+    collapsed = " ".join(_SYSTEM_PROMPT_BASE.split())
+    assert "Three or more things the user can act on" in collapsed
+    assert "are one bullet each, never a run of sentences" in collapsed
+    assert "Repeat a card or list a tool already rendered line for line" in collapsed
+
+
 def test_finite_material_ambiguity_requires_selectable_clarification() -> None:
     text = _SYSTEM_PROMPT_BASE
     collapsed = " ".join(text.split())

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -54,7 +54,44 @@ def test_scheduling_the_same_repository_again_reuses_the_loop(store_path: Path) 
     assert second.reused is True
     assert second.task_id == first.task_id
     assert len(list_tasks(store_path)) == 1
-    assert ci_loop.loop_card(second)[0].startswith("Already scheduled")
+    assert ci_loop.loop_card(second).headline.startswith("Already scheduled")
+
+
+def test_the_card_is_a_bulleted_list_not_a_paragraph(store_path: Path) -> None:
+    """Markdown folds consecutive lines into one paragraph; the card must survive that.
+
+    Read as prose, the schedule, the inbox and the management commands ran
+    together into a block nobody finished reading.
+    """
+    # Arrange
+    scheduled = ci_loop.schedule_ci_reliability_loop(
+        "acme", "app", timezone="UTC", store_path=store_path
+    )
+
+    # Act
+    markdown = ci_loop.loop_card(scheduled).markdown()
+
+    # Assert: a bold headline, a blank line, then one bullet per fact.
+    headline, blank, *bullets = markdown.split("\n")
+    assert headline == "**Scheduled: CI reliability check · acme/app**"
+    assert blank == ""
+    assert all(line.startswith("- ") for line in bullets)
+    assert len(bullets) == 4
+
+
+def test_the_next_run_is_shown_in_the_schedule_timezone(store_path: Path) -> None:
+    """A raw UTC ISO stamp contradicted the local time the user had just picked."""
+    # Arrange: 08:00 in Chicago is not 08:00 UTC.
+    scheduled = ci_loop.schedule_ci_reliability_loop(
+        "acme", "app", timezone="America/Chicago", store_path=store_path
+    )
+
+    # Act
+    schedule_line = ci_loop.loop_card(scheduled).details[0]
+
+    # Assert
+    assert "T" not in schedule_line.split("next ")[1]
+    assert schedule_line.endswith("08:00")
 
 
 def test_unparseable_time_raises_before_anything_is_stored(store_path: Path) -> None:
@@ -306,7 +343,7 @@ def test_tool_never_reads_github_live_when_no_snapshot_exists(
     assert live_calls == []
     assert result["ok"] is True
     assert result["report_as_of"] == ""
-    assert result["response_text"].startswith("Scheduled:")
+    assert result["response_text"].startswith("**Scheduled:")
 
 
 def test_registered_tool_runs_the_scheduling_function() -> None:
@@ -382,5 +419,5 @@ def test_the_card_says_how_to_run_the_loop_at_another_time(
     result = loop_tool.schedule_ci_reliability_loop(owner="acme", repo="app")
 
     # Assert
-    assert "to run it at another time" in result["response_text"].lower()
+    assert "delete to reschedule" in result["response_text"].lower()
     assert "/loops delete task1" in result["response_text"]


### PR DESCRIPTION
The scheduled-agent demo closes with a card that arrived as one dense
paragraph — the schedule, where reports land, and three /loops commands
run together. The lines were separate in source; markdown folds
consecutive lines into a paragraph.

- loop_card returns a LoopCard (headline + one fact per bullet) instead
  of a list of sentences. The action tool sends its markdown; the
  startup demo paints the same content through ReplyMarkdown, so both
  entry points show one card.
- Four bullets instead of five sentences, none wrapping at 120 columns.
- The next run prints in the schedule's timezone ("next Fri 11 Sep
  08:00") rather than a UTC ISO stamp contradicting the local time
  stated beside it.
- System prompt: three or more actionable things are one bullet each,
  never a run of sentences; a card a tool already rendered is repeated
  line for line, never re-flowed into prose.