### PR TITLE
fix(install): authenticate GitHub API calls to avoid canary 403s (#6128)

### DIFF
--- a/.github/workflows/installer-canary.yml
+++ b/.github/workflows/installer-canary.yml
@@ -80,7 +80,9 @@ jobs:
           # Shared runner IPs hit the unauthenticated GitHub API rate limit
           # (403), which fails the canary. The installers forward this token to
           # api.github.com only — never to asset downloads (issue #6128).
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_TOKEN mirrors config/constants/github.py (GH_TOKEN_ENV) and the
+          # report job below; the installers also accept GITHUB_TOKEN_ENV.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
           uv run python -m pytest ${{ matrix.test_path }} -v \

--- a/.github/workflows/installer-canary.yml
+++ b/.github/workflows/installer-canary.yml
@@ -76,6 +76,11 @@ jobs:
         # test_live_installers.py — Homebrew ships preinstalled on
         # macos-latest runners, so they aren't skipped.
         shell: bash
+        env:
+          # Shared runner IPs hit the unauthenticated GitHub API rate limit
+          # (403), which fails the canary. The installers forward this token to
+          # api.github.com only — never to asset downloads (issue #6128).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
           uv run python -m pytest ${{ matrix.test_path }} -v \

--- a/install.ps1
+++ b/install.ps1
@@ -429,6 +429,18 @@ function Get-OpenSreRequestHeaders {
     }
 }
 
