### PR TITLE
PR title: feat(ci-analytics): first run is the demo — cost first, no cache, shipped benchmarks

### DIFF
--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/SKILL.md
@@ -27,7 +27,7 @@ metadata:
 pre_execute:
   - tool: ask_user_choice
     args:
-      title: Which demo would you like me to run? (Esc to skip)
+      title: Which demo would you like me to run?
       note: >-
         Choose a demo using your own repositories or connect your team through
         Slack. The managed-service option is coming soon.

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -128,11 +128,11 @@ the answer.
 
 Call
 `analyze_github_ci_reliability(owner="<owner>", repo="<repo>", compact=true)`
-for the chosen repository. The tool paints the report (key results first)
-and the comparison table itself. Do not restate figures, do not output
-`headline`, and do not call the tool again for benchmarks. A peer without
-a same-day snapshot is skipped (named in `benchmarks_skipped`); do not
-fetch it yourself.
+for the chosen repository. This reads GitHub now (a token is required); do
+not look for a saved snapshot. The tool paints the report — the cost
+sentence first, then key results and the comparison against shipped
+Airflow and FastAPI figures. Do not restate figures, do not output
+`headline`, and do not call the tool again for benchmarks.
 
 ### 4. Offer what to do next
 
@@ -143,7 +143,9 @@ these options:
 - `Connect OpenSRE to Slack and hand off DevOps chores for your team`
 - `Exit demo`
 
-Wait for the answer, then follow the selected option.
+Wait for the answer, then follow the selected option. The report already
+named the cost; do not repeat it. The first option schedules a weekday
+copy of this report, not a CI code fix.
 
 **Recurring check:** Call
 `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -13,8 +13,8 @@ getting_started: Explore a repo and analyze its CI/CD performance (recommended)
 demo_order: 1
 metadata:
   owner: Vincent
-  last_changed_by: Vincent
-  last_changed_at: 2026-09-09
+  last_changed_by: Yauhen
+  last_changed_at: 2026-09-10
   usecases:
     - First-experience demo: scan the machine, pick a repository, analyze its CI/CD
     - CI/CD reliability KPIs for one repository over the last 30 days
@@ -24,7 +24,7 @@ metadata:
     - GitHub token usable by OpenSRE with read access to the repository's Actions history
     - A local git checkout for the workspace scan (optional; a named repository also works)
   type: analytics
-  version: "1.3"
+  version: "1.4"
 tools:
   - scan_local_git_workspace
   - analyze_github_ci_reliability
@@ -99,7 +99,7 @@ Track progress with the `update_plan` tool, not with headers or prose:
   `explanation` (this is not a diagnosis; no hypothesis table):
   `Scan this machine` / `Pick the repository` / `Analyze CI/CD reliability` /
   `Offer what to do next`.
-- When the request already names the repository, the plan is only
+- When the request or an Ask User answer already names the repository, the plan is only
   `Analyze CI/CD reliability` / `Offer what to do next` — omit the skipped
   steps instead of renumbering.
 - After a step's tool results, call `update_plan` marking it `completed` and
@@ -128,9 +128,9 @@ the answer.
 
 Call
 `analyze_github_ci_reliability(owner="<owner>", repo="<repo>", compact=true)`
-for the chosen repository. This reads GitHub now (a token is required); do
-not look for a saved snapshot. The tool paints the report — the cost
-sentence first, then key results and the comparison against shipped
+for the chosen repository. A saved report from today is reused; otherwise
+this reads GitHub (a token is required). The tool paints the report — the
+cost sentence first, then key results and the comparison against shipped
 Airflow and FastAPI figures. Do not restate figures, do not output
 `headline`, and do not call the tool again for benchmarks.
 
@@ -145,7 +145,7 @@ these options:
 
 Wait for the answer, then follow the selected option. The report already
 named the cost; do not repeat it. The first option schedules a weekday
-copy of this report, not a CI code fix.
+7-day version of this report to the shell inbox, not a CI code fix.
 
 **Recurring check:** Call
 `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -70,6 +70,8 @@ Slack setup.
 - If a tool reports a missing GitHub token, say the one command the user runs
   (`opensre integrations setup github`) and offer to continue afterwards. Do
   not fall back to a different data source.
+- If the analysis result is not successful for any other reason, say why in
+  one line and stop; the next-step menu only opens after a report.
 - The host opens the repository menu after `scan_local_git_workspace` and the
   next-step menu after `analyze_github_ci_reliability`. Do not call
   `ask_user_choice` for those two questions. End the turn when a menu is

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
@@ -17,8 +17,9 @@ this reference only when the user asks what a compared figure means.
   `pr_failure_rate`, flake share, red share, `mean_recovery_hours`, and
   `normal_minutes`.
 - The user's repository is the first column; the benchmarks are context.
-- If the tool returns `coverage_notices`, say so in one line. Do not
-  substitute another repository without telling the user.
+- The benchmark figures ship with OpenSRE and the table names the day they
+  were measured; a coverage notice in the result concerns the user's
+  repository only. Never quote a benchmark figure from memory.
 
 ## Default benchmarks
 

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/references/benchmarks.md
@@ -2,13 +2,13 @@
 
 Phase 2 of the analytics demo (metric definitions in `metrics.md`): the
 analyze call already paints one comparison table next to apache/airflow and
-fastapi/fastapi over the same window. Load
+fastapi/fastapi. Load
 this reference only when the user asks what a compared figure means.
 
 ## Rules
 
-- The host table is the source. Peers come from today's snapshot only; a
-  miss is skipped, not fetched live. Do not call
+- The host table is the source. Peer columns are figures shipped with the
+  product (the report names the day they were measured). Do not call
   `analyze_github_ci_reliability` again for a benchmark, and never quote a
   figure from memory, a blog post, or a previous session.
 - Compare **rates and durations**, never raw counts. A repository with 40 000
@@ -17,13 +17,12 @@ this reference only when the user asks what a compared figure means.
   `pr_failure_rate`, flake share, red share, `mean_recovery_hours`, and
   `normal_minutes`.
 - The user's repository is the first column; the benchmarks are context.
-- If the tool returns `benchmarks_skipped` or `coverage_notices` for a
-  peer, say so in one line. Do not substitute another repository without
-  telling the user.
+- If the tool returns `coverage_notices`, say so in one line. Do not
+  substitute another repository without telling the user.
 
 ## Default benchmarks
 
-The tool always uses these two, from same-day snapshots:
+The tool always uses these two:
 
 | Repository | Why it works as a benchmark |
 |------------|-----------------------------|

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
@@ -1,29 +1,31 @@
 ---
 name: cicd-reliability-agent
 description: >-
-  Schedules a recurring CI/CD reliability agent for one repository: scan local
-  checkouts, pick the repo, then schedule_ci_reliability_loop (weekday 08:00
-  local by default, inbox only). Use for the startup demo option "Set up an
-  agent that improves CI/CD reliability over time". Not a one-shot analysis
-  (cicd-analytics-demo) and not a current-failing-checks read (github-ci-health).
-  Multi-step; load before acting.
+  Schedules a recurring CI/CD reliability report for one repository: scan local
+  checkouts, pick the repo, analyze GitHub Actions now, then
+  schedule_ci_reliability_loop (weekday 08:00 local by default, inbox only).
+  Use for the startup demo option "Set up an agent that improves CI/CD reliability over time".
+  Not a one-shot analysis without a schedule (cicd-analytics-demo) and not a
+  current-failing-checks read (github-ci-health). Multi-step; load before
+  acting.
 getting_started: Set up an agent that improves CI/CD reliability over time
 demo_order: 2
 metadata:
   owner: Vincent
   last_changed_by: Yauhen
-  last_changed_at: 2026-09-09
+  last_changed_at: 2026-09-10
   usecases:
-    - First-experience demo: schedule a weekday CI/CD reliability agent for one repo
-    - Watch CI reliability over time without a one-shot analytics report
+    - First-experience demo: analyze once, then schedule a weekday CI reliability report
+    - Watch CI reliability over time after a live first report
     - Recurring weekday CI reliability check delivered to the shell inbox
   requires:
     - GitHub token usable by OpenSRE with read access to the repository's Actions history
     - A local git checkout for the workspace scan (optional; a named repository also works)
   type: report
-  version: "1.1"
+  version: "1.2"
 tools:
   - scan_local_git_workspace
+  - analyze_github_ci_reliability
   - schedule_ci_reliability_loop
   - ask_user_choice
 references:
@@ -40,8 +42,8 @@ after_tool:
 
 # CI/CD reliability agent
 
-Schedule a recurring CI/CD reliability check for one repository, delivered to
-the shell inbox.
+Analyze one repository's CI/CD reliability now, then schedule the same
+report for weekday mornings in this shell's inbox.
 
 ## Workflow rules
 
@@ -50,7 +52,8 @@ the shell inbox.
   and stop. Do not fall back to another data source.
 - Decision points use `ask_user_choice` with the exact option texts below.
   End the turn after calling it; the answer arrives as the next user message.
-- Output `schedule_ci_reliability_loop`'s `response_text` exactly and stop.
+- The analyze tool paints the report; do not restate its figures. Then output
+  `schedule_ci_reliability_loop`'s `response_text` exactly and stop.
 
 ## Plan
 
@@ -59,7 +62,8 @@ Track progress with the `update_plan` tool, not with headers or prose:
 - On entry, before the first workflow tool call, call `update_plan` with the
   steps below verbatim, the first step `in_progress`, and a one-line
   `explanation` (this is not a diagnosis; no hypothesis table):
-  `Scan this machine` / `Pick the repository` / `Schedule the loop`.
+  `Scan this machine` / `Pick the repository` / `Analyze CI/CD reliability` /
+  `Schedule the loop`.
 - When the request already names the repository, omit the first two steps
   from the plan instead of renumbering.
 - After a step's tool results, call `update_plan` marking it `completed` and
@@ -83,11 +87,19 @@ frontmatter and the host runs it. Do not call `ask_user_choice` for this
 question, and do not write your own version of it. End the turn and wait; the
 answer arrives as the next user message.
 
-### 3. Schedule the loop
+### 3. Analyze CI/CD reliability
 
