### PR TITLE
fix(observability): OTLP parser tolerates null JSON fields

### DIFF
--- a/infrastructure/observability/otlp_parser.py
+++ b/infrastructure/observability/otlp_parser.py
@@ -28,11 +28,20 @@ def extract_span_attributes(span: dict[str, Any]) -> dict[str, Any]:
     with an unsupported value kind are skipped.
     """
     attributes: dict[str, Any] = {}
-    for attr in span.get("attributes", []):
+    if not isinstance(span, dict):
+        return attributes
+    raw_attributes = span.get("attributes")
+    if not isinstance(raw_attributes, list):
+        return attributes
+    for attr in raw_attributes:
+        if not isinstance(attr, dict):
+            continue
         key = attr.get("key", "")
         if not key:
             continue
-        value = attr.get("value", {})
+        value = attr.get("value")
+        if not isinstance(value, dict):
+            continue
         for kind in _OTLP_SCALAR_KINDS:
             if kind in value:
                 attributes[key] = value[kind]
@@ -62,20 +71,36 @@ def parse_otlp_trace(trace_data: dict[str, Any]) -> list[dict[str, Any]]:
     callers can correlate spans to services without a nested lookup.
     """
     spans: list[dict[str, Any]] = []
+    if not isinstance(trace_data, dict):
+        return spans
+    raw_batches = trace_data.get("batches")
+    if not isinstance(raw_batches, list):
+        return spans
 
-    for batch in trace_data.get("batches", []):
+    for batch in raw_batches:
         if not isinstance(batch, dict):
             continue
-        resource_attributes = extract_span_attributes(batch.get("resource", {}))
+        resource = batch.get("resource")
+        resource_attributes = extract_span_attributes(
+            resource if isinstance(resource, dict) else {}
+        )
         service_name = str(resource_attributes.get("service.name", ""))
 
-        for scope in batch.get("scopeSpans", []):
+        raw_scopes = batch.get("scopeSpans")
+        if not isinstance(raw_scopes, list):
+            continue
+        for scope in raw_scopes:
             if not isinstance(scope, dict):
                 continue
-            for span in scope.get("spans", []):
+            raw_spans = scope.get("spans")
+            if not isinstance(raw_spans, list):
+                continue
+            for span in raw_spans:
                 if not isinstance(span, dict):
                     continue
-                status = span.get("status") or {}
+                status = span.get("status")
+                if not isinstance(status, dict):
+                    status = {}
                 spans.append(
                     {
                         "name": span.get("name", _UNKNOWN_SPAN_NAME),

--- a/infrastructure/observability/otlp_parser.py
+++ b/infrastructure/observability/otlp_parser.py
@@ -21,11 +21,13 @@ _EMPTY_DURATION_MILLISECONDS = 0.0
 _UNKNOWN_SPAN_NAME = "unknown"
 
 
-def extract_span_attributes(span: dict[str, Any]) -> dict[str, Any]:
+def extract_span_attributes(span: object) -> dict[str, Any]:
     """Flatten an OTLP attribute list into a plain key -> value mapping.
 
-    Handles the common OTLP/JSON scalar value kinds. Attributes without a key or
-    with an unsupported value kind are skipped.
+    ``span`` is a JSON-decoded value, so a non-mapping input or a non-list
+    ``attributes`` field yields an empty mapping. Handles the common OTLP/JSON
+    scalar value kinds. Attributes without a key or with an unsupported value
+    kind are skipped.
     """
     attributes: dict[str, Any] = {}
     if not isinstance(span, dict):
@@ -64,11 +66,13 @@ def _duration_ms(start_unix_nano: Any, end_unix_nano: Any) -> float:
     )
 
 
-def parse_otlp_trace(trace_data: dict[str, Any]) -> list[dict[str, Any]]:
+def parse_otlp_trace(trace_data: object) -> list[dict[str, Any]]:
     """Parse an OTLP/JSON trace into a flat list of span dicts.
 
-    The ``service_name`` is lifted from each batch's resource attributes so
-    callers can correlate spans to services without a nested lookup.
+    ``trace_data`` is a JSON-decoded value; a non-mapping input, a non-list
+    ``batches`` field, or a malformed batch is skipped. The ``service_name`` is
+    lifted from each batch's resource attributes so callers can correlate spans
+    to services without a nested lookup.
     """
     spans: list[dict[str, Any]] = []
     if not isinstance(trace_data, dict):

--- a/tests/infrastructure/observability/test_otlp_trace.py
+++ b/tests/infrastructure/observability/test_otlp_trace.py
@@ -69,3 +69,41 @@ def test_parse_otlp_trace_handles_empty_and_malformed() -> None:
     assert parse_otlp_trace({}) == []
     assert parse_otlp_trace({"batches": ["not-a-dict"]}) == []
     assert parse_otlp_trace({"batches": [{"scopeSpans": [{"spans": []}]}]}) == []
+
+
+def test_extract_span_attributes_tolerates_null_and_non_dict_entries() -> None:
+    assert extract_span_attributes({"attributes": None}) == {}
+    assert extract_span_attributes(None) == {}
+    span = {
+        "attributes": [
+            None,
+            "junk",
+            {"key": "null-value", "value": None},
+            {"key": "ok", "value": {"stringValue": "v"}},
+        ]
+    }
+    assert extract_span_attributes(span) == {"ok": "v"}
+
+
+def test_parse_otlp_trace_tolerates_null_collections() -> None:
+    assert parse_otlp_trace({"batches": None}) == []
+
+    trace = {
+        "batches": [
+            {
+                "resource": None,
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {"name": "kept", "attributes": None, "status": None},
+                        ]
+                    }
+                ],
+            },
+            {"resource": {"attributes": None}, "scopeSpans": None},
+        ]
+    }
+    spans = parse_otlp_trace(trace)
+    assert [span["name"] for span in spans] == ["kept"]
+    assert spans[0]["attributes"] == {}
+    assert spans[0]["status_code"] == ""


### PR DESCRIPTION
No linked issue — small robustness bug found while auditing JSON shape handling in the shared OTLP parser.

#### Describe the changes you have made in this PR -

`parse_otlp_trace` and `extract_span_attributes` assumed OTLP/JSON collection fields were either present or absent, never `null`. A payload like `{"batches": null}`, `{"resource": null}` or `{"attributes": null}` reached a `for` loop and raised `TypeError: 'NoneType' object is not iterable`; a `null` attribute value raised `TypeError`, and a non-dict `resource`/`attributes` raised `AttributeError`.

`integrations/tempo/client.py` calls `parse_otlp_trace(payload or {})` without a catch, so a Tempo response with a null field failed the `tempo_get_trace` tool instead of returning spans. The Grafana Cloud Tempo mixin catches the exception but then silently reports zero spans.

The parser now normalizes every collection and mapping before iterating (`batches`, `resource`, `scopeSpans`, `spans`, `attributes`, `status`, attribute entries and their `value`), consistent with the non-dict entry guards already in the function.

### Demo/Screenshot for feature changes and bug fixes -

Before (new tests against `main`):

```
tests/infrastructure/observability/test_otlp_trace.py::test_extract_span_attributes_tolerates_null_and_non_dict_entries
    for attr in span.get("attributes", []):
E   TypeError: 'NoneType' object is not iterable

tests/infrastructure/observability/test_otlp_trace.py::test_parse_otlp_trace_tolerates_null_collections
    for batch in trace_data.get("batches", []):
E   TypeError: 'NoneType' object is not iterable
```

After:

```
$ uv run python -m pytest tests/infrastructure/observability/ -q
156 passed

$ uv run python -m pytest tests/integrations/grafana/test_tempo.py tests/integrations/tempo -q
18 passed
```

`make lint`, `make format-check` and `make typecheck` are clean.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The root cause is that `dict.get(key, default)` only covers a missing key, not an explicit `null`, and OTLP/JSON can carry null collections. I chose one normalization per field before the loop rather than sprinkling `or []` inline: `isinstance(x, list)` for collections and `isinstance(x, dict)` for mappings, matching the `isinstance(batch, dict)` guards already used one level down. `extract_span_attributes` also accepts a non-dict span now because `parse_otlp_trace` can pass a `resource` that is present but not a mapping.

---

## Checklist before requesting a review
- [x] I have added a proper PR title and described the change (no tracking issue exists for this small fix)
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