+function Get-OpenSreApiHeaders {
+    $headers = Get-OpenSreRequestHeaders
+    $token = $env:GITHUB_TOKEN
+    if (-not $token) {
+        $token = $env:GH_TOKEN
+    }
+    if ($token) {
+        $headers["Authorization"] = "Bearer $token"
+    }
+    return $headers
+}
+
 function Invoke-OpenSreWithRetry {
     param(
         [Parameter(Mandatory = $true)]
@@ -525,7 +537,7 @@ function Invoke-OpenSreRestMethod {
 
     $params = @{
         Uri = $Uri
-        Headers = Get-OpenSreRequestHeaders
+        Headers = Get-OpenSreApiHeaders
     }
 
     $command = Get-Command Invoke-RestMethod -ErrorAction Stop

--- a/install.sh
+++ b/install.sh
@@ -278,11 +278,17 @@ download_to() {
 
 download_text() {
   local url="$1"
+  local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+  local -a headers=(
+    -H "Accept: application/vnd.github+json"
+    -H "User-Agent: opensre-install-script"
+  )
 
-  curl "${CURL_FLAGS[@]}" \
-    -H "Accept: application/vnd.github+json" \
-    -H "User-Agent: opensre-install-script" \
-    "$url"
+  if [ -n "$token" ]; then
+    headers+=(-H "Authorization: Bearer ${token}")
+  fi
+
+  curl "${CURL_FLAGS[@]}" "${headers[@]}" "$url"
 }
 
 fetch_release_json() {

--- a/install.sh
+++ b/install.sh
@@ -278,17 +278,32 @@ download_to() {
 
 download_text() {
   local url="$1"
+  # Names mirror config/constants/github.py (GITHUB_TOKEN_ENV, GH_TOKEN_ENV).
   local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
-  local -a headers=(
-    -H "Accept: application/vnd.github+json"
-    -H "User-Agent: opensre-install-script"
-  )
 
-  if [ -n "$token" ]; then
-    headers+=(-H "Authorization: Bearer ${token}")
+  if [ -z "$token" ]; then
+    curl "${CURL_FLAGS[@]}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "User-Agent: opensre-install-script" \
+      "$url"
+    return
   fi
 
-  curl "${CURL_FLAGS[@]}" "${headers[@]}" "$url"
+  # Pass the token through a private curl config file: process arguments are
+  # visible to other users via ps on shared machines.
+  local config_file
+  config_file="$(mktemp "${TMPDIR:-/tmp}/opensre-curl.XXXXXX")"
+  chmod 600 "$config_file"
+  {
+    printf 'header = "Accept: application/vnd.github+json"\n'
+    printf 'header = "User-Agent: opensre-install-script"\n'
+    printf 'header = "Authorization: Bearer %s"\n' "$token"
+  } > "$config_file"
+
+  local status=0
+  curl "${CURL_FLAGS[@]}" --config "$config_file" "$url" || status=$?
+  rm -f "$config_file"
+  return "$status"
 }
 
 fetch_release_json() {

--- a/tests/cli/test_install_ps1_github_auth.py
+++ b/tests/cli/test_install_ps1_github_auth.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from config.constants import GH_TOKEN_ENV, GITHUB_TOKEN_ENV
+
 INSTALL_PS1 = Path(__file__).parents[2] / "install.ps1"
 
 
@@ -31,12 +33,17 @@ def test_install_ps1_api_headers_include_bearer_token() -> None:
     if shell is None:
         pytest.skip("PowerShell is not installed in this environment.")
 
+    script_path = str(INSTALL_PS1).replace("'", "''")
     script = textwrap.dedent(
         f"""
-        $env:GITHUB_TOKEN = 'test-token'
-        . '{INSTALL_PS1}' -SkipMain
-        $api = Get-OpenSreApiHeaders
-        Write-Output "API_AUTH=$($api['Authorization'])"
+        Remove-Item "Env:{GITHUB_TOKEN_ENV}" -ErrorAction SilentlyContinue
+        $env:{GH_TOKEN_ENV} = 'fallback-token'
+        . '{script_path}' -SkipMain
+        $fallback = Get-OpenSreApiHeaders
+        Write-Output "FALLBACK=$($fallback['Authorization'])"
+        $env:{GITHUB_TOKEN_ENV} = 'primary-token'
+        $primary = Get-OpenSreApiHeaders
+        Write-Output "PRIMARY=$($primary['Authorization'])"
         $download = Get-OpenSreRequestHeaders
         Write-Output "DOWNLOAD_HAS_AUTH=$($download.ContainsKey('Authorization'))"
         """
@@ -50,5 +57,6 @@ def test_install_ps1_api_headers_include_bearer_token() -> None:
 
     assert result.returncode == 0, result.stderr
     output = result.stdout + result.stderr
-    assert "API_AUTH=Bearer test-token" in output
+    assert "FALLBACK=Bearer fallback-token" in output
+    assert "PRIMARY=Bearer primary-token" in output
     assert "DOWNLOAD_HAS_AUTH=False" in output

--- a/tests/cli/test_install_ps1_github_auth.py
+++ b/tests/cli/test_install_ps1_github_auth.py
@@ -1,0 +1,54 @@
+"""install.ps1 must send a GitHub token to API requests only, never downloads."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+INSTALL_PS1 = Path(__file__).parents[2] / "install.ps1"
+
+
+def _powershell() -> str | None:
+    return shutil.which("pwsh") or shutil.which("powershell")
+
+
+def test_install_ps1_uses_token_headers_only_for_api_requests() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert "function Get-OpenSreApiHeaders" in source
+    assert "Headers = Get-OpenSreApiHeaders" in source
+    # Download paths stay unauthenticated: release assets redirect to signed
+    # URLs on another host, which must never receive the token.
+    assert "Headers = Get-OpenSreRequestHeaders" in source
+
+
+def test_install_ps1_api_headers_include_bearer_token() -> None:
+    shell = _powershell()
+    if shell is None:
+        pytest.skip("PowerShell is not installed in this environment.")
+
+    script = textwrap.dedent(
+        f"""
+        $env:GITHUB_TOKEN = 'test-token'
+        . '{INSTALL_PS1}' -SkipMain
+        $api = Get-OpenSreApiHeaders
+        Write-Output "API_AUTH=$($api['Authorization'])"
+        $download = Get-OpenSreRequestHeaders
+        Write-Output "DOWNLOAD_HAS_AUTH=$($download.ContainsKey('Authorization'))"
+        """
+    )
+
+    result = subprocess.run(
+        [shell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert "API_AUTH=Bearer test-token" in output
+    assert "DOWNLOAD_HAS_AUTH=False" in output

--- a/tests/cli/test_install_sh_github_auth.py
+++ b/tests/cli/test_install_sh_github_auth.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+from config.constants import GH_TOKEN_ENV, GITHUB_TOKEN_ENV
+
 # Same Windows-skip rationale as ``test_install_sh_path.py`` — install.sh is
 # POSIX-only and the GitHub Actions ``windows-latest`` runner has no usable
 # bash. See issue #1099.
@@ -37,7 +39,21 @@ def _run_download_text(*, env: dict[str, str]) -> subprocess.CompletedProcess[st
     script = textwrap.dedent(
         f"""\
         CURL_FLAGS=(--silent)
-        curl() {{ printf '%s\\n' "$@"; }}
+        curl() {{
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              --config)
+                printf 'CONFIG_FILE=%s\\n' "$2"
+                cat "$2"
+                shift 2
+                ;;
+              *)
+                printf 'ARG=%s\\n' "$1"
+                shift
+                ;;
+            esac
+          done
+        }}
         {_extract_function("download_text")}
         download_text "{API_URL}"
         """
@@ -51,18 +67,20 @@ def _run_download_text(*, env: dict[str, str]) -> subprocess.CompletedProcess[st
 
 
 def test_github_token_adds_bearer_authorization() -> None:
-    result = _run_download_text(env={"GITHUB_TOKEN": "test-token"})
+    result = _run_download_text(env={GITHUB_TOKEN_ENV: "test-token"})
 
     assert result.returncode == 0, result.stderr
-    assert "Authorization: Bearer test-token" in result.stdout
+    assert 'header = "Authorization: Bearer test-token"' in result.stdout
     assert API_URL in result.stdout
+    # The token must not travel through curl's process arguments.
+    assert "ARG=Authorization" not in result.stdout
 
 
 def test_gh_token_is_the_fallback_when_github_token_is_absent() -> None:
-    result = _run_download_text(env={"GH_TOKEN": "fallback-token"})
+    result = _run_download_text(env={GH_TOKEN_ENV: "fallback-token"})
 
     assert result.returncode == 0, result.stderr
-    assert "Authorization: Bearer fallback-token" in result.stdout
+    assert 'header = "Authorization: Bearer fallback-token"' in result.stdout
 
 
 def test_no_authorization_without_a_token() -> None:
@@ -70,3 +88,4 @@ def test_no_authorization_without_a_token() -> None:
 
     assert result.returncode == 0, result.stderr
     assert "Authorization" not in result.stdout
+    assert "CONFIG_FILE" not in result.stdout

--- a/tests/cli/test_install_sh_github_auth.py
+++ b/tests/cli/test_install_sh_github_auth.py
@@ -1,0 +1,72 @@
+"""install.sh must authenticate GitHub API metadata calls when a token is available."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Same Windows-skip rationale as ``test_install_sh_path.py`` — install.sh is
+# POSIX-only and the GitHub Actions ``windows-latest`` runner has no usable
+# bash. See issue #1099.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "install.sh is POSIX-only; the Windows runner has no usable bash "
+        "(resolves to unconfigured WSL), so this module's subprocess-driven "
+        "tests cannot run there. See issue #1099."
+    ),
+)
+
+INSTALL_SH = Path(__file__).parents[2] / "install.sh"
+API_URL = "https://api.github.com/repos/Tracer-Cloud/opensre/releases/latest"
+
+
+def _extract_function(name: str) -> str:
+    lines = INSTALL_SH.read_text(encoding="utf-8").splitlines()
+    start = lines.index(f"{name}() {{")
+    end = lines.index("}", start)
+    return "\n".join(lines[start : end + 1])
+
+
+def _run_download_text(*, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    script = textwrap.dedent(
+        f"""\
+        CURL_FLAGS=(--silent)
+        curl() {{ printf '%s\\n' "$@"; }}
+        {_extract_function("download_text")}
+        download_text "{API_URL}"
+        """
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env={"PATH": os.environ.get("PATH", ""), **env},
+    )
+
+
+def test_github_token_adds_bearer_authorization() -> None:
+    result = _run_download_text(env={"GITHUB_TOKEN": "test-token"})
+
+    assert result.returncode == 0, result.stderr
+    assert "Authorization: Bearer test-token" in result.stdout
+    assert API_URL in result.stdout
+
+
+def test_gh_token_is_the_fallback_when_github_token_is_absent() -> None:
+    result = _run_download_text(env={"GH_TOKEN": "fallback-token"})
+
+    assert result.returncode == 0, result.stderr
+    assert "Authorization: Bearer fallback-token" in result.stdout
+
+
+def test_no_authorization_without_a_token() -> None:
+    result = _run_download_text(env={})
+
+    assert result.returncode == 0, result.stderr
+    assert "Authorization" not in result.stdout


### PR DESCRIPTION
Fixes #6128

#### Describe the changes you have made in this PR -

The installers query `api.github.com` unauthenticated. GitHub-hosted runners share egress IPs, so the unauthenticated limit (60 requests/hour/IP) is often already exhausted and the release metadata call fails with `403 Forbidden`. That is the canary failure: the latest run failed on macOS, an earlier one on Windows, and each retry rotates which platform loses the race.

Changes:

- `install.sh` / `install.ps1` now send `Authorization: Bearer $GITHUB_TOKEN`   (`GH_TOKEN` as fallback) on the GitHub API metadata request when either variable is set. Without a token, behavior is unchanged.
- The token is only attached to the API request. Release asset downloads keep the  unauthenticated header set because assets redirect to signed URLs on another  host, which must never receive the token.
- `.github/workflows/installer-canary.yml` passes its `contents: read`  `GITHUB_TOKEN` to the installer test step.
- Tests: `tests/cli/test_install_sh_github_auth.py` runs the real `download_text`  with a stubbed `curl` and pins the header, the `GH_TOKEN` fallback, and the  no-token path. `tests/cli/test_install_ps1_github_auth.py` pins the PowerShell  split (API headers authenticated, download headers not) and runs it under  PowerShell when available.

The Cloudflare install proxy serves `main` with `cache-control: no-store` (`infrastructure/deployment/cloudflare_install_proxy/src/index.mjs`), so the CDN path picks this up on the first canary run after merge.

### Demo/Screenshot for feature changes and bug fixes -

Before (canary run, macOS leg):

```
E   AssertionError: curl: (56) The requested URL returned error: 403
E     Error: Failed to query release metadata from GitHub.
```

After:

```
$ uv run python -m pytest tests/cli/test_install_sh_github_auth.py tests/cli/test_install_ps1_github_auth.py -q
4 passed, 1 skipped (PowerShell not installed locally)

$ uv run python -m pytest tests/cli/test_install_matrix.py tests/cli/test_install_sh_path.py \
    tests/cli/test_install_sh_resolution.py tests/cli/test_install_ps1_progress.py -q
71 passed, 5 skipped
```

`bash -n install.sh`, YAML parse, `make lint`, `make format-check` and
`make typecheck` are clean. The PowerShell runtime test runs on the Windows CI job.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The failure is environmental (shared runner IP + unauthenticated API), not an installer bug, so the fix is to make authentication available without changing the default behavior for real users. I put the header in the single existing API fetch path per installer (`download_text` in bash, `Invoke-OpenSreRestMethod`'s header builder in PowerShell) rather than threading a parameter through callers. The important edge is the one I deliberately did not change: downloads from `objects.githubusercontent.com` keep the unauthenticated headers, because those URLs are signed and forwarding a token to another host is the wrong default. `GH_TOKEN` is the fallback because that is the `gh` CLI convention, and CI sets `GITHUB_TOKEN`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