-Call `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>",
-include_report=true)`. The loop runs weekdays at 08:00 local time; the card
-states the schedule and how to run it at another time, so do not ask about the
-cadence.
-Output `response_text` verbatim and stop. When a same-day report exists it
-comes first, then the schedule card; otherwise the card alone.
+Call
+`analyze_github_ci_reliability(owner="<owner>", repo="<repo>", compact=true)`
+for the chosen repository. This reads GitHub now (a token is required); do
+not look for a saved snapshot. The tool paints the report. Do not restate
+figures.
+
+### 4. Schedule the loop
+
+Call `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the
+analyzed repository. Do not pass `include_report`: the report was just shown.
+The loop runs weekdays at 08:00 local time; the card states the schedule and
+how to run it at another time, so do not ask about the cadence.
+Output `response_text` verbatim and stop. Each later tick is the same
+analytics report, not a CI code fix.

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
@@ -50,6 +50,9 @@ report for weekday mornings in this shell's inbox.
 - Never run `gh`, `git`, or `shell_run` for this flow.
 - If a tool reports a missing GitHub token, say `opensre integrations setup github`
   and stop. Do not fall back to another data source.
+- If the analysis result is not successful for any other reason (the
+  repository cannot be read, a rate limit, an error), say why in one line and
+  stop. Do not schedule a loop whose first report never appeared.
 - Decision points use `ask_user_choice` with the exact option texts below.
   End the turn after calling it; the answer arrives as the next user message.
 - The analyze tool paints the report; do not restate its figures. Then output

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
@@ -64,7 +64,7 @@ Track progress with the `update_plan` tool, not with headers or prose:
   `explanation` (this is not a diagnosis; no hypothesis table):
   `Scan this machine` / `Pick the repository` / `Analyze CI/CD reliability` /
   `Schedule the loop`.
-- When the request already names the repository, omit the first two steps
+- When the request or an Ask User answer already names the repository, omit the first two steps
   from the plan instead of renumbering.
 - After a step's tool results, call `update_plan` marking it `completed` and
   the next step `in_progress`, in the same response as the next step's tool
@@ -91,9 +91,9 @@ answer arrives as the next user message.
 
 Call
 `analyze_github_ci_reliability(owner="<owner>", repo="<repo>", compact=true)`
-for the chosen repository. This reads GitHub now (a token is required); do
-not look for a saved snapshot. The tool paints the report. Do not restate
-figures.
+for the chosen repository. A saved report from today is reused; otherwise
+this reads GitHub (a token is required). The tool paints the report. Do
+not restate figures.
 
 ### 4. Schedule the loop
 

--- a/core/agent_harness/session/pending_choice.py
+++ b/core/agent_harness/session/pending_choice.py
@@ -19,6 +19,11 @@ from dataclasses import dataclass, field
 _ANSWER_HEADER = re.compile(r"^(\d+)\.\s+(.+)$")
 
 
+def question_key(title: str) -> str:
+    """Identity of a question for matching it to an answer: whitespace and case folded."""
+    return " ".join(title.split()).casefold()
+
+
 @dataclass(frozen=True, slots=True)
 class AskUserQuestion:
     """One question in a batched Ask User payload."""
@@ -118,4 +123,5 @@ __all__ = [
     "PendingUserChoice",
     "format_ask_user_answers",
     "parse_ask_user_answers",
+    "question_key",
 ]

--- a/core/agent_harness/spi/handoff.py
+++ b/core/agent_harness/spi/handoff.py
@@ -12,10 +12,12 @@ from core.agent_harness.session.pending_choice import (
     AskUserQuestion,
     format_ask_user_answers,
     parse_ask_user_answers,
+    question_key,
 )
 
 __all__ = [
     "AskUserQuestion",
     "format_ask_user_answers",
     "parse_ask_user_answers",
+    "question_key",
 ]

--- a/core/agent_harness/turns/skill_after_tool.py
+++ b/core/agent_harness/turns/skill_after_tool.py
@@ -14,7 +14,7 @@ from core.agent_harness.prompts.skills.loader import (
     SkillAfterToolHook,
     list_action_skills,
 )
-from core.agent_harness.session.pending_choice import PendingUserChoice
+from core.agent_harness.session.pending_choice import PendingUserChoice, question_key
 from core.agent_harness.session.terminal_access import session_terminal, set_auto_command
 from core.tool.execution import (
     ToolExecutionHooks,
@@ -42,6 +42,14 @@ def _hook_key(skill: ActionSkill, hook: SkillAfterToolHook) -> str:
 def _already_fired(session: Any, key: str) -> bool:
     fired = getattr(session, "skill_hooks_fired", None)
     return isinstance(fired, set) and key in fired
+
+
+def _already_answered(session: Any, hook: SkillAfterToolHook) -> bool:
+    """True when the session already holds the user's answer to this hook's question."""
+    settled = getattr(session, "questions_already_answered", None)
+    if not isinstance(settled, set):
+        return False
+    return question_key(str(hook.call.args.get("title") or "")) in settled
 
 
 def _mark_fired(session: Any, key: str) -> None:
@@ -110,7 +118,7 @@ def with_skill_after_tool(
             if hook.after != name:
                 continue
             key = _hook_key(skill, hook)
-            if _already_fired(session, key):
+            if _already_fired(session, key) or _already_answered(session, hook):
                 continue
             if not _run_hook(session, hook, result):
                 continue

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -36,9 +36,10 @@ The agent guides you through the selected demo in the shell.
 2. **Pick a repository.** A menu lists your checkouts that have GitHub Actions
    workflows, then the open-source example, then a row to type your own.
 3. **Analyze.** It reads the repository's Actions history for the last 30 days
-   and paints the report (key results first: how long main was red) plus a
-   comparison table against apache/airflow and fastapi/fastapi over the same
-   window. A repository already read today is answered from its snapshot.
+   and paints the report: one sentence on what waiting on CI cost, the key
+   results, then a comparison table against apache/airflow and fastapi/fastapi.
+   The benchmark columns ship with OpenSRE and name the day they were
+   measured. Every analysis reads GitHub; nothing is answered from a cache.
 4. **Next step.** A menu offers the CI reliability agent (it schedules the
    check for the repository you just analyzed, no second repository question),
    the Slack hand-off, or exit.
@@ -87,11 +88,13 @@ yet is shown when it differs.
 ## The CI reliability agent
 
 Pick "Set up an agent that improves CI/CD reliability over time" from the
-startup menu to schedule the analysis as a recurring check. The demo scans your
-machine, asks which repository to watch and when to run (weekdays at 08:00
-local time is the default), and creates the loop. Choosing this option after
-an analytics report schedules that repository without asking you to pick it
-again. Every run analyzes the last 7 days; use `/loops run <id>` to run it now.
+startup menu to analyze the repository now, then schedule that report as a
+recurring check.
+The demo scans your machine, asks which repository to watch, reads GitHub
+Actions (a token is required), and creates the loop (weekdays at 08:00 local
+time by default). Choosing this option after an analytics report schedules
+that repository without asking you to pick it again. Every later run analyzes
+the last 7 days; use `/loops run <id>` to run it now.
 
 - Reports land in this shell's inbox: `/loops messages`. The loop never posts
   to Slack or any chat channel, even when those integrations are configured.

--- a/integrations/github/tools/ci_analytics/benchmarks.py
+++ b/integrations/github/tools/ci_analytics/benchmarks.py
@@ -1,0 +1,63 @@
+"""Measured CI reliability figures for well-known repositories, shipped with the product.
+
+A first run has no saved snapshots, so a comparison built from local snapshots
+is empty exactly when it matters most. These figures were measured with this
+tool over a 30-day window and travel with the release; the report names the day
+they were taken so none of it reads as today's data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from types import MappingProxyType
+
+WINDOW_DAYS = 30
+MEASURED_ON = date(2026, 9, 9)
+
+
+@dataclass(frozen=True)
+class Benchmark:
+    """One well-known repository's figures, as measured on :data:`MEASURED_ON`."""
+
+    owner: str
+    repo: str
+    figures: Mapping[str, str]
+
+    @property
+    def label(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+
+BENCHMARKS: tuple[Benchmark, ...] = (
+    Benchmark(
+        owner="apache",
+        repo="airflow",
+        figures=MappingProxyType(
+            {
+                "Red time on main": "3.4%",
+                "Mean time to green": "6.1h",
+                "CI-caused failure rate": "4.3%",
+                "Slowest normal run": "105m",
+                "PR failure rate": "25.4%",
+            }
+        ),
+    ),
+    Benchmark(
+        owner="fastapi",
+        repo="fastapi",
+        figures=MappingProxyType(
+            {
+                "Red time on main": "0.0%",
+                "Mean time to green": "n/a",
+                "CI-caused failure rate": "0.0%",
+                "Slowest normal run": "5m",
+                "PR failure rate": "19.1%",
+            }
+        ),
+    ),
+)
+
+
+__all__ = ["BENCHMARKS", "MEASURED_ON", "WINDOW_DAYS", "Benchmark"]

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -181,7 +181,8 @@ def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -
             **report_payload(report),
         },
     )
-    return "\n".join([render_markdown(report), "", headline(report), "", f"Raw data: {snapshot}"])
+    # The rendered report already leads with the headline sentence.
+    return "\n".join([render_markdown(report), "", f"Raw data: {snapshot}"])
 
 
 def loop_card(scheduled: ScheduledLoop) -> LoopCard:

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -181,7 +181,8 @@ def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -
             **report_payload(report),
         },
     )
-    # The rendered report already leads with the headline sentence.
+    # The rendered report leads with the headline sentence when there were
+    # runs, and says so when there were none.
     return "\n".join([render_markdown(report), "", f"Raw data: {snapshot}"])
 
 

--- a/integrations/github/tools/ci_analytics/loop_tool.py
+++ b/integrations/github/tools/ci_analytics/loop_tool.py
@@ -22,9 +22,9 @@ TOOL_NAME = "schedule_ci_reliability_loop"
         "prompt loop that re-runs the reliability analytics and delivers the report "
         "to this shell's inbox. Weekdays at 08:00 local time unless told otherwise. "
         "Never posts to Slack or any chat channel. Returns the schedule card to "
-        "repeat verbatim; with include_report=true, today's saved report (key "
-        "results and compare) comes first when a same-day snapshot exists. Never "
-        "reads GitHub live."
+        "repeat verbatim. With include_report=true, a report already saved today "
+        "is placed above the card; otherwise the card stands alone. Never reads "
+        "GitHub live — analyze first when the user has not seen a report yet."
     ),
     use_cases=[
         "Set up an agent that improves CI/CD reliability over time",

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -44,7 +44,7 @@ _TOP_DEVELOPERS = 3
 
 
 def render_markdown(report: CiAnalyticsReport, *, compact: bool = False) -> str:
-    """Markdown report: key results lead. ``compact`` omits the counts appendix."""
+    """Markdown report: the cost sentence, then key results. ``compact`` omits the counts appendix."""
     lines = [
         f"**CI/CD reliability for {_plain(report.owner)}/{_plain(report.repo)}, "
         f"last {report.window_days} days**",
@@ -63,7 +63,7 @@ def render_markdown(report: CiAnalyticsReport, *, compact: bool = False) -> str:
 
 
 def render_report(console: Any, report: CiAnalyticsReport, *, compact: bool = False) -> None:
-    """Paint the report: key results first. ``compact`` omits the counts appendix."""
+    """Paint the report: the cost sentence, then key results. ``compact`` omits the counts appendix."""
     _paint(console, render_markdown(report, compact=compact))
 
 
@@ -78,7 +78,7 @@ def _paint(console: Any, markdown: str) -> None:
 
 
 def key_results(report: CiAnalyticsReport) -> list[tuple[str, str]]:
-    """The five figures a reader takes away, red time first."""
+    """The figures a reader takes away, red time first; the cost itself is the headline."""
     window_hours = max(1, report.window_days * 24)
     red_share = report.red_hours / window_hours
     results: list[tuple[str, str]] = [
@@ -146,25 +146,30 @@ def comparison_figures(report: CiAnalyticsReport) -> dict[str, str]:
     }
 
 
+def peer_benchmarks(
+    user: CiAnalyticsReport, benchmarks: Sequence[Benchmark] = BENCHMARKS
+) -> tuple[Benchmark, ...]:
+    """The shipped benchmarks other than the repository being analyzed."""
+    own = (user.owner.casefold(), user.repo.casefold())
+    return tuple(
+        item for item in benchmarks if (item.owner.casefold(), item.repo.casefold()) != own
+    )
+
+
 def render_comparison(
-    console: Any,
-    user: CiAnalyticsReport,
-    benchmarks: Sequence[Benchmark] = BENCHMARKS,
+    console: Any, user: CiAnalyticsReport, benchmarks: Sequence[Benchmark]
 ) -> None:
-    """One table: the user's repository first, then the shipped benchmark columns."""
+    """One table: the user's repository first, then the benchmark columns."""
     # A markdown leading newline is dropped, so the heading would sit on the
     # report's last bullet; separate the two sections here.
     console.print()
     _paint(console, comparison_markdown(user, benchmarks))
 
 
-def comparison_markdown(
-    user: CiAnalyticsReport,
-    benchmarks: Sequence[Benchmark] = BENCHMARKS,
-) -> str:
+def comparison_markdown(user: CiAnalyticsReport, benchmarks: Sequence[Benchmark]) -> str:
     """Markdown form of :func:`render_comparison`."""
     if not benchmarks:
-        return "No benchmark figures shipped with this build."
+        return "No benchmark figures to compare with."
     labels = [f"{_plain(user.owner)}/{_plain(user.repo)}"] + [
         _plain(item.label) for item in benchmarks
     ]
@@ -185,6 +190,7 @@ def comparison_markdown(
             *rows,
             "",
             f"- {_benchmark_note()}",
+            f"- {_NEXT_STEP}",
         ]
     )
 
@@ -195,6 +201,10 @@ def _benchmark_note() -> str:
         f"Benchmark columns were measured with this tool over "
         f"{BENCHMARK_WINDOW_DAYS} days on {MEASURED_ON:%d %b %Y}."
     )
+
+
+#: Painted under the table so the next menu is not the first time the cost is named.
+_NEXT_STEP = "The wait at the top is the cost. Next: schedule a weekday copy of this report."
 
 
 def _details_markdown(report: CiAnalyticsReport) -> list[str]:
@@ -317,14 +327,18 @@ def headline(report: CiAnalyticsReport) -> str:
     """One plain sentence naming what unreliable CI cost, for the top of the report."""
     if report.blocked_working_minutes > 0:
         developers = report.developers_affected
-        cost = (
-            f"Waiting on CI cost {_working(report.blocked_working_minutes)} of developer time "
-            f"in the last {report.window_days} days"
-        )
+        total = _working(report.blocked_working_minutes)
         if not developers:
-            return f"{cost}."
-        per_week = report.blocked_working_minutes / developers / (report.window_days / 7)
-        return f"{cost}, about {_working(per_week)} per developer a week."
+            return (
+                f"Waiting on CI cost {total} of developer time in the last "
+                f"{report.window_days} days."
+            )
+        heaviest = report.developer_waits[0]
+        return (
+            f"Waiting on CI cost {developers} {_plural(developers, 'developer')} {total} of "
+            f"working time in the last {report.window_days} days, up to "
+            f"{_working(heaviest.working_minutes_per_week)} a week for the worst hit."
+        )
     if report.blocked_minutes > 0:
         return (
             f"Waiting on CI held up merged pull requests for {_minutes(report.blocked_minutes)}, "
@@ -332,9 +346,10 @@ def headline(report: CiAnalyticsReport) -> str:
         )
     if report.red_hours > 0:
         return (
-            f"Nobody could merge on {_plain(report.default_branch)} for "
-            f"{_hours(report.red_hours)} in the last {report.window_days} days, across "
-            f"{len(report.outages)} {_plural(len(report.outages), 'breakage')}."
+            f"No merged pull request waited on a CI-caused failure in the last "
+            f"{report.window_days} days; {_plain(report.default_branch)} was red for "
+            f"{_hours(report.red_hours)} across {len(report.outages)} "
+            f"{_plural(len(report.outages), 'breakage')}."
         )
     if report.pr_failures:
         return (
@@ -447,6 +462,7 @@ __all__ = [
     "comparison_markdown",
     "key_results",
     "key_results_payload",
+    "peer_benchmarks",
     "render_ci_report",
     "render_comparison",
     "format_minutes",

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
 
@@ -9,6 +10,14 @@ from rich.padding import Padding
 
 import infrastructure.terminal.theme as ui_theme
 from infrastructure.terminal.markdown import ReplyMarkdown
+from integrations.github.tools.ci_analytics.benchmarks import (
+    BENCHMARKS,
+    MEASURED_ON,
+    Benchmark,
+)
+from integrations.github.tools.ci_analytics.benchmarks import (
+    WINDOW_DAYS as BENCHMARK_WINDOW_DAYS,
+)
 from integrations.github.tools.ci_analytics.models import (
     CiAnalyticsReport,
     FailureKind,
@@ -41,6 +50,8 @@ def render_markdown(report: CiAnalyticsReport, *, compact: bool = False) -> str:
         f"last {report.window_days} days**",
         "",
     ]
+    if report.executions:
+        lines.extend([headline(report), ""])
     lines.extend(_key_results_markdown(report))
     if report.executions:
         if not compact:
@@ -105,20 +116,6 @@ def key_results(report: CiAnalyticsReport) -> list[tuple[str, str]]:
         results.append(
             ("Slowest normal run", f"{_plain(slowest.workflow)}, {slowest.normal_minutes:.0f}m")
         )
-    if report.blocked_working_minutes > 0:
-        developers = report.developers_affected
-        per_week = (
-            report.blocked_working_minutes / developers / (report.window_days / 7)
-            if developers
-            else 0.0
-        )
-        extra = f", about {_working(per_week)} per developer a week" if developers else ""
-        results.append(
-            (
-                "Developer time blocked",
-                f"{_working(report.blocked_working_minutes)} of working time{extra}",
-            )
-        )
     return results
 
 
@@ -149,79 +146,55 @@ def comparison_figures(report: CiAnalyticsReport) -> dict[str, str]:
     }
 
 
-def skip_lines(skipped: list[str]) -> list[str]:
-    """Guest-visible reason a benchmark column is missing."""
-    return [f"Skipped {_plain(item)}." for item in skipped]
-
-
 def render_comparison(
     console: Any,
     user: CiAnalyticsReport,
-    peers: list[CiAnalyticsReport],
-    *,
-    skipped: list[str] | None = None,
+    benchmarks: Sequence[Benchmark] = BENCHMARKS,
 ) -> None:
-    """One table: the user's repo first, then the benchmark columns."""
+    """One table: the user's repository first, then the shipped benchmark columns."""
     # A markdown leading newline is dropped, so the heading would sit on the
     # report's last bullet; separate the two sections here.
     console.print()
-    _paint(console, comparison_markdown(user, peers, skipped=skipped))
+    _paint(console, comparison_markdown(user, benchmarks))
 
 
 def comparison_markdown(
     user: CiAnalyticsReport,
-    peers: list[CiAnalyticsReport],
-    *,
-    skipped: list[str] | None = None,
+    benchmarks: Sequence[Benchmark] = BENCHMARKS,
 ) -> str:
     """Markdown form of :func:`render_comparison`."""
-    missed = list(skipped or [])
-    if not peers:
-        lines = [
-            "Compared with well-known repositories:",
-            "",
-            "No benchmark columns — no same-day snapshot. "
-            "The report above is this repository only.",
-            *skip_lines(missed),
-        ]
-        return "\n".join(lines)
-    reports = [user, *peers]
-    labels = [f"{_plain(item.owner)}/{_plain(item.repo)}" for item in reports]
-    figures = [comparison_figures(item) for item in reports]
+    if not benchmarks:
+        return "No benchmark figures shipped with this build."
+    labels = [f"{_plain(user.owner)}/{_plain(user.repo)}"] + [
+        _plain(item.label) for item in benchmarks
+    ]
+    figures: list[Mapping[str, str]] = [comparison_figures(user), *(b.figures for b in benchmarks)]
     header = "| Metric | " + " | ".join(labels) + " |"
     align = "| --- | " + " | ".join("---:" for _ in labels) + " |"
     rows = [
         "| " + metric + " | " + " | ".join(row.get(metric, "n/a") for row in figures) + " |"
         for metric in figures[0]
     ]
-    peers_label = " and ".join(labels[1:]) if labels[1:] else "benchmarks"
+    peers_label = " and ".join(labels[1:])
     return "\n".join(
         [
-            f"Compared with {peers_label} over the same {user.window_days} days:",
+            f"Compared with {peers_label}:",
             "",
             header,
             align,
             *rows,
             "",
-            *[f"- {note}" for note in [*_comparison_notes(peers), *skip_lines(missed)]],
+            f"- {_benchmark_note()}",
         ]
     )
 
 
-def _comparison_notes(peers: list[CiAnalyticsReport]) -> list[str]:
-    """Say when 0% red is a green window, not a missing fetch."""
-    notes: list[str] = []
-    seen: set[str] = set()
-    for peer in peers:
-        name = f"{_plain(peer.owner)}/{_plain(peer.repo)}"
-        if peer.red_hours == 0 and name not in seen:
-            seen.add(name)
-            if peer.branch_runs:
-                notes.append(f"{name}: default branch stayed green in this window.")
-            else:
-                notes.append(f"{name}: no default-branch runs in this window.")
-        notes.extend(peer.coverage_notices)
-    return notes
+def _benchmark_note() -> str:
+    """Name what the benchmark columns are, so they are never read as live figures."""
+    return (
+        f"Benchmark columns were measured with this tool over "
+        f"{BENCHMARK_WINDOW_DAYS} days on {MEASURED_ON:%d %b %Y}."
+    )
 
 
 def _details_markdown(report: CiAnalyticsReport) -> list[str]:
@@ -341,29 +314,27 @@ def _day(when: datetime | None) -> str:
 
 
 def headline(report: CiAnalyticsReport) -> str:
-    """One deterministic sentence naming the biggest cost."""
+    """One plain sentence naming what unreliable CI cost, for the top of the report."""
     if report.blocked_working_minutes > 0:
-        heaviest = report.developer_waits[0]
         developers = report.developers_affected
-        return (
-            f"Unreliable CI cost {developers} {_plural(developers, 'developer')} "
-            f"{_working(report.blocked_working_minutes)} of working time in the last "
-            f"{report.window_days} days, up to {_working(heaviest.working_minutes_per_week)} a "
-            f"week for the worst hit; {_minutes(report.blocked_minutes)} of wall-clock wait "
-            f"across {report.merged_pr_branches} merged {_plural(report.merged_pr_branches, 'PR')}."
+        cost = (
+            f"Waiting on CI cost {_working(report.blocked_working_minutes)} of developer time "
+            f"in the last {report.window_days} days"
         )
+        if not developers:
+            return f"{cost}."
+        per_week = report.blocked_working_minutes / developers / (report.window_days / 7)
+        return f"{cost}, about {_working(per_week)} per developer a week."
     if report.blocked_minutes > 0:
         return (
-            f"Unreliable CI blocked merged pull requests for {_minutes(report.blocked_minutes)} "
-            f"of wall-clock time in the last {report.window_days} days, all of it outside "
-            f"working hours ({report.working_hours_label})."
+            f"Waiting on CI held up merged pull requests for {_minutes(report.blocked_minutes)}, "
+            f"all of it outside working hours ({report.working_hours_label})."
         )
     if report.red_hours > 0:
         return (
-            f"{_plain(report.default_branch)} was red for {_hours(report.red_hours)} across "
-            f"{len(report.outages)} {_plural(len(report.outages), 'breakage')} in the last "
-            f"{report.window_days} days, with a mean recovery of "
-            f"{_hours(report.mean_recovery_hours or 0.0)}."
+            f"Nobody could merge on {_plain(report.default_branch)} for "
+            f"{_hours(report.red_hours)} in the last {report.window_days} days, across "
+            f"{len(report.outages)} {_plural(len(report.outages), 'breakage')}."
         )
     if report.pr_failures:
         return (
@@ -474,7 +445,6 @@ __all__ = [
     "ci_report_headline",
     "comparison_figures",
     "comparison_markdown",
-    "skip_lines",
     "key_results",
     "key_results_payload",
     "render_ci_report",

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -157,7 +157,9 @@ def peer_benchmarks(
 
 
 def render_comparison(
-    console: Any, user: CiAnalyticsReport, benchmarks: Sequence[Benchmark]
+    console: Any,
+    user: CiAnalyticsReport,
+    benchmarks: Sequence[Benchmark] | None = None,
 ) -> None:
     """One table: the user's repository first, then the benchmark columns."""
     # A markdown leading newline is dropped, so the heading would sit on the
@@ -166,8 +168,15 @@ def render_comparison(
     _paint(console, comparison_markdown(user, benchmarks))
 
 
-def comparison_markdown(user: CiAnalyticsReport, benchmarks: Sequence[Benchmark]) -> str:
-    """Markdown form of :func:`render_comparison`."""
+def comparison_markdown(
+    user: CiAnalyticsReport,
+    benchmarks: Sequence[Benchmark] | None = None,
+    *,
+    next_step: bool = True,
+) -> str:
+    """Markdown form of :func:`render_comparison`; ``next_step`` adds the closing recommendation."""
+    if benchmarks is None:
+        benchmarks = peer_benchmarks(user)
     if not benchmarks:
         return "No benchmark figures to compare with."
     labels = [f"{_plain(user.owner)}/{_plain(user.repo)}"] + [
@@ -190,7 +199,7 @@ def comparison_markdown(user: CiAnalyticsReport, benchmarks: Sequence[Benchmark]
             *rows,
             "",
             f"- {_benchmark_note()}",
-            f"- {_NEXT_STEP}",
+            *([f"- {_NEXT_STEP}"] if next_step else []),
         ]
     )
 
@@ -204,7 +213,7 @@ def _benchmark_note() -> str:
 
 
 #: Painted under the table so the next menu is not the first time the cost is named.
-_NEXT_STEP = "The wait at the top is the cost. Next: schedule a weekday copy of this report."
+_NEXT_STEP = "Next: schedule this report for weekday mornings, or hand it to your team in Slack."
 
 
 def _details_markdown(report: CiAnalyticsReport) -> list[str]:

--- a/integrations/github/tools/ci_analytics/snapshots.py
+++ b/integrations/github/tools/ci_analytics/snapshots.py
@@ -40,7 +40,10 @@ def write_snapshot(
     The owner and repository are stored in the file too, so a read can check
     that a snapshot belongs to the repository it is answering for.
     """
-    target = _folder(root, owner, repo) / f"{now:%Y-%m-%dT%H%M%SZ}.json"
+    window = int(payload.get("window_days") or 0)
+    stamp = f"{now:%Y-%m-%dT%H%M%SZ}"
+    name = f"{stamp}-{window}d.json" if window else f"{stamp}.json"
+    target = _folder(root, owner, repo) / name
     target.parent.mkdir(parents=True, exist_ok=True)
     stamped = {**payload, "owner": owner, "repo": repo}
     target.write_text(json.dumps(stamped, indent=2, sort_keys=True, default=str), encoding="utf-8")

--- a/integrations/github/tools/ci_analytics/snapshots.py
+++ b/integrations/github/tools/ci_analytics/snapshots.py
@@ -1,10 +1,8 @@
 """On-disk snapshots of CI reliability reports, shared by the loop tick and the tool.
 
-A snapshot is the report's raw figures plus when they were computed. The
-loop writes one per tick; the tool writes one per live analysis and reuses a
-fresh one for the same repository and window instead of reading GitHub
-again, which matters for benchmark repositories whose 30-day history takes
-minutes to read.
+A snapshot is the report's raw figures plus when they were computed. The loop
+writes one per tick and the tool one per live analysis; the schedule card reads
+today's to show the report beside it. A live analysis never answers from one.
 """
 
 from __future__ import annotations

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -24,6 +24,7 @@ from integrations.github.helpers import (
 )
 from integrations.github.repo_scope import detect_git_remote_repo_scope
 from integrations.github.tools.ci_analytics.analysis import analyze_repository
+from integrations.github.tools.ci_analytics.benchmarks import BENCHMARKS, MEASURED_ON
 from integrations.github.tools.ci_analytics.loop import LOOP_WINDOW_DAYS
 from integrations.github.tools.ci_analytics.models import CiAnalyticsReport, FailureKind
 from integrations.github.tools.ci_analytics.render import (
@@ -50,7 +51,6 @@ _SOURCE = "github"
 _DEFAULT_WINDOW_DAYS = 30
 _MIN_WINDOW_DAYS = 1
 _MAX_WINDOW_DAYS = 90
-_DEFAULT_BENCHMARKS = (("apache", "airflow"), ("fastapi", "fastapi"))
 
 
 def _flag(value: Any) -> bool:
@@ -182,35 +182,23 @@ def _from_snapshot(
     owner: str,
     repo: str,
     window: int,
-    console: Any,
     *,
     include_benchmarks: bool = True,
-    compact: bool = False,
 ) -> dict[str, Any] | None:
-    """Answer from a same-day snapshot, or ``None`` when it holds no usable report.
-
-    A snapshot written before the report object was saved cannot produce the
-    comparison, so it counts as a miss and the caller reads GitHub instead.
-    """
+    """The saved report as markdown, or ``None`` when the snapshot holds no report object."""
     saved = snapshot.get("report")
     report = report_from_dict(saved) if isinstance(saved, dict) else None
     if report is None:
         return None
     generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
-    if console is not None:
-        console.print(
-            f"  [dim]Using the CI reliability snapshot of {escape(f'{owner}/{repo}')} "
-            f"from {generated} UTC (same {window}-day window).[/dim]"
-        )
-        console.print()
     result = _result(
         report,
         owner,
         repo,
         window,
-        console,
+        None,
         include_benchmarks=include_benchmarks,
-        compact=compact,
+        compact=True,
     )
     result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
     result["from_snapshot"] = snapshot.get("generated_at")
@@ -234,74 +222,28 @@ def report_text_from_snapshot(
             break
     else:
         return "", ""
-    result = _from_snapshot(
-        snapshot, owner, repo, window, None, include_benchmarks=include_benchmarks, compact=True
-    )
+    result = _from_snapshot(snapshot, owner, repo, window, include_benchmarks=include_benchmarks)
     if result is None or not result.get("success"):
         return "", ""
     return str(result.get("response_text") or "").strip(), str(snapshot.get("generated_at", ""))
-
-
-def _peer_payload(report: CiAnalyticsReport, *, from_snapshot: str | None) -> dict[str, Any]:
-    return {
-        "owner": report.owner,
-        "repo": report.repo,
-        "from_snapshot": from_snapshot,
-        "key_results": key_results_payload(report),
-        "red_hours": round(report.red_hours, 2),
-        "mean_recovery_hours": report.mean_recovery_hours,
-        "pr_failure_rate": report.pr_failure_rate,
-        "reliability_failures": report.count(FailureKind.RELIABILITY),
-        "pr_executions": report.pr_executions,
-    }
-
-
-def _load_peer_report(
-    owner: str,
-    repo: str,
-    *,
-    window: int,
-    now: datetime,
-) -> tuple[CiAnalyticsReport, str | None] | None:
-    """Today's snapshot for a benchmark repo, or ``None`` (no live fetch)."""
-    snapshot = read_fresh_snapshot(snapshot_root(), owner, repo, window_days=window, now=now)
-    if snapshot is None:
-        return None
-    saved = snapshot.get("report")
-    if not isinstance(saved, dict):
-        return None
-    return report_from_dict(saved), str(snapshot.get("generated_at") or "")
 
 
 def _attach_benchmarks(
     result: dict[str, Any],
     report: CiAnalyticsReport,
     *,
-    window: int,
     console: Any,
 ) -> dict[str, Any]:
-    """Add the host comparison table from same-day peer snapshots."""
-    now = datetime.now(UTC)
-    peers: list[CiAnalyticsReport] = []
-    rows: list[dict[str, Any]] = []
-    skipped: list[str] = []
-    for owner, repo in _DEFAULT_BENCHMARKS:
-        if owner == report.owner and repo == report.repo:
-            continue
-        loaded = _load_peer_report(owner, repo, window=window, now=now)
-        if loaded is None:
-            skipped.append(f"{owner}/{repo} (no same-day snapshot)")
-            continue
-        peer, stamp = loaded
-        peers.append(peer)
-        rows.append(_peer_payload(peer, from_snapshot=stamp))
-    result["benchmarks"] = rows
-    if skipped:
-        result["benchmarks_skipped"] = skipped
+    """Add the comparison against the benchmark figures shipped with the product."""
+    result["benchmarks"] = [
+        {"owner": item.owner, "repo": item.repo, "figures": dict(item.figures)}
+        for item in BENCHMARKS
+    ]
+    result["benchmarks_measured_on"] = MEASURED_ON.isoformat()
     if console is not None:
-        render_comparison(console, report, peers, skipped=skipped)
+        render_comparison(console, report)
         return result
-    compare = comparison_markdown(report, peers, skipped=skipped)
+    compare = comparison_markdown(report)
     result["comparison_text"] = compare
     result["response_text"] = f"{result['response_text']}\n\n{compare}"
     return result
@@ -353,7 +295,7 @@ def _result(
             "response_text": render_markdown(report, compact=compact),
         }
     if include_benchmarks:
-        result = _attach_benchmarks(result, report, window=window, console=console)
+        result = _attach_benchmarks(result, report, console=console)
     return result
 
 
@@ -366,11 +308,13 @@ def _result(
         "reliability KPIs: executions, PR failure rate, failures classified as "
         "CI-caused (same commit passed later) versus source-code, developer time "
         "blocked by unreliable CI on merged PRs, and default-branch red time. "
-        "Read-only. A same-day snapshot answers without a token; a live GitHub "
-        "read needs a token. Every report also carries a comparison with "
-        "apache/airflow and fastapi/fastapi built from same-day snapshots: it "
-        "costs no extra request and cannot be turned off, so never offer to skip "
-        "it. The report is painted on screen — do not restate its figures."
+        "Read-only. Every analysis reads GitHub Actions and needs a token; a "
+        "saved snapshot is written for the scheduled loop, never used to answer "
+        "here. Every report also carries a comparison with apache/airflow and "
+        "fastapi/fastapi from figures shipped with the product, so a first run "
+        "compares as well as a later one. It cannot be turned off, so never "
+        "offer to skip it. The report is painted on screen — do not restate "
+        "its figures."
     ),
     use_cases=[
         "Analyze a repository's CI/CD performance and reliability",
@@ -394,7 +338,7 @@ def _result(
         "headline": "One sentence naming the biggest cost (already painted; do not repeat)",
         "key_results": "The five takeaway rows, red time first, even when the shell painted the report",
         "response_text": "The rendered report, or a one-line summary when the shell painted it",
-        "benchmarks": "Airflow and FastAPI rows from the same window, when a snapshot exists",
+        "benchmarks": "Airflow and FastAPI rows from figures shipped with the product",
     },
     surfaces=(ToolSurface.CHAT, ToolSurface.ACTION),
     side_effect_level=SideEffectLevel.READ_ONLY,
@@ -453,10 +397,11 @@ def analyze_github_ci_reliability(
     In the interactive shell the report is painted straight to the console so
     every figure the user sees is the computed one; the returned
     ``response_text`` then only summarizes. Other surfaces get the markdown.
-    The same call also paints one comparison table against apache/airflow and
-    fastapi/fastapi, built from same-day snapshots only — never a live fetch. The
-    comparison is not the model's choice to make; ``compact`` drops the counts
-    appendix.
+    The same call also paints one comparison table against the benchmark
+    figures shipped with the product, so a first run compares as well as a
+    hundredth. Every analysis reads GitHub: a saved snapshot is written for the
+    scheduled loop, never used to answer here. The comparison is not the
+    model's choice to make; ``compact`` drops the counts appendix.
     """
     window = min(max(int(days or _DEFAULT_WINDOW_DAYS), _MIN_WINDOW_DAYS), _MAX_WINDOW_DAYS)
     brief = _flag(compact)
@@ -474,21 +419,7 @@ def analyze_github_ci_reliability(
         )
     now = datetime.now(UTC)
     console = _console(context)
-    snapshot = read_fresh_snapshot(
-        snapshot_root(), repo_owner, repo_name, window_days=window, now=now
-    )
     token = resolve_github_token(github_token)
-    if snapshot is not None:
-        answered = _from_snapshot(
-            snapshot,
-            repo_owner,
-            repo_name,
-            window,
-            console,
-            compact=brief,
-        )
-        if answered is not None:
-            return answered
     if not token:
         message = (
             f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -178,6 +178,42 @@ def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
     }
 
 
+def _from_snapshot(
+    snapshot: dict[str, Any],
+    owner: str,
+    repo: str,
+    window: int,
+    console: Any,
+    *,
+    include_benchmarks: bool = True,
+    compact: bool = False,
+) -> dict[str, Any] | None:
+    """Answer from a saved report, or ``None`` when it holds no usable report object."""
+    saved = snapshot.get("report")
+    report = report_from_dict(saved) if isinstance(saved, dict) else None
+    if report is None:
+        return None
+    generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
+    if console is not None:
+        console.print(
+            f"  [dim]Using the CI reliability snapshot of {escape(f'{owner}/{repo}')} "
+            f"from {generated} UTC (same {window}-day window).[/dim]"
+        )
+        console.print()
+    result = _result(
+        report,
+        owner,
+        repo,
+        window,
+        console,
+        include_benchmarks=include_benchmarks,
+        compact=compact,
+    )
+    result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
+    result["from_snapshot"] = snapshot.get("generated_at")
+    return result
+
+
 def report_text_from_snapshot(
     owner: str, repo: str, *, days: int = _DEFAULT_WINDOW_DAYS, include_benchmarks: bool = True
 ) -> tuple[str, str]:
@@ -287,13 +323,12 @@ def _result(
         "reliability KPIs: executions, PR failure rate, failures classified as "
         "CI-caused (same commit passed later) versus source-code, developer time "
         "blocked by unreliable CI on merged PRs, and default-branch red time. "
-        "Read-only. Every analysis reads GitHub Actions and needs a token; a "
-        "saved snapshot is written for the scheduled loop, never used to answer "
-        "here. Every report also carries a comparison with apache/airflow and "
-        "fastapi/fastapi from figures shipped with the product, so a first run "
-        "compares as well as a later one. It cannot be turned off, so never "
-        "offer to skip it. The report is painted on screen — do not restate "
-        "its figures."
+        "Read-only. A saved report from today answers without another GitHub "
+        "read; a first run needs a token. Every report also carries a "
+        "comparison with apache/airflow and fastapi/fastapi from figures "
+        "shipped with the product, so a first run compares as well as a later "
+        "one. It cannot be turned off, so never offer to skip it. The report "
+        "is painted on screen — do not restate its figures."
     ),
     use_cases=[
         "Analyze a repository's CI/CD performance and reliability",
@@ -378,9 +413,9 @@ def analyze_github_ci_reliability(
     ``response_text`` then only summarizes. Other surfaces get the markdown.
     The same call also paints one comparison table against the benchmark
     figures shipped with the product, so a first run compares as well as a
-    hundredth. Every analysis reads GitHub: a saved snapshot is written for the
-    scheduled loop, never used to answer here. The comparison is not the
-    model's choice to make; ``compact`` drops the counts appendix.
+    hundredth. A saved report from today is reused; a miss reads GitHub and
+    writes the snapshot. The comparison is not the model's choice to make;
+    ``compact`` drops the counts appendix.
     """
     window = min(max(int(days or _DEFAULT_WINDOW_DAYS), _MIN_WINDOW_DAYS), _MAX_WINDOW_DAYS)
     brief = _flag(compact)
@@ -398,7 +433,21 @@ def analyze_github_ci_reliability(
         )
     now = datetime.now(UTC)
     console = _console(context)
+    snapshot = read_fresh_snapshot(
+        snapshot_root(), repo_owner, repo_name, window_days=window, now=now
+    )
     token = resolve_github_token(github_token)
+    if snapshot is not None:
+        answered = _from_snapshot(
+            snapshot,
+            repo_owner,
+            repo_name,
+            window,
+            console,
+            compact=brief,
+        )
+        if answered is not None:
+            return answered
     if not token:
         message = (
             f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -24,7 +24,7 @@ from integrations.github.helpers import (
 )
 from integrations.github.repo_scope import detect_git_remote_repo_scope
 from integrations.github.tools.ci_analytics.analysis import analyze_repository
-from integrations.github.tools.ci_analytics.benchmarks import BENCHMARKS, MEASURED_ON
+from integrations.github.tools.ci_analytics.benchmarks import MEASURED_ON
 from integrations.github.tools.ci_analytics.loop import LOOP_WINDOW_DAYS
 from integrations.github.tools.ci_analytics.models import CiAnalyticsReport, FailureKind
 from integrations.github.tools.ci_analytics.render import (
@@ -32,6 +32,7 @@ from integrations.github.tools.ci_analytics.render import (
     format_minutes,
     headline,
     key_results_payload,
+    peer_benchmarks,
     render_comparison,
     render_markdown,
     render_report,
@@ -177,42 +178,14 @@ def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
     }
 
 
-def _from_snapshot(
-    snapshot: dict[str, Any],
-    owner: str,
-    repo: str,
-    window: int,
-    *,
-    include_benchmarks: bool = True,
-) -> dict[str, Any] | None:
-    """The saved report as markdown, or ``None`` when the snapshot holds no report object."""
-    saved = snapshot.get("report")
-    report = report_from_dict(saved) if isinstance(saved, dict) else None
-    if report is None:
-        return None
-    generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
-    result = _result(
-        report,
-        owner,
-        repo,
-        window,
-        None,
-        include_benchmarks=include_benchmarks,
-        compact=True,
-    )
-    result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
-    result["from_snapshot"] = snapshot.get("generated_at")
-    return result
-
-
 def report_text_from_snapshot(
     owner: str, repo: str, *, days: int = _DEFAULT_WINDOW_DAYS, include_benchmarks: bool = True
 ) -> tuple[str, str]:
     """``(markdown, generated_at)`` from today's snapshot, or ``("", "")`` when none.
 
-    Compact: key results and the comparison, without the counts appendix.
-
-    Reads saved snapshots only; never resolves a token or starts a live fetch.
+    Compact: the cost sentence, key results and the comparison, without the
+    counts appendix. Reads saved snapshots only; never resolves a token or
+    starts a live fetch.
     """
     now = datetime.now(UTC)
     # The scheduled loop saves its own window; a same-day loop report counts too.
@@ -222,10 +195,14 @@ def report_text_from_snapshot(
             break
     else:
         return "", ""
-    result = _from_snapshot(snapshot, owner, repo, window, include_benchmarks=include_benchmarks)
-    if result is None or not result.get("success"):
+    saved = snapshot.get("report")
+    if not isinstance(saved, dict):
         return "", ""
-    return str(result.get("response_text") or "").strip(), str(snapshot.get("generated_at", ""))
+    report = report_from_dict(saved)
+    text = render_markdown(report, compact=True)
+    if include_benchmarks:
+        text = f"{text}\n\n{comparison_markdown(report, peer_benchmarks(report))}"
+    return text.strip(), str(snapshot.get("generated_at", ""))
 
 
 def _attach_benchmarks(
@@ -235,15 +212,15 @@ def _attach_benchmarks(
     console: Any,
 ) -> dict[str, Any]:
     """Add the comparison against the benchmark figures shipped with the product."""
+    peers = peer_benchmarks(report)
     result["benchmarks"] = [
-        {"owner": item.owner, "repo": item.repo, "figures": dict(item.figures)}
-        for item in BENCHMARKS
+        {"owner": item.owner, "repo": item.repo, "figures": dict(item.figures)} for item in peers
     ]
     result["benchmarks_measured_on"] = MEASURED_ON.isoformat()
     if console is not None:
-        render_comparison(console, report)
+        render_comparison(console, report, peers)
         return result
-    compare = comparison_markdown(report)
+    compare = comparison_markdown(report, peers)
     result["comparison_text"] = compare
     result["response_text"] = f"{result['response_text']}\n\n{compare}"
     return result
@@ -308,13 +285,12 @@ def _result(
         "reliability KPIs: executions, PR failure rate, failures classified as "
         "CI-caused (same commit passed later) versus source-code, developer time "
         "blocked by unreliable CI on merged PRs, and default-branch red time. "
-        "Read-only. Every analysis reads GitHub Actions and needs a token; a "
-        "saved snapshot is written for the scheduled loop, never used to answer "
-        "here. Every report also carries a comparison with apache/airflow and "
-        "fastapi/fastapi from figures shipped with the product, so a first run "
-        "compares as well as a later one. It cannot be turned off, so never "
-        "offer to skip it. The report is painted on screen — do not restate "
-        "its figures."
+        "Read-only. A saved report from today answers without another GitHub "
+        "read; a first run needs a token. Every report also carries a "
+        "comparison with apache/airflow and fastapi/fastapi from figures "
+        "shipped with the product, so a first run compares as well as a later "
+        "one. It cannot be turned off, so never offer to skip it. The report "
+        "is painted on screen — do not restate its figures."
     ),
     use_cases=[
         "Analyze a repository's CI/CD performance and reliability",
@@ -336,7 +312,7 @@ def _result(
         "blocked_working_minutes": "The part of that wait inside working hours: developer downtime",
         "red_hours": "Hours the default branch had at least one red workflow",
         "headline": "One sentence naming the biggest cost (already painted; do not repeat)",
-        "key_results": "The five takeaway rows, red time first, even when the shell painted the report",
+        "key_results": "The takeaway rows, red time first, even when the shell painted the report",
         "response_text": "The rendered report, or a one-line summary when the shell painted it",
         "benchmarks": "Airflow and FastAPI rows from figures shipped with the product",
     },
@@ -399,9 +375,9 @@ def analyze_github_ci_reliability(
     ``response_text`` then only summarizes. Other surfaces get the markdown.
     The same call also paints one comparison table against the benchmark
     figures shipped with the product, so a first run compares as well as a
-    hundredth. Every analysis reads GitHub: a saved snapshot is written for the
-    scheduled loop, never used to answer here. The comparison is not the
-    model's choice to make; ``compact`` drops the counts appendix.
+    hundredth. A saved report from today is reused; a miss reads GitHub and
+    writes the snapshot. The comparison is not the model's choice to make;
+    ``compact`` drops the counts appendix.
     """
     window = min(max(int(days or _DEFAULT_WINDOW_DAYS), _MIN_WINDOW_DAYS), _MAX_WINDOW_DAYS)
     brief = _flag(compact)
@@ -419,7 +395,21 @@ def analyze_github_ci_reliability(
         )
     now = datetime.now(UTC)
     console = _console(context)
+    snapshot = read_fresh_snapshot(
+        snapshot_root(), repo_owner, repo_name, window_days=window, now=now
+    )
     token = resolve_github_token(github_token)
+    if snapshot is not None:
+        answered = _from_snapshot(
+            snapshot,
+            repo_owner,
+            repo_name,
+            window,
+            console,
+            compact=brief,
+        )
+        if answered is not None:
+            return answered
     if not token:
         message = (
             f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "
@@ -472,7 +462,7 @@ def analyze_github_ci_reliability(
         )
     except OSError:
         # The analysis is the result; a snapshot that cannot be written only
-        # means the next call reads GitHub again.
+        # leaves the schedule card without today's report beside it.
         logger.warning("Could not save the CI reliability snapshot", exc_info=True)
     if console is not None:
         console.print(

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -201,7 +201,9 @@ def report_text_from_snapshot(
     report = report_from_dict(saved)
     text = render_markdown(report, compact=True)
     if include_benchmarks:
-        text = f"{text}\n\n{comparison_markdown(report, peer_benchmarks(report))}"
+        # This report sits above the schedule card, so the next step is already taken.
+        compare = comparison_markdown(report, peer_benchmarks(report), next_step=False)
+        text = f"{text}\n\n{compare}"
     return text.strip(), str(snapshot.get("generated_at", ""))
 
 
@@ -285,12 +287,13 @@ def _result(
         "reliability KPIs: executions, PR failure rate, failures classified as "
         "CI-caused (same commit passed later) versus source-code, developer time "
         "blocked by unreliable CI on merged PRs, and default-branch red time. "
-        "Read-only. A saved report from today answers without another GitHub "
-        "read; a first run needs a token. Every report also carries a "
-        "comparison with apache/airflow and fastapi/fastapi from figures "
-        "shipped with the product, so a first run compares as well as a later "
-        "one. It cannot be turned off, so never offer to skip it. The report "
-        "is painted on screen — do not restate its figures."
+        "Read-only. Every analysis reads GitHub Actions and needs a token; a "
+        "saved snapshot is written for the scheduled loop, never used to answer "
+        "here. Every report also carries a comparison with apache/airflow and "
+        "fastapi/fastapi from figures shipped with the product, so a first run "
+        "compares as well as a later one. It cannot be turned off, so never "
+        "offer to skip it. The report is painted on screen — do not restate "
+        "its figures."
     ),
     use_cases=[
         "Analyze a repository's CI/CD performance and reliability",
@@ -375,9 +378,9 @@ def analyze_github_ci_reliability(
     ``response_text`` then only summarizes. Other surfaces get the markdown.
     The same call also paints one comparison table against the benchmark
     figures shipped with the product, so a first run compares as well as a
-    hundredth. A saved report from today is reused; a miss reads GitHub and
-    writes the snapshot. The comparison is not the model's choice to make;
-    ``compact`` drops the counts appendix.
+    hundredth. Every analysis reads GitHub: a saved snapshot is written for the
+    scheduled loop, never used to answer here. The comparison is not the
+    model's choice to make; ``compact`` drops the counts appendix.
     """
     window = min(max(int(days or _DEFAULT_WINDOW_DAYS), _MIN_WINDOW_DAYS), _MAX_WINDOW_DAYS)
     brief = _flag(compact)
@@ -395,21 +398,7 @@ def analyze_github_ci_reliability(
         )
     now = datetime.now(UTC)
     console = _console(context)
-    snapshot = read_fresh_snapshot(
-        snapshot_root(), repo_owner, repo_name, window_days=window, now=now
-    )
     token = resolve_github_token(github_token)
-    if snapshot is not None:
-        answered = _from_snapshot(
-            snapshot,
-            repo_owner,
-            repo_name,
-            window,
-            console,
-            compact=brief,
-        )
-        if answered is not None:
-            return answered
     if not token:
         message = (
             f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -14,12 +14,21 @@ from __future__ import annotations
 from rich.console import Console
 from rich.markup import escape
 
-from config.constants.skills import SKIP_DEMO_OPTION
-from core.agent_harness.spi.handoff import format_ask_user_answers
+from config.constants.skills import ONBOARDING_SKILL_NAME, SKIP_DEMO_OPTION
+from core.agent_harness.spi.handoff import (
+    AskUserQuestion,
+    format_ask_user_answers,
+    question_key,
+)
 from infrastructure.terminal import theme as ui_theme
 from infrastructure.terminal.notify import NotifyEvent, play_notification
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
+from surfaces.interactive_shell.runtime.startup.demo_repository import (
+    choose_demo_repository,
+    demo_skill_for,
+    repository_question,
+)
 from surfaces.interactive_shell.runtime.startup.onboarding_telemetry import (
     capture_onboarding_choice,
 )
@@ -41,7 +50,15 @@ def _remember_answered(session: Session, *titles: str) -> None:
     settled = getattr(session, "questions_already_answered", None)
     if not isinstance(settled, set):
         return
-    settled.update(" ".join(title.split()).casefold() for title in titles if title.strip())
+    settled.update(question_key(title) for title in titles if title.strip())
+
+
+def _demo_repository_question(session: Session, answer: str) -> str | None:
+    """The repository question the chosen demo needs, when the onboarding menu was answered."""
+    if session.active_skill != ONBOARDING_SKILL_NAME:
+        return None
+    skill = demo_skill_for(answer)
+    return repository_question(skill) if skill is not None else None
 
 
 def _leave_menu(session: Session, console: Console, note: str) -> None:
@@ -122,6 +139,24 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         console.print(f"[{ui_theme.DIM}]Running {escape(command)}.[/]")
         session.terminal.awaiting_handoff_answer = False
         session.terminal.set_auto_command(command)
+        return True
+    repository_title = _demo_repository_question(session, picked_one)
+    if repository_title is not None:
+        # The demo's repository is the user's choice, made here: left to the
+        # model, the scan is skipped and the menu tied to it never opens.
+        repository = choose_demo_repository(console, repository_title)
+        if repository is None:
+            _leave_menu(session, console, _CANCELLED)
+            return True
+        _remember_answered(session, repository_title)
+        answered = (
+            items[0],
+            AskUserQuestion(label="", title=repository_title, options=(repository,)),
+        )
+        session.terminal.set_auto_command(
+            format_ask_user_answers(answered, (picked_one, repository))
+        )
+        session.terminal.awaiting_handoff_answer = True
         return True
     render_choice_selection(console, items[0].title, picked_one)
     # The answer travels with its question, as the batched wizard's does: a bare

--- a/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
+++ b/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
@@ -91,7 +91,7 @@ def marker_path() -> Path:
     return OPENSRE_HOME_DIR / MARKER_FILENAME
 
 
-def _scan_and_show(console: Console | None) -> WorkspaceSnapshot:
+def scan_and_show(console: Console | None) -> WorkspaceSnapshot:
     """Scan the home directory under a spinner and paint the activity chart."""
     home = Path.home()
     if console is not None:
@@ -122,7 +122,7 @@ def start_ci_agent_demo(
 ) -> bool:
     """Scan, choose a repository and time, then schedule and run the reliability loop."""
     if repository is None:
-        snapshot = _scan_and_show(console)
+        snapshot = scan_and_show(console)
         if not resolve_github_token(None):
             _warn(console, _LOOP_TOKEN_MISSING)
             return False

--- a/surfaces/interactive_shell/runtime/startup/demo_repository.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_repository.py
@@ -1,0 +1,55 @@
+"""The repository a demo needs, chosen in the shell before the model runs.
+
+A demo skill declares its repository menu as an ``after_tool`` hook on the
+workspace scan. Left to the model, the scan is skipped and the repository is
+read out of the request, so the menu never opens. When a demo is picked, the
+shell scans the machine and asks the declared question itself; the model then
+receives the repository beside the demo answer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from core.agent_harness.spi.grounding import ActionSkill, getting_started_skills
+from surfaces.interactive_shell.runtime.startup.ci_agent_demo import (
+    choose_repository,
+    scan_and_show,
+)
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+_SCAN_TOOL = "scan_local_git_workspace"
+_MENU_TOOL = "ask_user_choice"
+_SCAN_REPOSITORIES = "local_git_scan_repos"
+
+
+def demo_skill_for(answer: str) -> ActionSkill | None:
+    """The demo skill whose menu row is ``answer``, or ``None``."""
+    return next(
+        (skill for skill in getting_started_skills() if skill.getting_started == answer),
+        None,
+    )
+
+
+def repository_question(skill: ActionSkill) -> str | None:
+    """The repository question ``skill`` declares after the workspace scan, or ``None``."""
+    for hook in skill.after_tool:
+        if hook.after != _SCAN_TOOL or hook.call.tool != _MENU_TOOL:
+            continue
+        if hook.options_from != _SCAN_REPOSITORIES:
+            continue
+        title = str(hook.call.args.get("title") or "").strip()
+        if title:
+            return title
+    return None
+
+
+def choose_demo_repository(console: Console | None, question: str) -> str | None:
+    """Scan this machine, paint the chart, and ask ``question``; ``None`` when the user escapes."""
+    snapshot = scan_and_show(console)
+    return choose_repository(snapshot, title=question)
+
+
+__all__ = ["choose_demo_repository", "demo_skill_for", "repository_question"]

--- a/surfaces/interactive_shell/runtime/startup/loop_suggestions.py
+++ b/surfaces/interactive_shell/runtime/startup/loop_suggestions.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_MENU_TITLE = "No loops scheduled yet — pick one to set up (Esc to skip)"
+_MENU_TITLE = "No loops scheduled yet — pick one to set up"
 _MENU_EXPLAINER = (
     "Loops are scheduled check-ins that post a summary here each weekday. "
     "Picking one runs a first pass now, then offers the schedule — nothing is "

--- a/surfaces/shared/terminal/components/key_reader.py
+++ b/surfaces/shared/terminal/components/key_reader.py
@@ -41,6 +41,22 @@ def flush_pending_input() -> None:
             msvcrt.getwch()  # type: ignore[attr-defined]
 
 
+def _raw_input_mode(fd: int) -> None:
+    """Raw keystrokes with output left cooked: a line feed still returns the carriage.
+
+    ``tty.setraw`` also clears OPOST. A termios snapshot taken while a key read
+    is in flight restores that later, and everything painted after it walks
+    across the screen one column further per line.
+    """
+    import termios
+    import tty
+
+    tty.setraw(fd)  # type: ignore[attr-defined]
+    attrs = termios.tcgetattr(fd)  # type: ignore[attr-defined]
+    attrs[1] |= termios.OPOST  # type: ignore[attr-defined]
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)  # type: ignore[attr-defined]
+
+
 def restore_stdin_terminal() -> None:
     """Return stdin to canonical echo mode after Live/raw progress UI.
 
@@ -94,12 +110,11 @@ def read_key_unix(
     """
     import select as _sel
     import termios
-    import tty
 
     fd = sys.stdin.fileno()
     old = termios.tcgetattr(fd)  # type: ignore[attr-defined]
     try:
-        tty.setraw(fd)  # type: ignore[attr-defined]
+        _raw_input_mode(fd)
         ch = os.read(fd, 1)
         if not ch:
             return "eof"
@@ -230,12 +245,11 @@ def read_menu_or_char(*, allow_chars: bool = False, alpha_keys: bool = False) ->
 def _read_menu_or_char_unix(*, allow_chars: bool, alpha_keys: bool = False) -> str:
     import select as _sel
     import termios
-    import tty
 
     fd = sys.stdin.fileno()
     old = termios.tcgetattr(fd)  # type: ignore[attr-defined]
     try:
-        tty.setraw(fd)  # type: ignore[attr-defined]
+        _raw_input_mode(fd)
         ch = os.read(fd, 1)
         if not ch:
             return "eof"
@@ -347,12 +361,11 @@ def _read_menu_or_char_windows(*, allow_chars: bool, alpha_keys: bool = False) -
 def _read_typing_key_unix() -> str:
     import select as _sel
     import termios
-    import tty
 
     fd = sys.stdin.fileno()
     old = termios.tcgetattr(fd)  # type: ignore[attr-defined]
     try:
-        tty.setraw(fd)  # type: ignore[attr-defined]
+        _raw_input_mode(fd)
         ch = os.read(fd, 1)
         if not ch:
             return "eof"

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -43,7 +43,7 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
     # options are the children's own labels so the two cannot drift apart.
     assert [call.tool for call in master_skill.pre_execute] == ["ask_user_choice"]
     menu = master_skill.pre_execute[0].args
-    assert menu["title"] == "Which demo would you like me to run? (Esc to skip)"
+    assert menu["title"] == "Which demo would you like me to run?"
     assert menu["note"]
     assert tuple(menu["options"]) == (*GETTING_STARTED_OPTIONS, SKIP_DEMO_OPTION)
     assert "Call `ask_user_choice`" not in master
@@ -68,6 +68,12 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
     assert "compact=true" in body
     assert "Compare these numbers" not in body
     assert "Output its `headline`" not in body
+    assert "same-day snapshot" not in body
+    reliability = loader.load_skill_body("cicd-reliability-agent")
+    assert "analyze_github_ci_reliability" in reliability
+    assert "compact=true" in reliability
+    assert "include_report=true" not in reliability
+    assert "same-day snapshot" not in reliability
     assert menu["allow_custom"] is False
     assert GETTING_STARTED_CUSTOM not in master
     assert "not implemented yet" in loader.load_skill_body("remote-managed-service")

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -167,6 +167,7 @@ SPI_ROLE_NAMES: dict[str, frozenset[str]] = {
             "AskUserQuestion",
             "format_ask_user_answers",
             "parse_ask_user_answers",
+            "question_key",
         }
     ),
     "task_plan": frozenset(

--- a/tests/core/agent_harness/turns/test_skill_after_tool.py
+++ b/tests/core/agent_harness/turns/test_skill_after_tool.py
@@ -159,3 +159,27 @@ def test_the_same_hook_does_not_fire_twice(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert first is not None
     assert session.pending_user_choice is None
+
+
+def test_a_question_the_session_already_answered_is_not_asked_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shell asked the repository question itself; the scan's hook must not reopen it."""
+    import core.agent_harness.turns.skill_after_tool as after_tool
+
+    # Arrange: the repository answer is already on the session.
+    monkeypatch.setattr(after_tool, "list_action_skills", lambda: (_skill_with_hooks(),))
+    session = _session()
+    session.questions_already_answered = {"which repository should i analyze?"}
+    hooks = with_skill_after_tool(None, session)
+    details = {"repos": [{"github": "acme/one", "has_workflows": True, "commits": 4}]}
+
+    # Act
+    hooks.after_tool_call(
+        _request("scan_local_git_workspace"),
+        ToolExecutionResult(content="scanned", details=details),
+    )
+
+    # Assert
+    assert session.pending_user_choice is None
+    assert session.terminal.pending_prompt_default is None

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -1,8 +1,7 @@
-"""Same-day CI reliability snapshots are reused instead of re-reading GitHub."""
+"""Snapshots are written for the scheduled loop; a live analysis never answers from them."""
 
 from __future__ import annotations
 
-import contextlib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -50,39 +49,6 @@ def test_a_different_window_or_a_stale_snapshot_is_ignored(tmp_path: Path) -> No
 
     # Act / Assert: neither serves a 30-day request today.
     assert read_fresh_snapshot(tmp_path, "apache", "airflow", window_days=30, now=now) is None
-
-
-def test_the_tool_answers_from_a_fresh_snapshot_without_reading_github(
-    tmp_path: Path, monkeypatch
-) -> None:
-    from typing import Any, cast
-
-    from integrations.github.tools.ci_analytics import tool as tool_module
-
-    # Arrange: a snapshot exists; GitHub must not be read.
-    now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(), now)
-    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
-
-    def _boom(*_a: Any, **_k: Any) -> Any:
-        raise AssertionError("GitHub must not be read when a fresh snapshot exists")
-
-    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
-
-    # Act
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="apache", repo="airflow", days=30, github_token="tok"
-    )
-
-    # Assert: figures and provenance come from the saved report, not a fetch.
-    from integrations.github.tools.ci_analytics.render import headline
-
-    assert result["success"] is True
-    assert result["from_snapshot"]
-    assert result["red_hours"] == 24.5
-    assert result["headline"] == headline(_report())
-    assert "as of" in result["summary"]
 
 
 def _report(*, owner: str = "apache", repo: str = "airflow", red_hours: float = 24.5) -> Any:
@@ -134,55 +100,111 @@ def _write_report_snapshot(root: Path, report: Any, now: datetime) -> None:
     )
 
 
-def test_a_saved_report_round_trips_and_paints_like_a_live_one(tmp_path: Path, monkeypatch) -> None:
+def test_a_saved_snapshot_never_answers_a_live_analysis(tmp_path: Path, monkeypatch) -> None:
+    """Most people run this for the first time; the demo has to be the first run.
+
+    A same-day snapshot used to answer instead of reading GitHub, so the
+    rehearsed path was one nobody else would take.
+    """
+    # Arrange: a fresh snapshot exists and GitHub is readable.
     from typing import Any, cast
 
     from integrations.github.tools.ci_analytics import tool as tool_module
-    from integrations.github.tools.ci_analytics.snapshots import report_from_dict, report_to_dict
 
-    # Arrange: the report object is saved and rebuilt with its nested types intact.
-    report = _report()
-    rebuilt = report_from_dict(report_to_dict(report))
-    assert rebuilt == report
     now = datetime.now(UTC)
-    write_snapshot(
-        tmp_path,
-        "apache",
-        "airflow",
-        now - timedelta(minutes=5),
-        {
-            "generated_at": (now - timedelta(minutes=5)).isoformat(),
-            "window_days": 30,
-            "headline": "h",
-            "report": report_to_dict(report),
-        },
-    )
+    _write_report_snapshot(tmp_path, _report(), now)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
-    painted: list[Any] = []
+    reads: list[str] = []
 
-    class _Console:
-        is_terminal = True
+    def _analyze(owner: str, repo: str, **_kwargs: Any) -> Any:
+        reads.append(f"{owner}/{repo}")
+        return type("A", (), {"report": _report(red_hours=1.0), "runs_read": 3})()
 
-        def print(self, *args: Any, **_kwargs: Any) -> None:
-            painted.append(args[0] if args else "")
+    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
 
-        def use_theme(self, _theme: Any) -> contextlib.AbstractContextManager[None]:
-            return contextlib.nullcontext()
-
-    monkeypatch.setattr(tool_module, "_console", lambda _context: _Console())
-
-    # Act: through the shell console the saved report is painted, not markdown.
+    # Act
     result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="apache", repo="airflow", days=30, github_token="tok", context=object()
+        owner="apache", repo="airflow", days=30, github_token="tok"
     )
 
+    # Assert: the figures are the ones just read, and nothing claims a snapshot.
+    assert reads == ["apache/airflow"]
+    assert result["red_hours"] == 1.0
+    assert "from_snapshot" not in result
+    assert "as of" not in result["summary"]
+
+
+def test_the_comparison_needs_no_saved_peer_figures(tmp_path: Path, monkeypatch) -> None:
+    """The benchmark columns ship with the product, so a first run compares too."""
+    # Arrange: an empty snapshot directory — no peer has ever been analyzed here.
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+    from integrations.github.tools.ci_analytics.benchmarks import BENCHMARKS, MEASURED_ON
+
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+
+    def _analyze(_owner: str, _repo: str, **_kwargs: Any) -> Any:
+        return type("A", (), {"report": _report(owner="acme", repo="app"), "runs_read": 3})()
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
+
+    # Act
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(owner="acme", repo="app", days=30)
+
     # Assert
-    assert result["rendered_in_shell"] is True
-    assert result["from_snapshot"]
-    assert "coverage_notices" in result and "red_hours" not in result
-    assert result["key_results"]
-    assert any(not isinstance(item, str) for item in painted)
+    text = result["response_text"]
+    for benchmark in BENCHMARKS:
+        assert benchmark.label in text
+    assert f"{MEASURED_ON:%d %b %Y}" in text
+    assert result["benchmarks_measured_on"] == MEASURED_ON.isoformat()
+
+
+def test_the_report_leads_with_what_unreliable_ci_cost(tmp_path: Path, monkeypatch) -> None:
+    """Key results opened on red hours; a reader had to turn that into a cost themselves."""
+    # Arrange
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+
+    def _analyze(_owner: str, _repo: str, **_kwargs: Any) -> Any:
+        return type("A", (), {"report": _report(owner="acme", repo="app"), "runs_read": 3})()
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
+
+    # Act
+    text = cast(Any, tool_module.analyze_github_ci_reliability)(owner="acme", repo="app", days=30)[
+        "response_text"
+    ]
+
+    # Assert: the cost sentence sits above Key results and is not repeated as a row.
+    assert text.index("Waiting on CI") < text.index("**Key results**")
+    assert "Developer time blocked" not in text
+
+
+def test_a_saved_report_round_trips_for_the_scheduled_loop(tmp_path: Path, monkeypatch) -> None:
+    """The loop still reads its own saved figures; only the live analysis stopped doing so."""
+    # Arrange
+    from integrations.github.tools.ci_analytics import tool as tool_module
+    from integrations.github.tools.ci_analytics.snapshots import report_from_dict, report_to_dict
+
+    report = _report()
+    assert report_from_dict(report_to_dict(report)) == report
+    now = datetime.now(UTC)
+    _write_report_snapshot(tmp_path, report, now)
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+
+    # Act
+    text, generated_at = tool_module.report_text_from_snapshot("apache", "airflow")
+
+    # Assert
+    assert generated_at
+    assert "**Key results**" in text
 
 
 def test_repositories_whose_names_join_the_same_way_do_not_share_a_snapshot(
@@ -222,125 +244,6 @@ def test_a_snapshot_write_failure_does_not_discard_the_analysis(
 
     assert result["success"] is True
     assert result["red_hours"] == 24.5
-
-
-def test_include_benchmarks_builds_the_comparison_from_snapshots(
-    tmp_path: Path, monkeypatch
-) -> None:
-    from typing import Any, cast
-
-    from integrations.github.tools.ci_analytics import tool as tool_module
-
-    now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(owner="acme", repo="app", red_hours=48.0), now)
-    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
-    _write_report_snapshot(tmp_path, _report(owner="fastapi", repo="fastapi", red_hours=2.0), now)
-    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
-
-    def _boom(*_a: Any, **_k: Any) -> Any:
-        raise AssertionError("GitHub must not be read when peer snapshots exist")
-
-    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
-
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="acme",
-        repo="app",
-        days=30,
-        github_token="tok",
-    )
-
-    assert result["success"] is True
-    assert result["key_results"]
-    assert result["key_results"][0]["label"].startswith("main branch red")
-    assert "Compared with apache/airflow and fastapi/fastapi" in result["response_text"]
-    assert {row["owner"] + "/" + row["repo"] for row in result["benchmarks"]} == {
-        "apache/airflow",
-        "fastapi/fastapi",
-    }
-    assert "benchmarks_skipped" not in result
-
-
-def test_include_benchmarks_skips_a_peer_that_cannot_be_fetched(
-    tmp_path: Path, monkeypatch
-) -> None:
-    from typing import Any, cast
-
-    from integrations.github.tools.ci_analytics import tool as tool_module
-
-    now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(owner="acme", repo="app"), now)
-    _write_report_snapshot(tmp_path, _report(), now)
-    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
-
-    def _boom(*_a: Any, **_k: Any) -> Any:
-        raise AssertionError("A missing peer must not start a live GitHub read")
-
-    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
-
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="acme",
-        repo="app",
-        days=30,
-    )
-
-    assert result["benchmarks_skipped"] == ["fastapi/fastapi (no same-day snapshot)"]
-    assert [row["repo"] for row in result["benchmarks"]] == ["airflow"]
-    assert "Compared with apache/airflow" in result["response_text"]
-    assert "Skipped fastapi/fastapi (no same-day snapshot)." in result["response_text"]
-
-
-def test_include_benchmarks_says_when_every_peer_snapshot_is_missing(
-    tmp_path: Path, monkeypatch
-) -> None:
-    from typing import Any, cast
-
-    from integrations.github.tools.ci_analytics import tool as tool_module
-
-    now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(owner="acme", repo="app"), now)
-    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
-
-    def _boom(*_a: Any, **_k: Any) -> Any:
-        raise AssertionError("A missing peer must not start a live GitHub read")
-
-    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
-
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(owner="acme", repo="app", days=30)
-
-    assert result["success"] is True
-    assert result["benchmarks"] == []
-    assert "No benchmark columns" in result["response_text"]
-    assert "Skipped apache/airflow (no same-day snapshot)." in result["response_text"]
-    assert "Skipped fastapi/fastapi (no same-day snapshot)." in result["response_text"]
-
-
-def test_a_fresh_snapshot_answers_without_a_github_token(tmp_path: Path, monkeypatch) -> None:
-    from typing import Any, cast
-
-    from integrations.github.tools.ci_analytics import tool as tool_module
-
-    now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(owner="acme", repo="app", red_hours=48.0), now)
-    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
-    _write_report_snapshot(tmp_path, _report(owner="fastapi", repo="fastapi", red_hours=0.0), now)
-    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
-
-    def _boom(*_a: Any, **_k: Any) -> Any:
-        raise AssertionError("GitHub must not be read when snapshots exist")
-
-    monkeypatch.setattr(tool_module, "analyze_repository", _boom)
-
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(owner="acme", repo="app", days=30)
-
-    assert result["success"] is True
-    assert result["from_snapshot"]
-    assert "Compared with apache/airflow and fastapi/fastapi" in result["response_text"]
-    assert "fastapi/fastapi: default branch stayed green in this window." in result["response_text"]
-    assert "opensre integrations setup github" not in result.get("response_text", "")
 
 
 def test_a_snapshot_without_a_saved_report_is_a_miss_not_a_lesser_answer(

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -100,39 +101,6 @@ def _write_report_snapshot(root: Path, report: Any, now: datetime) -> None:
     )
 
 
-def test_a_saved_report_from_today_answers_without_reading_github(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """A first run is live; the next call the same day must not wait on GitHub again."""
-    # Arrange: a fresh snapshot exists and GitHub would return different figures.
-    from typing import Any, cast
-
-    from integrations.github.tools.ci_analytics import tool as tool_module
-
-    now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
-    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
-    reads: list[str] = []
-
-    def _analyze(owner: str, repo: str, **_kwargs: Any) -> Any:
-        reads.append(f"{owner}/{repo}")
-        return type("A", (), {"report": _report(red_hours=1.0), "runs_read": 3})()
-
-    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
-
-    # Act
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="apache", repo="airflow", days=30, github_token="tok"
-    )
-
-    # Assert: the saved figures win, and GitHub was not called.
-    assert reads == []
-    assert result["red_hours"] == 24.5
-    assert result.get("from_snapshot")
-    assert "as of" in result["summary"]
-
-
 def test_the_comparison_needs_no_saved_peer_figures(tmp_path: Path, monkeypatch) -> None:
     """The benchmark columns ship with the product, so a first run compares too."""
     # Arrange: an empty snapshot directory — no peer has ever been analyzed here.
@@ -170,8 +138,10 @@ def test_the_report_leads_with_what_unreliable_ci_cost(tmp_path: Path, monkeypat
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
 
+    blocked = dataclasses.replace(_report(owner="acme", repo="app"), blocked_working_minutes=90.0)
+
     def _analyze(_owner: str, _repo: str, **_kwargs: Any) -> Any:
-        return type("A", (), {"report": _report(owner="acme", repo="app"), "runs_read": 3})()
+        return type("A", (), {"report": blocked, "runs_read": 3})()
 
     monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
 
@@ -181,12 +151,14 @@ def test_the_report_leads_with_what_unreliable_ci_cost(tmp_path: Path, monkeypat
     ]
 
     # Assert: the cost sentence sits above Key results and is not repeated as a row.
-    assert text.index("Waiting on CI") < text.index("**Key results**")
+    assert text.index("Waiting on CI cost") < text.index("**Key results**")
     assert "Developer time blocked" not in text
 
 
-def test_a_saved_report_round_trips_for_the_scheduled_loop(tmp_path: Path, monkeypatch) -> None:
-    """The loop still reads its own saved figures; only the live analysis stopped doing so."""
+def test_the_schedule_card_report_comes_from_todays_saved_figures(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Scheduling with include_report reads today's snapshot; only the live analysis stopped."""
     # Arrange
     from integrations.github.tools.ci_analytics import tool as tool_module
     from integrations.github.tools.ci_analytics.snapshots import report_from_dict, report_to_dict
@@ -200,9 +172,60 @@ def test_a_saved_report_round_trips_for_the_scheduled_loop(tmp_path: Path, monke
     # Act
     text, generated_at = tool_module.report_text_from_snapshot("apache", "airflow")
 
-    # Assert
+    # Assert: the report, without a next step the card beneath it has already taken.
     assert generated_at
     assert "**Key results**" in text
+    assert "Next:" not in text
+
+
+def test_a_saved_snapshot_never_answers_a_live_analysis(tmp_path: Path, monkeypatch) -> None:
+    """Most people run this for the first time; the demo has to be the first run.
+
+    A same-day snapshot used to answer instead of reading GitHub, so the
+    rehearsed path was one nobody else would take.
+    """
+    # Arrange: a fresh snapshot exists and GitHub is readable.
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    now = datetime.now(UTC)
+    _write_report_snapshot(tmp_path, _report(), now)
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+    reads: list[str] = []
+
+    def _analyze(owner: str, repo: str, **_kwargs: Any) -> Any:
+        reads.append(f"{owner}/{repo}")
+        return type("A", (), {"report": _report(red_hours=1.0), "runs_read": 3})()
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
+
+    # Act
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="apache", repo="airflow", days=30, github_token="tok"
+    )
+
+    # Assert: the figures are the ones just read, and nothing claims a snapshot.
+    assert reads == ["apache/airflow"]
+    assert result["red_hours"] == 1.0
+    assert "from_snapshot" not in result
+    assert "as of" not in result["summary"]
+
+
+def test_a_benchmark_repository_is_not_compared_with_itself() -> None:
+    """Analyzing apache/airflow put an airflow column beside the airflow column."""
+    # Arrange
+    from integrations.github.tools.ci_analytics.render import comparison_markdown, peer_benchmarks
+
+    report = _report(owner="apache", repo="airflow")
+
+    # Act
+    markdown = comparison_markdown(report, peer_benchmarks(report))
+
+    # Assert: the analyzed repository appears once, as the first column.
+    assert markdown.count("apache/airflow") == 1
+    assert "fastapi/fastapi" in markdown
 
 
 def test_repositories_whose_names_join_the_same_way_do_not_share_a_snapshot(
@@ -242,45 +265,3 @@ def test_a_snapshot_write_failure_does_not_discard_the_analysis(
 
     assert result["success"] is True
     assert result["red_hours"] == 24.5
-
-
-def test_a_snapshot_without_a_saved_report_is_a_miss_not_a_lesser_answer(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """A snapshot written before the report object cannot build the comparison.
-
-    Answering from it would drop the comparison the report always carries, so
-    it counts as a cache miss and GitHub is read instead.
-    """
-    # Arrange: a fresh snapshot in the old shape, and a token to read with.
-    from typing import Any, cast
-
-    from integrations.github.tools.ci_analytics import tool as tool_module
-
-    now = datetime.now(UTC)
-    write_snapshot(
-        tmp_path,
-        "apache",
-        "airflow",
-        now - timedelta(minutes=5),
-        _payload(generated_at=(now - timedelta(minutes=5)).isoformat(), headline="old shape"),
-    )
-    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
-    reads: list[str] = []
-
-    def _analyze(owner: str, repo: str, **_kwargs: Any) -> Any:
-        reads.append(f"{owner}/{repo}")
-        return type("A", (), {"report": _report(), "runs_read": 1})()
-
-    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
-
-    # Act
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="apache", repo="airflow", days=30, github_token="tok"
-    )
-
-    # Assert
-    assert reads == ["apache/airflow"]
-    assert result["success"] is True
-    assert not result.get("from_snapshot")

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -178,19 +178,17 @@ def test_the_schedule_card_report_comes_from_todays_saved_figures(
     assert "Next:" not in text
 
 
-def test_a_saved_snapshot_never_answers_a_live_analysis(tmp_path: Path, monkeypatch) -> None:
-    """Most people run this for the first time; the demo has to be the first run.
-
-    A same-day snapshot used to answer instead of reading GitHub, so the
-    rehearsed path was one nobody else would take.
-    """
-    # Arrange: a fresh snapshot exists and GitHub is readable.
+def test_a_saved_report_from_today_answers_without_reading_github(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A first run is live; the next call the same day must not wait on GitHub again."""
+    # Arrange: a fresh snapshot exists and GitHub would return different figures.
     from typing import Any, cast
 
     from integrations.github.tools.ci_analytics import tool as tool_module
 
     now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(), now)
+    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
     reads: list[str] = []
@@ -206,11 +204,46 @@ def test_a_saved_snapshot_never_answers_a_live_analysis(tmp_path: Path, monkeypa
         owner="apache", repo="airflow", days=30, github_token="tok"
     )
 
-    # Assert: the figures are the ones just read, and nothing claims a snapshot.
-    assert reads == ["apache/airflow"]
-    assert result["red_hours"] == 1.0
-    assert "from_snapshot" not in result
-    assert "as of" not in result["summary"]
+    # Assert: the saved figures win, and GitHub was not called.
+    assert reads == []
+    assert result["red_hours"] == 24.5
+    assert result.get("from_snapshot")
+    assert "as of" in result["summary"]
+
+
+def test_a_saved_report_answers_without_a_token(tmp_path: Path, monkeypatch) -> None:
+    """A warmed machine must not fail the demo just because GitHub is not called."""
+    from typing import Any, cast
+
+    from integrations.github.tools.ci_analytics import tool as tool_module
+
+    now = datetime.now(UTC)
+    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
+    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
+
+    def _analyze(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("GitHub must not be read when today's report is saved")
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
+
+    result = cast(Any, tool_module.analyze_github_ci_reliability)(
+        owner="apache", repo="airflow", days=30, github_token=""
+    )
+
+    assert result["success"] is True
+    assert result["red_hours"] == 24.5
+
+
+def test_two_windows_written_in_the_same_second_do_not_overwrite(tmp_path: Path) -> None:
+    now = datetime(2026, 9, 10, 15, 44, 40, tzinfo=UTC)
+    write_snapshot(tmp_path, "o", "r", now, _payload(window_days=30, generated_at=now.isoformat()))
+    write_snapshot(tmp_path, "o", "r", now, _payload(window_days=14, generated_at=now.isoformat()))
+
+    thirty = read_fresh_snapshot(tmp_path, "o", "r", window_days=30, now=now)
+    fourteen = read_fresh_snapshot(tmp_path, "o", "r", window_days=14, now=now)
+    assert thirty is not None and thirty["window_days"] == 30
+    assert fourteen is not None and fourteen["window_days"] == 14
 
 
 def test_a_benchmark_repository_is_not_compared_with_itself() -> None:

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -1,4 +1,4 @@
-"""Snapshots are written for the scheduled loop; a live analysis never answers from them."""
+"""A saved report from today answers analyze; a miss reads GitHub."""
 
 from __future__ import annotations
 
@@ -100,19 +100,17 @@ def _write_report_snapshot(root: Path, report: Any, now: datetime) -> None:
     )
 
 
-def test_a_saved_snapshot_never_answers_a_live_analysis(tmp_path: Path, monkeypatch) -> None:
-    """Most people run this for the first time; the demo has to be the first run.
-
-    A same-day snapshot used to answer instead of reading GitHub, so the
-    rehearsed path was one nobody else would take.
-    """
-    # Arrange: a fresh snapshot exists and GitHub is readable.
+def test_a_saved_report_from_today_answers_without_reading_github(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A first run is live; the next call the same day must not wait on GitHub again."""
+    # Arrange: a fresh snapshot exists and GitHub would return different figures.
     from typing import Any, cast
 
     from integrations.github.tools.ci_analytics import tool as tool_module
 
     now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(), now)
+    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
     reads: list[str] = []
@@ -128,11 +126,11 @@ def test_a_saved_snapshot_never_answers_a_live_analysis(tmp_path: Path, monkeypa
         owner="apache", repo="airflow", days=30, github_token="tok"
     )
 
-    # Assert: the figures are the ones just read, and nothing claims a snapshot.
-    assert reads == ["apache/airflow"]
-    assert result["red_hours"] == 1.0
-    assert "from_snapshot" not in result
-    assert "as of" not in result["summary"]
+    # Assert: the saved figures win, and GitHub was not called.
+    assert reads == []
+    assert result["red_hours"] == 24.5
+    assert result.get("from_snapshot")
+    assert "as of" in result["summary"]
 
 
 def test_the_comparison_needs_no_saved_peer_figures(tmp_path: Path, monkeypatch) -> None:

--- a/tests/interactive_shell/command_registry/test_choice_prompt_demo_repository.py
+++ b/tests/interactive_shell/command_registry/test_choice_prompt_demo_repository.py
@@ -1,0 +1,118 @@
+"""Picking a repository demo asks for the repository in the shell before the model runs.
+
+Left to the model, the workspace scan was skipped and "CI/CD" was read out of
+the menu row as owner/repo; the repository menu, tied to the scan, never opened.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from config.constants.skills import ONBOARDING_SKILL_NAME, SKIP_DEMO_OPTION
+from core.agent_harness.session.pending_choice import (
+    AskUserQuestion,
+    PendingUserChoice,
+    format_ask_user_answers,
+)
+from surfaces.interactive_shell.command_registry import choice_prompt
+from surfaces.interactive_shell.session import Session
+
+_DEMO_QUESTION = "Which demo would you like me to run?"
+_DEMO = "Explore a repo and analyze its CI/CD performance (recommended)"
+_REPOSITORY_QUESTION = "Which repository should I analyze?"
+
+
+def _pick_demo(**_kwargs: Any) -> str:
+    return _DEMO
+
+
+def _arrange(
+    monkeypatch: pytest.MonkeyPatch, *, repository: str | None
+) -> tuple[Session, list[str]]:
+    session = Session()
+    session.active_skill = ONBOARDING_SKILL_NAME
+    session.pending_user_choice = PendingUserChoice(
+        title=_DEMO_QUESTION, options=(_DEMO, SKIP_DEMO_OPTION), custom_answer=False
+    )
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(choice_prompt, "repl_choose_one", _pick_demo)
+    monkeypatch.setattr(choice_prompt, "clear_live_prompt_paint", lambda _session: None)
+    monkeypatch.setattr(choice_prompt, "play_notification", lambda _event: None)
+    monkeypatch.setattr(choice_prompt, "capture_onboarding_choice", lambda *_a, **_k: None)
+    asked: list[str] = []
+
+    def _choose(_console: Any, question: str) -> str | None:
+        asked.append(question)
+        return repository
+
+    monkeypatch.setattr(choice_prompt, "choose_demo_repository", _choose)
+    return session, asked
+
+
+def test_the_repository_is_asked_in_the_shell_and_travels_with_the_demo_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the onboarding menu is pending; the picker returns the analytics demo.
+    session, asked = _arrange(monkeypatch, repository="acme/app")
+    console = Console(file=io.StringIO(), force_terminal=False, width=100)
+
+    # Act
+    handled = choice_prompt._cmd_choose(session, console, [])
+
+    # Assert: the skill's own question was asked, and both answers go to the model at once.
+    assert handled is True
+    assert asked == [_REPOSITORY_QUESTION]
+    questions = (
+        AskUserQuestion(label="", title=_DEMO_QUESTION, options=(_DEMO, SKIP_DEMO_OPTION)),
+        AskUserQuestion(label="", title=_REPOSITORY_QUESTION, options=("acme/app",)),
+    )
+    assert session.terminal.pending_prompt_default == format_ask_user_answers(
+        questions, (_DEMO, "acme/app")
+    )
+    assert session.terminal.awaiting_handoff_answer is True
+    assert "which repository should i analyze?" in session.questions_already_answered
+
+
+def test_escaping_the_repository_menu_cancels_instead_of_letting_the_model_guess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the user escapes the repository menu.
+    session, _asked = _arrange(monkeypatch, repository=None)
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, width=100)
+
+    # Act
+    choice_prompt._cmd_choose(session, console, [])
+
+    # Assert: nothing is queued for the model and the skill is left.
+    assert session.terminal.pending_prompt_default in (None, "")
+    assert session.terminal.awaiting_handoff_answer is False
+    assert session.active_skill is None
+    assert "cancelled" in buffer.getvalue().lower()
+
+
+def test_a_demo_without_a_repository_question_is_answered_as_before(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the Slack demo declares no repository menu.
+    slack = "Connect OpenSRE to Slack and hand off DevOps chores for your team"
+    session, asked = _arrange(monkeypatch, repository="unused")
+    session.pending_user_choice = PendingUserChoice(
+        title=_DEMO_QUESTION, options=(slack, SKIP_DEMO_OPTION), custom_answer=False
+    )
+    monkeypatch.setattr(choice_prompt, "repl_choose_one", lambda **_k: slack)
+    console = Console(file=io.StringIO(), force_terminal=False, width=100)
+
+    # Act
+    choice_prompt._cmd_choose(session, console, [])
+
+    # Assert: no scan, the single answer travels alone.
+    assert asked == []
+    assert session.terminal.pending_prompt_default == format_ask_user_answers(
+        (AskUserQuestion(label="", title=_DEMO_QUESTION, options=(slack, SKIP_DEMO_OPTION)),),
+        (slack,),
+    )

--- a/tests/interactive_shell/command_registry/test_choice_prompt_skip.py
+++ b/tests/interactive_shell/command_registry/test_choice_prompt_skip.py
@@ -25,7 +25,7 @@ def test_skip_option_opens_the_plain_shell_without_a_model_turn(
     session = Session()
     session.active_skill = "onboarding-cicd-fix"
     session.pending_user_choice = PendingUserChoice(
-        title="Which demo would you like me to run? (Esc to skip)",
+        title="Which demo would you like me to run?",
         options=("Explore a repo", SKIP_DEMO_OPTION),
     )
     monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -335,6 +335,7 @@ def test_demo_skills_keep_their_tool_contracts_after_moving() -> None:
     )
     assert by_name["cicd-reliability-agent"].tools == (
         "scan_local_git_workspace",
+        "analyze_github_ci_reliability",
         "schedule_ci_reliability_loop",
         "ask_user_choice",
     )

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -17,7 +17,11 @@ from config.constants.skills import ONBOARDING_SKILL_NAME, SKIP_DEMO_OPTION
 from core.agent_harness.prompts.action.assemble import build_action_system_prompt_envelope
 from core.agent_harness.prompts.getting_started import GETTING_STARTED_OPTIONS
 from core.agent_harness.prompts.skills import list_action_skills
-from core.agent_harness.session.pending_choice import PendingUserChoice, format_ask_user_answers
+from core.agent_harness.session.pending_choice import (
+    AskUserQuestion,
+    PendingUserChoice,
+    format_ask_user_answers,
+)
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 from surfaces.interactive_shell.session import Session
@@ -29,6 +33,8 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
 from tools.system.workspace_git_scan.scan import WorkspaceSnapshot
 
 _TITLE = "Which demo would you like me to run?"
+_REPOSITORY_TITLE = "Which repository should I analyze?"
+_REPOSITORY = "acme/one"
 _NOTE = (
     "Choose a demo using your own repositories or connect your team through Slack. "
     "The managed-service option is coming soon."
@@ -41,6 +47,14 @@ def _offerable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(demo_picker, "capture_onboarding_demo_prompted", lambda: None)
     monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(slash_adapter, "repl_tty_interactive", lambda: True)
+    # A repository demo asks for the repository in the shell; no scan in tests.
+    monkeypatch.setattr(choice_prompt, "choose_demo_repository", lambda _c, _q: _REPOSITORY)
+
+
+def _demo_with_repository(pending: PendingUserChoice, answer: str) -> str:
+    """The message the model receives: the demo pick, then the repository the shell asked for."""
+    repository = AskUserQuestion(label="", title=_REPOSITORY_TITLE, options=(_REPOSITORY,))
+    return format_ask_user_answers((*pending.items(), repository), (answer, _REPOSITORY))
 
 
 def _take_prompt(session: Session) -> str:
@@ -90,8 +104,15 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
         picker_calls.append(kwargs)
         return GETTING_STARTED_OPTIONS[0]
 
+    asked: list[str] = []
+
+    def choose_repository(_console: Any, question: str) -> str:
+        asked.append(question)
+        return _REPOSITORY
+
     monkeypatch.setattr(scan_tool, "scan_workspace", scan)
     monkeypatch.setattr(choice_prompt, "repl_choose_one", pick)
+    monkeypatch.setattr(choice_prompt, "choose_demo_repository", choose_repository)
     assert demo_picker.offer_demo(session, console)
     # The host asked the skill's question itself: no prose prompt, no model, no output.
     assert buffer.getvalue() == ""
@@ -113,12 +134,12 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
     )
     session.terminal.exclusive_stdin_active = False
     assert llm.invocations == 0  # Nothing before the pick used the model.
-    # The whole boot-to-pick sequence painted exactly one thing besides the
-    # picker itself: the selection recap. No work-turn marker, no skill tree.
+    # The shell asked the repository in the same turn; the card with both
+    # answers is painted when the answer is echoed. Nothing else: no work-turn
+    # marker, no skill tree.
+    assert asked == [_REPOSITORY_TITLE]
     painted = buffer.getvalue()
-    assert painted.strip().startswith("Ask User"), painted
-    assert f"1.  {_TITLE}" in painted, painted
-    for chrome in ("/goal", "Skill ", "activated", "skill_view", "[1]"):
+    for chrome in ("Ask User", "/goal", "Skill ", "activated", "skill_view", "[1]"):
         assert chrome not in painted, painted
     assert len(picker_calls) == 1
     assert callable(picker_calls[0].pop("on_custom_answer"))
@@ -136,7 +157,7 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
     }
     assert session.active_skill == ONBOARDING_SKILL_NAME
     answer = _take_prompt(session)
-    assert answer == format_ask_user_answers(pending.items(), (GETTING_STARTED_OPTIONS[0],))
+    assert answer == _demo_with_repository(pending, GETTING_STARTED_OPTIONS[0])
     envelope = build_action_system_prompt_envelope(
         TurnSnapshot.from_session(answer, session, surface="interactive_shell")
     )
@@ -144,14 +165,12 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
     assert "## Follow the selected child" not in envelope.render_cached()
 
     run_action_tool_turn(answer, session, console, is_tty=True, llm_factory=lambda: llm)
-    assert llm.invocations == 2
     assert len(scans) == 1
     assert session.active_skill == "cicd-analytics-demo"
-    assert session.pending_user_choice is not None
-    assert session.pending_user_choice.title == "Which repository should I analyze?"
-    assert "Use the open-source example repository (Tracer-Cloud/opensre)" in (
-        session.pending_user_choice.options
-    )
+    # The repository was answered in the shell; a scan the model runs anyway
+    # does not reopen that question, so the turn runs on to its end.
+    assert session.pending_user_choice is None
+    assert llm.invocations == 3
     assert "analyze_github_ci_reliability" in session.active_skill_tools
     assert onboarding_outcomes == [("ci_analytics", False)]
 
@@ -234,7 +253,7 @@ def test_onboarding_telemetry_failure_does_not_lose_the_answer(
     monkeypatch.setattr(onboarding_telemetry, "capture_onboarding_demo_selected", fail_capture)
     monkeypatch.setattr(choice_prompt, "repl_choose_one", lambda **_kw: answer)
     choice_prompt._cmd_choose(session, Console(file=io.StringIO()), [])
-    assert _take_prompt(session) == format_ask_user_answers(pending.items(), (answer,))
+    assert _take_prompt(session) == _demo_with_repository(pending, answer)
     assert session.active_skill == ONBOARDING_SKILL_NAME
 
 
@@ -262,7 +281,7 @@ def test_typed_option_label_keeps_its_custom_source_through_the_picker(
     monkeypatch.setattr(choice_menu, "leave_inline_menu", lambda: None)
     monkeypatch.setattr(cpr_stdin, "drain_stale_cpr_bytes", lambda: None)
     choice_prompt._cmd_choose(session, Console(file=io.StringIO()), [])
-    assert _take_prompt(session) == format_ask_user_answers(pending.items(), (answer,))
+    assert _take_prompt(session) == _demo_with_repository(pending, answer)
     assert onboarding_outcomes == [("custom", True) if typed else ("ci_analytics", False)]
 
 

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -28,7 +28,7 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
 )
 from tools.system.workspace_git_scan.scan import WorkspaceSnapshot
 
-_TITLE = "Which demo would you like me to run? (Esc to skip)"
+_TITLE = "Which demo would you like me to run?"
 _NOTE = (
     "Choose a demo using your own repositories or connect your team through Slack. "
     "The managed-service option is coming soon."

--- a/tests/interactive_shell/runtime/test_demo_repository.py
+++ b/tests/interactive_shell/runtime/test_demo_repository.py
@@ -1,0 +1,36 @@
+"""The repository question a demo needs is read from the skill that declares it."""
+
+from __future__ import annotations
+
+from core.agent_harness.spi.grounding import getting_started_skills
+from surfaces.interactive_shell.runtime.startup.demo_repository import (
+    demo_skill_for,
+    repository_question,
+)
+
+
+def test_each_repository_demo_declares_the_question_the_shell_asks() -> None:
+    # Arrange: the bundled demo skills, as the menu lists them.
+    by_name = {skill.name: skill for skill in getting_started_skills()}
+
+    # Act
+    questions = {name: repository_question(skill) for name, skill in by_name.items()}
+
+    # Assert: the two repository demos name their question; the others need none.
+    assert questions["cicd-analytics-demo"] == "Which repository should I analyze?"
+    assert questions["cicd-reliability-agent"] == "Which repository should the agent watch?"
+    assert questions["slack-handoff"] is None
+    assert questions["remote-managed-service"] is None
+
+
+def test_the_demo_answer_maps_to_its_skill_by_the_exact_menu_row() -> None:
+    # Arrange
+    row = "Explore a repo and analyze its CI/CD performance (recommended)"
+
+    # Act
+    matched = demo_skill_for(row)
+    unmatched = demo_skill_for("Explore a repo")
+
+    # Assert
+    assert matched is not None and matched.name == "cicd-analytics-demo"
+    assert unmatched is None

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -208,7 +208,7 @@ def test_choice_selection_is_the_ask_user_card() -> None:
 
     render_choice_selection(
         console,
-        "Which demo would you like me to run? (Esc to skip)",
+        "Which demo would you like me to run?",
         "Explore a repo and analyze its CI/CD performance (recommended)",
     )
 
@@ -217,7 +217,7 @@ def test_choice_selection_is_the_ask_user_card() -> None:
     lines = [line.rstrip() for line in output.splitlines() if line.strip()]
     assert lines == [
         "Ask User",
-        "  1.  Which demo would you like me to run? (Esc to skip)",
+        "  1.  Which demo would you like me to run?",
         "      Explore a repo and analyze its CI/CD performance (recommended)",
     ]
     assert "↳" not in output

--- a/tests/shared/terminal/test_choice_menu.py
+++ b/tests/shared/terminal/test_choice_menu.py
@@ -82,7 +82,7 @@ def test_draw_menu_note_sits_inside_the_erased_block(monkeypatch) -> None:
     monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
 
     choice_menu._draw_menu(
-        title="Which demo would you like me to run? (Esc to skip)",
+        title="Which demo would you like me to run?",
         crumb="",
         labels=["Explore a repo"],
         index=0,

--- a/tests/shared/terminal/test_key_reader.py
+++ b/tests/shared/terminal/test_key_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -83,3 +84,28 @@ def test_read_key_unix_alpha_mode_ignores_digits(monkeypatch: pytest.MonkeyPatch
     # Numbering is off in letter menus, so a digit is inert rather than a selector.
     assert _drive_read_key_unix(monkeypatch, b"2", alpha_keys=True) == "ignore"
     assert _drive_read_key_unix(monkeypatch, b"2", alpha_keys=False) == "2"
+
+
+def test_raw_key_reads_keep_output_post_processing() -> None:
+    """A termios snapshot taken during a key read is restored later; it must not carry bare LFs.
+
+    With OPOST cleared, a report painted mid-turn started every line where the
+    previous one ended and walked across the screen.
+    """
+    termios = pytest.importorskip("termios")
+    pty = pytest.importorskip("pty")
+    # Arrange: a real terminal, cooked.
+    master, slave = pty.openpty()
+    try:
+        assert termios.tcgetattr(slave)[1] & termios.OPOST
+
+        # Act
+        key_reader._raw_input_mode(slave)
+        during = termios.tcgetattr(slave)
+
+        # Assert: keystrokes are raw, output is still post-processed.
+        assert not during[3] & termios.ICANON
+        assert during[1] & termios.OPOST
+    finally:
+        os.close(master)
+        os.close(slave)

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -148,27 +149,14 @@ def _scheduled_stub(owner: str, repo: str) -> ci_loop.ScheduledLoop:
     return ci_loop.ScheduledLoop(loop=loop, reused=False)
 
 
-def _saved_report(root: Path, *, window_days: int) -> dict:
-    """Write a snapshot and hand back the report payload inside it."""
-    import json
-
-    _write_report_snapshot(root, window_days=window_days)
-    path = next((root / "acme" / "app").glob("*.json"))
-    return dict(json.loads(path.read_text())["report"])
-
-
-def _write_report_snapshot(root: Path, *, window_days: int) -> datetime:
-    from datetime import UTC, datetime, timedelta
-
+def _sample_report(*, window_days: int, now: datetime) -> Any:
     from integrations.github.tools.ci_analytics.models import (
         CiAnalyticsReport,
         Outage,
         WorkflowSummary,
     )
-    from integrations.github.tools.ci_analytics.snapshots import report_to_dict, write_snapshot
 
-    now = datetime.now(UTC)
-    report = CiAnalyticsReport(
+    return CiAnalyticsReport(
         owner="acme",
         repo="app",
         default_branch="main",
@@ -190,6 +178,15 @@ def _write_report_snapshot(root: Path, *, window_days: int) -> datetime:
         coverage_notices=(),
         working_hours_label="Mon-Fri 09:00-18:00 UTC",
     )
+
+
+def _write_report_snapshot(root: Path, *, window_days: int) -> datetime:
+    from datetime import UTC, datetime, timedelta
+
+    from integrations.github.tools.ci_analytics.snapshots import report_to_dict, write_snapshot
+
+    now = datetime.now(UTC)
+    report = _sample_report(window_days=window_days, now=now)
     write_snapshot(
         root,
         "acme",
@@ -307,7 +304,7 @@ def test_build_report_renders_the_analytics_and_keeps_a_json_snapshot(
         {"owner": "acme", "repo": "app", "days": "7"}, snapshot_dir=tmp_path
     )
 
-    # Assert: header, headline, and a traceable snapshot on disk.
+    # Assert: header and a traceable snapshot on disk.
     assert "CI/CD reliability for acme/app, last 7 days" in report
     assert "Raw data: " in report
     snapshot = Path(report.rsplit("Raw data: ", 1)[1].strip())
@@ -390,21 +387,20 @@ def test_tool_uses_the_loops_seven_day_snapshot_when_no_thirty_day_one_exists(
     )
 
 
-def test_analyze_markdown_keeps_details_when_benchmarks_are_requested(
+def test_analyze_markdown_keeps_the_details_beside_the_comparison(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Arrange: a non-terminal caller asks for the report with benchmarks.
-    from typing import Any
+    # Arrange: a caller with no console gets markdown; the live read is stubbed.
+    from datetime import UTC, datetime
 
     from integrations.github.tools.ci_analytics import tool as tool_module
-    from integrations.github.tools.ci_analytics.snapshots import report_from_dict
 
-    saved = _saved_report(tmp_path, window_days=30)
+    report = _sample_report(window_days=30, now=datetime.now(UTC))
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
 
     def _analyze(_owner: str, _repo: str, **_kwargs: Any) -> Any:
-        return type("A", (), {"report": report_from_dict(saved), "runs_read": 3})()
+        return type("A", (), {"report": report, "runs_read": 3})()
 
     monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
 

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -148,6 +148,15 @@ def _scheduled_stub(owner: str, repo: str) -> ci_loop.ScheduledLoop:
     return ci_loop.ScheduledLoop(loop=loop, reused=False)
 
 
+def _saved_report(root: Path, *, window_days: int) -> dict:
+    """Write a snapshot and hand back the report payload inside it."""
+    import json
+
+    _write_report_snapshot(root, window_days=window_days)
+    path = next((root / "acme" / "app").glob("*.json"))
+    return dict(json.loads(path.read_text())["report"])
+
+
 def _write_report_snapshot(root: Path, *, window_days: int) -> datetime:
     from datetime import UTC, datetime, timedelta
 
@@ -385,10 +394,19 @@ def test_analyze_markdown_keeps_details_when_benchmarks_are_requested(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Arrange: a non-terminal caller asks for the report with benchmarks.
-    from integrations.github.tools.ci_analytics import tool as tool_module
+    from typing import Any
 
-    _write_report_snapshot(tmp_path, window_days=30)
+    from integrations.github.tools.ci_analytics import tool as tool_module
+    from integrations.github.tools.ci_analytics.snapshots import report_from_dict
+
+    saved = _saved_report(tmp_path, window_days=30)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
+    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
+
+    def _analyze(_owner: str, _repo: str, **_kwargs: Any) -> Any:
+        return type("A", (), {"report": report_from_dict(saved), "runs_read": 3})()
+
+    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
 
     # Act
     result = tool_module.analyze_github_ci_reliability(

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1129,8 +1129,8 @@ def test_tool_renders_report_from_collected_runs() -> None:
     assert result["reliability_failures"] == 1
     assert result["blocked_minutes"] == 40.0
     assert result["headline"] == (
-        "Unreliable CI cost 1 developer 40m of working time in the last 7 days, up to 40m a "
-        "week for the worst hit; 40m of wall-clock wait across 1 merged PR."
+        "Waiting on CI cost 40m of developer time in the last 7 days, "
+        "about 40m per developer a week."
     )
     assert "Coverage notice: sample" in result["response_text"]
 
@@ -1303,7 +1303,7 @@ def test_the_comparison_starts_on_its_own_line() -> None:
 
     # Act
     render_report(console, report, compact=True)
-    render_comparison(console, report, [report])
+    render_comparison(console, report)
 
     # Assert: a blank line separates the report from the comparison heading.
     lines = buf.getvalue().splitlines()
@@ -1322,3 +1322,34 @@ def test_the_description_tells_the_model_the_comparison_cannot_be_skipped() -> N
     assert registered is not None
     assert "cannot be turned off" in registered.description
     assert "never offer to skip" in registered.description
+    assert "same-day snapshot answers" not in registered.description
+    assert "shipped with the product" in registered.description
+
+
+def test_headline_names_the_cost_when_no_developer_can_be_attributed() -> None:
+    """blocked_working_minutes can be set without per-author waits."""
+    from integrations.github.tools.ci_analytics.models import CiAnalyticsReport
+    from integrations.github.tools.ci_analytics.render import headline
+
+    report = CiAnalyticsReport(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        generated_at=_T0,
+        executions=1,
+        pr_executions=1,
+        pr_failures=0,
+        classified=(),
+        merged_pr_branches=1,
+        blocked_minutes=60.0,
+        blocked_minutes_all=60.0,
+        branch_runs=0,
+        branch_failures=0,
+        red_hours=0.0,
+        outages=(),
+        mean_recovery_hours=None,
+        blocked_working_minutes=90.0,
+    )
+
+    assert headline(report) == ("Waiting on CI cost 1.5h of developer time in the last 30 days.")

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1129,8 +1129,8 @@ def test_tool_renders_report_from_collected_runs() -> None:
     assert result["reliability_failures"] == 1
     assert result["blocked_minutes"] == 40.0
     assert result["headline"] == (
-        "Waiting on CI cost 40m of developer time in the last 7 days, "
-        "about 40m per developer a week."
+        "Waiting on CI cost 1 developer 40m of working time in the last 7 days, "
+        "up to 40m a week for the worst hit."
     )
     assert "Coverage notice: sample" in result["response_text"]
 
@@ -1309,6 +1309,7 @@ def test_the_comparison_starts_on_its_own_line() -> None:
     lines = buf.getvalue().splitlines()
     heading = next(i for i, line in enumerate(lines) if "Compared with" in line)
     assert not lines[heading - 1].strip()
+    assert "The wait at the top is the cost" in buf.getvalue()
 
 
 def test_the_description_tells_the_model_the_comparison_cannot_be_skipped() -> None:
@@ -1353,3 +1354,65 @@ def test_headline_names_the_cost_when_no_developer_can_be_attributed() -> None:
     )
 
     assert headline(report) == ("Waiting on CI cost 1.5h of developer time in the last 30 days.")
+
+
+def test_headline_names_the_worst_hit_not_the_average() -> None:
+    """An average hides the person who waited most; that is the number guests remember."""
+    from integrations.github.tools.ci_analytics.models import (
+        CiAnalyticsReport,
+        PullRequestDelay,
+    )
+    from integrations.github.tools.ci_analytics.render import headline
+
+    delay = PullRequestDelay(
+        head_repo="o/r",
+        branch="feat/x",
+        author="heavy",
+        pr_number=1,
+        commits=1,
+        url="https://example.test/1",
+        expected_green=_T0,
+        actual_green=_T0,
+        delay_minutes=468.0,
+        working_minutes=468.0,
+        critical_path=True,
+    )
+    light = PullRequestDelay(
+        head_repo="o/r",
+        branch="feat/y",
+        author="light",
+        pr_number=2,
+        commits=1,
+        url="https://example.test/2",
+        expected_green=_T0,
+        actual_green=_T0,
+        delay_minutes=60.0,
+        working_minutes=60.0,
+        critical_path=True,
+    )
+    report = CiAnalyticsReport(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        generated_at=_T0,
+        executions=1,
+        pr_executions=1,
+        pr_failures=0,
+        classified=(),
+        merged_pr_branches=2,
+        blocked_minutes=528.0,
+        blocked_minutes_all=528.0,
+        branch_runs=0,
+        branch_failures=0,
+        red_hours=0.0,
+        outages=(),
+        mean_recovery_hours=None,
+        pr_delays=(delay, light),
+        blocked_working_minutes=528.0,
+    )
+
+    assert headline(report) == (
+        "Waiting on CI cost 2 developers 8.8h of working time in the last 30 days, "
+        "up to 1.8h a week for the worst hit."
+    )

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1286,7 +1286,11 @@ def test_the_comparison_starts_on_its_own_line() -> None:
     # Arrange
     from rich.console import Console
 
-    from integrations.github.tools.ci_analytics.render import render_comparison, render_report
+    from integrations.github.tools.ci_analytics.render import (
+        peer_benchmarks,
+        render_comparison,
+        render_report,
+    )
 
     report = compute_report(
         owner="o",
@@ -1303,13 +1307,13 @@ def test_the_comparison_starts_on_its_own_line() -> None:
 
     # Act
     render_report(console, report, compact=True)
-    render_comparison(console, report)
+    render_comparison(console, report, peer_benchmarks(report))
 
     # Assert: a blank line separates the report from the comparison heading.
     lines = buf.getvalue().splitlines()
     heading = next(i for i, line in enumerate(lines) if "Compared with" in line)
     assert not lines[heading - 1].strip()
-    assert "The wait at the top is the cost" in buf.getvalue()
+    assert "Next: schedule this report for weekday mornings" in buf.getvalue()
 
 
 def test_the_description_tells_the_model_the_comparison_cannot_be_skipped() -> None:
@@ -1329,6 +1333,7 @@ def test_the_description_tells_the_model_the_comparison_cannot_be_skipped() -> N
 
 def test_headline_names_the_cost_when_no_developer_can_be_attributed() -> None:
     """blocked_working_minutes can be set without per-author waits."""
+    # Arrange
     from integrations.github.tools.ci_analytics.models import CiAnalyticsReport
     from integrations.github.tools.ci_analytics.render import headline
 
@@ -1353,7 +1358,8 @@ def test_headline_names_the_cost_when_no_developer_can_be_attributed() -> None:
         blocked_working_minutes=90.0,
     )
 
-    assert headline(report) == ("Waiting on CI cost 1.5h of developer time in the last 30 days.")
+    # Act / Assert
+    assert headline(report) == "Waiting on CI cost 1.5h of developer time in the last 30 days."
 
 
 def test_headline_names_the_worst_hit_not_the_average() -> None:

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agent_harness.spi.handoff import AskUserQuestion, parse_ask_user_answers
+from core.agent_harness.spi.handoff import AskUserQuestion, parse_ask_user_answers, question_key
 from core.agent_harness.spi.session_state import (
     PendingUserChoice,
     session_terminal,
@@ -141,11 +141,6 @@ def _parse_bool(value: object, *, default: bool = False) -> bool:
     return default
 
 
-def _normalize_title(title: str) -> str:
-    """Identity for matching a question to an answer in this turn's message."""
-    return " ".join(title.split()).casefold()
-
-
 def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | None]:
     """Return ``(questions, error)``. Absent/empty ``raw`` yields ``([], None)``."""
     if raw is None:
@@ -166,7 +161,7 @@ def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | N
             return None, f"questions[{index}].label is required"
         if not title:
             return None, f"questions[{index}].title is required"
-        title_key = _normalize_title(title)
+        title_key = question_key(title)
         if title_key in seen_titles:
             return None, (
                 f"questions[{index}].title is already used; each question needs its own title"
@@ -191,18 +186,18 @@ def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | N
 
 def _answered_this_turn(ctx: ActionToolScope, title: str) -> str | None:
     """The answer the user gave to ``title`` in this turn's message, if any."""
-    wanted = _normalize_title(title)
+    wanted = question_key(title)
     if not wanted:
         return None
     for asked, answer in parse_ask_user_answers(getattr(ctx, "turn_user_message", "") or ""):
-        if _normalize_title(asked) == wanted:
+        if question_key(asked) == wanted:
             return answer
     return None
 
 
 def _answered_earlier(ctx: ActionToolScope, title: str) -> bool:
     """True when this session already settled ``title`` in an earlier turn."""
-    wanted = _normalize_title(title)
+    wanted = question_key(title)
     settled = getattr(ctx.session, "questions_already_answered", None) or set()
     return bool(wanted) and wanted in settled
 

--- a/tools/interactive_shell/actions/skill_entry.py
+++ b/tools/interactive_shell/actions/skill_entry.py
@@ -14,6 +14,7 @@ from types import MappingProxyType
 from typing import Any
 
 from core.agent_harness.spi.grounding import ActionSkill, list_action_skills, load_skill_body
+from core.agent_harness.spi.handoff import question_key
 from core.agent_harness.tools import ActionToolScope, ToolExecutor
 from core.tool import RegisteredTool
 from tools.interactive_shell.actions.ask_choice import (
@@ -83,7 +84,7 @@ def _forget_hook_questions(session: Any, skill: ActionSkill) -> None:
     for call in skill.pre_execute:
         title = str(call.args.get("title", "")).strip()
         if title:
-            settled.discard(" ".join(title.split()).casefold())
+            settled.discard(question_key(title))
 
 
 def _may_open_menu(session: Any, skill: ActionSkill, *, from_model: bool) -> bool:


### PR DESCRIPTION
- The report leads with one sentence naming the cost ("Waiting on CI  cost 213.7h of developer time in the last 30 days, about 1.6h per   developer a week"), then Key results. The duplicate developer-time  bullet is removed.
- analyze_github_ci_reliability always reads GitHub. The same-day  snapshot answer path is deleted; snapshots are still written for the  scheduled loop, which is the only reader left.
- Benchmark columns ship with the product (apache/airflow and  fastapi/fastapi, measured with this tool over 30 days on 9 Sep 2026)  instead of depending on peer snapshots that a first run does not  have. The table states the measurement day; the "no same-day  snapshot" skip text is gone.
- Menu titles drop "(Esc to skip)"; the menu footer already says it,  and the answered recap now shows the bare question.