### PR TITLE
ci(release): skip PyPI publish on the nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -740,29 +740,30 @@ jobs:
             exit 1
           fi
 
-  publish-python-dist:
-    name: Publish Python distributions to PyPI
-    runs-on: ubuntu-latest
-    needs:
-      - build-python-dist
-      - publish-release
-    environment:
-      name: pypi
-      url: https://pypi.org/p/opensre
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download Python distributions
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: release-python-dist
-          path: dist
-
-      - name: Publish Python distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          skip-existing: true
+  # PyPI publish is disabled: the nightly/main release was failing on this job.
+  # publish-python-dist:
+  #   name: Publish Python distributions to PyPI
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - build-python-dist
+  #     - publish-release
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/opensre
+  #   permissions:
+  #     id-token: write
+  #
+  #   steps:
+  #     - name: Download Python distributions
+  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+  #       with:
+  #         name: release-python-dist
+  #         path: dist
+  #
+  #     - name: Publish Python distributions to PyPI
+  #       uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+  #       with:
+  #         skip-existing: true
 
   publish-main-release:
     if: always() && needs.prepare.outputs.channel == 'main' && needs.build-binaries.result == 'success'

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -161,30 +161,13 @@ def test_release_workflow_does_not_run_on_pull_requests() -> None:
     assert "opensre_pr_" not in workflow
 
 
-def test_release_workflow_publishes_python_distributions_to_pypi() -> None:
-    workflow = yaml.load(_RELEASE_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
-    publish_job = workflow["jobs"]["publish-python-dist"]
+def test_release_workflow_does_not_publish_python_distributions_to_pypi() -> None:
+    raw = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.load(raw, Loader=yaml.BaseLoader)
 
-    assert publish_job["needs"] == ["build-python-dist", "publish-release"]
-    assert publish_job["environment"] == {
-        "name": "pypi",
-        "url": "https://pypi.org/p/opensre",
-    }
-    assert publish_job["permissions"] == {"id-token": "write"}
-
-    download_step, publish_step = publish_job["steps"]
-    assert download_step["uses"] == (
-        "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
-    )
-    assert download_step["with"] == {
-        "name": "release-python-dist",
-        "path": "dist",
-    }
-    assert publish_step["uses"] == (
-        "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33"
-    )
-    assert publish_step["with"]["skip-existing"] == "true"
-    assert "password" not in publish_step.get("with", {})
+    assert "publish-python-dist" not in workflow["jobs"]
+    assert "# publish-python-dist:" in raw
+    assert "#       uses: pypa/gh-action-pypi-publish@" in raw
 
 
 def test_infrastructure_data_excludes_the_cloudflare_worker() -> None:


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

The scheduled Release on `main` was failing at **Publish Python distributions to PyPI**. That job is commented out so GitHub/Homebrew artifacts still ship without uploading to PyPI.

### Demo/Screenshot for feature changes and bug fixes -

Failed job: https://github.com/Tracer-Cloud/opensre/actions/runs/34549175890 (`Publish Python distributions to PyPI`). After this change `publish-python-dist` is not an active workflow job.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Same pattern as the earlier “comment pypi” disable: leave the job in the file as comments so it is easy to restore, and pin that it is inactive in `tests/packaging/test_release_manifest.py`. Local check: `uv run python -m pytest tests/packaging/test_release_manifest.py` (15 passed).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions