### PR TITLE
fix(ci-analytics): every analysis reads GitHub

### DIFF
--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -178,42 +178,6 @@ def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
     }
 
 
-def _from_snapshot(
-    snapshot: dict[str, Any],
-    owner: str,
-    repo: str,
-    window: int,
-    console: Any,
-    *,
-    include_benchmarks: bool = True,
-    compact: bool = False,
-) -> dict[str, Any] | None:
-    """Answer from a saved report, or ``None`` when it holds no usable report object."""
-    saved = snapshot.get("report")
-    report = report_from_dict(saved) if isinstance(saved, dict) else None
-    if report is None:
-        return None
-    generated = str(snapshot.get("generated_at", ""))[:16].replace("T", " ")
-    if console is not None:
-        console.print(
-            f"  [dim]Using the CI reliability snapshot of {escape(f'{owner}/{repo}')} "
-            f"from {generated} UTC (same {window}-day window).[/dim]"
-        )
-        console.print()
-    result = _result(
-        report,
-        owner,
-        repo,
-        window,
-        console,
-        include_benchmarks=include_benchmarks,
-        compact=compact,
-    )
-    result["summary"] += f" Figures as of {generated} UTC, from the saved snapshot."
-    result["from_snapshot"] = snapshot.get("generated_at")
-    return result
-
-
 def report_text_from_snapshot(
     owner: str, repo: str, *, days: int = _DEFAULT_WINDOW_DAYS, include_benchmarks: bool = True
 ) -> tuple[str, str]:
@@ -323,12 +287,13 @@ def _result(
         "reliability KPIs: executions, PR failure rate, failures classified as "
         "CI-caused (same commit passed later) versus source-code, developer time "
         "blocked by unreliable CI on merged PRs, and default-branch red time. "
-        "Read-only. A saved report from today answers without another GitHub "
-        "read; a first run needs a token. Every report also carries a "
-        "comparison with apache/airflow and fastapi/fastapi from figures "
-        "shipped with the product, so a first run compares as well as a later "
-        "one. It cannot be turned off, so never offer to skip it. The report "
-        "is painted on screen — do not restate its figures."
+        "Read-only. Every analysis reads GitHub Actions and needs a token; a "
+        "saved snapshot is written for the scheduled loop, never used to answer "
+        "here. Every report also carries a comparison with apache/airflow and "
+        "fastapi/fastapi from figures shipped with the product, so a first run "
+        "compares as well as a later one. It cannot be turned off, so never "
+        "offer to skip it. The report is painted on screen — do not restate "
+        "its figures."
     ),
     use_cases=[
         "Analyze a repository's CI/CD performance and reliability",
@@ -413,9 +378,9 @@ def analyze_github_ci_reliability(
     ``response_text`` then only summarizes. Other surfaces get the markdown.
     The same call also paints one comparison table against the benchmark
     figures shipped with the product, so a first run compares as well as a
-    hundredth. A saved report from today is reused; a miss reads GitHub and
-    writes the snapshot. The comparison is not the model's choice to make;
-    ``compact`` drops the counts appendix.
+    hundredth. Every analysis reads GitHub: a saved snapshot is written for the
+    scheduled loop, never used to answer here. The comparison is not the
+    model's choice to make; ``compact`` drops the counts appendix.
     """
     window = min(max(int(days or _DEFAULT_WINDOW_DAYS), _MIN_WINDOW_DAYS), _MAX_WINDOW_DAYS)
     brief = _flag(compact)
@@ -433,21 +398,7 @@ def analyze_github_ci_reliability(
         )
     now = datetime.now(UTC)
     console = _console(context)
-    snapshot = read_fresh_snapshot(
-        snapshot_root(), repo_owner, repo_name, window_days=window, now=now
-    )
     token = resolve_github_token(github_token)
-    if snapshot is not None:
-        answered = _from_snapshot(
-            snapshot,
-            repo_owner,
-            repo_name,
-            window,
-            console,
-            compact=brief,
-        )
-        if answered is not None:
-            return answered
     if not token:
         message = (
             f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "

--- a/tests/integrations/github/test_ci_analytics_snapshots.py
+++ b/tests/integrations/github/test_ci_analytics_snapshots.py
@@ -178,17 +178,19 @@ def test_the_schedule_card_report_comes_from_todays_saved_figures(
     assert "Next:" not in text
 
 
-def test_a_saved_report_from_today_answers_without_reading_github(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """A first run is live; the next call the same day must not wait on GitHub again."""
-    # Arrange: a fresh snapshot exists and GitHub would return different figures.
+def test_a_saved_snapshot_never_answers_a_live_analysis(tmp_path: Path, monkeypatch) -> None:
+    """Most people run this for the first time; the demo has to be the first run.
+
+    A same-day snapshot used to answer instead of reading GitHub, so the
+    rehearsed path was one nobody else would take.
+    """
+    # Arrange: a fresh snapshot exists and GitHub is readable.
     from typing import Any, cast
 
     from integrations.github.tools.ci_analytics import tool as tool_module
 
     now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
+    _write_report_snapshot(tmp_path, _report(), now)
     monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
     monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "tok")
     reads: list[str] = []
@@ -204,35 +206,11 @@ def test_a_saved_report_from_today_answers_without_reading_github(
         owner="apache", repo="airflow", days=30, github_token="tok"
     )
 
-    # Assert: the saved figures win, and GitHub was not called.
-    assert reads == []
-    assert result["red_hours"] == 24.5
-    assert result.get("from_snapshot")
-    assert "as of" in result["summary"]
-
-
-def test_a_saved_report_answers_without_a_token(tmp_path: Path, monkeypatch) -> None:
-    """A warmed machine must not fail the demo just because GitHub is not called."""
-    from typing import Any, cast
-
-    from integrations.github.tools.ci_analytics import tool as tool_module
-
-    now = datetime.now(UTC)
-    _write_report_snapshot(tmp_path, _report(red_hours=24.5), now)
-    monkeypatch.setattr(tool_module, "snapshot_root", lambda _root=None: tmp_path)
-    monkeypatch.setattr(tool_module, "resolve_github_token", lambda _t=None: "")
-
-    def _analyze(*_a: Any, **_k: Any) -> Any:
-        raise AssertionError("GitHub must not be read when today's report is saved")
-
-    monkeypatch.setattr(tool_module, "analyze_repository", _analyze)
-
-    result = cast(Any, tool_module.analyze_github_ci_reliability)(
-        owner="apache", repo="airflow", days=30, github_token=""
-    )
-
-    assert result["success"] is True
-    assert result["red_hours"] == 24.5
+    # Assert: the figures are the ones just read, and nothing claims a snapshot.
+    assert reads == ["apache/airflow"]
+    assert result["red_hours"] == 1.0
+    assert "from_snapshot" not in result
+    assert "as of" not in result["summary"]
 
 
 def test_two_windows_written_in_the_same_second_do_not_overwrite(tmp_path: Path) -> None:


### PR DESCRIPTION
The merge of #6178 carried a same-day snapshot short-circuit back into
analyze_github_ci_reliability, while its docs and skills say nothing is
answered from a cache. The short-circuit and its helper are removed;
snapshots are still written for the scheduled loop and read only for
the schedule card's report.