### PR TITLE
fix(guardrails): empty rules key loads as no rules (#6033)

### DIFF
--- a/infrastructure/safety/guardrails/rules.py
+++ b/infrastructure/safety/guardrails/rules.py
@@ -61,8 +61,13 @@ def load_rules(path: Path | None = None) -> list[GuardrailRule]:
         logger.warning("Guardrails config missing 'rules' key at %s", rules_path)
         return []
 
+    raw_rules = raw["rules"]
+    if not isinstance(raw_rules, list):
+        logger.warning("Guardrails config 'rules' must be a list at %s", rules_path)
+        return []
+
     rules: list[GuardrailRule] = []
-    for entry in raw["rules"]:
+    for entry in raw_rules:
         if not isinstance(entry, dict):
             continue
         parsed = _parse_rule(entry)

--- a/tests/infrastructure/safety/guardrails/test_rules.py
+++ b/tests/infrastructure/safety/guardrails/test_rules.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
+import pytest
 import yaml
 
 from infrastructure.safety.guardrails.rules import GuardrailAction, load_rules
@@ -25,6 +27,19 @@ class TestLoadRules:
     def test_returns_empty_when_rules_key_missing(self, tmp_path: Path) -> None:
         path = _write_config(tmp_path, {"version": 1})
         assert load_rules(path) == []
+
+    def test_returns_empty_when_rules_key_is_null(self, tmp_path: Path) -> None:
+        path = tmp_path / "guardrails.yml"
+        path.write_text("rules:", encoding="utf-8")
+        assert load_rules(path) == []
+
+    def test_returns_empty_when_rules_value_is_not_a_list(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        path = _write_config(tmp_path, {"rules": "aws_key"})
+        with caplog.at_level(logging.WARNING, logger="infrastructure.safety.guardrails.rules"):
+            assert load_rules(path) == []
+        assert any("must be a list" in record.message for record in caplog.records)
 
     def test_parses_pattern_rule(self, tmp_path: Path) -> None:
         path = _write_config(


### PR DESCRIPTION
Fixes #6033

#### Describe the changes you have made in this PR

`load_rules` iterated `raw["rules"]` without checking its shape. A `rules:` key with no entries parses as `None`, so the loop raised `TypeError: 'NoneType' object is not iterable`. The exception escaped `load_rules`, so `get_guardrail_evaluator()` failed to build its singleton and `opensre health` raised while rendering the guardrails row.

The fix validates the value before iterating: any non-list `rules` value is treated as malformed, logs a warning, and returns an empty list - matching the existing missing-key path. This also stops the silent acceptance of a scalar such as `rules: aws_key`, which previously returned `[]` only because iterating the string produced characters that failed the per-entry `isinstance` check.

Tests added in `tests/infrastructure/safety/guardrails/test_rules.py`:
- `rules:` with no entries returns `[]` (previously `TypeError`).
- `rules: aws_key` returns `[]` and logs the malformed-shape warning.

### Demo/Screenshot for feature changes and bug fixes -

Before (new test against `main`):

```
tests/infrastructure/safety/guardrails/test_rules.py::TestLoadRules::test_returns_empty_when_rules_key_is_null
    for entry in raw["rules"]:
E   TypeError: 'NoneType' object is not iterable
```

After:

```
$ uv run python -m pytest tests/infrastructure/safety/guardrails/test_rules.py -q
15 passed in 0.49s
```

Full guardrails package: `115 passed`. `make lint`, `make format-check` and
`make typecheck` are clean.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a missing shape check, not a parsing problem: `yaml.safe_load`
returns `{"rules": None}` for an empty `rules:` key, and the loader assumed a
list. I considered coercing `None` to `[]` inline in the loop, but the issue also
notes that scalar values are silently accepted, so I validate the value once
before iterating. That keeps one canonical "malformed config → warn + empty
list" path, consistent with the existing missing-key and malformed-YAML
branches, and fixes both shapes with one check.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
