### PR TITLE
 fix(scheduler): reject work-item reminders without an item ID

### DIFF
--- a/infrastructure/scheduling/scheduler/types.py
+++ b/infrastructure/scheduling/scheduler/types.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import UTC, datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class TaskKind(StrEnum):
@@ -84,6 +84,16 @@ class ScheduledTask(BaseModel):
     created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
     last_run: str | None = None
     next_run: str | None = None
+
+    @model_validator(mode="after")
+    def _require_work_item_id_for_reminders(self) -> ScheduledTask:
+        """Require the durable work-item reference used to build a reminder."""
+        if (
+            self.kind is TaskKind.WORK_ITEM_REMINDER
+            and not self.params.get("work_item_id", "").strip()
+        ):
+            raise ValueError("work_item_reminder requires a non-empty params.work_item_id")
+        return self
 
     def display_id(self) -> str:
         """Short display ID for CLI output."""

--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -34,6 +34,18 @@ _KIND_CHOICES = [k.value for k in _CRON_ADD_SUPPORTED_KINDS]
 _PROVIDER_CHOICES = [p.value for p in Provider]
 
 
+def _reject_generic_work_item_reminder(
+    _ctx: click.Context, _param: click.Parameter, kind: str
+) -> str:
+    """Keep reminders on the work-item creation path that supplies their ID."""
+    if kind == TaskKind.WORK_ITEM_REMINDER.value:
+        raise click.BadParameter(
+            "work_item_reminder tasks must be created with `opensre work add --remind-at`.",
+            param_hint="--kind",
+        )
+    return kind
+
+
 @click.group(name="cron")
 def cron_command() -> None:
     """Manage cron-driven scheduled deliveries to messaging providers."""
@@ -51,6 +63,7 @@ def cron_command() -> None:
     "--kind",
     type=click.Choice(_KIND_CHOICES, case_sensitive=False),
     required=True,
+    callback=_reject_generic_work_item_reminder,
     help="The kind of scheduled task.",
 )
 @click.option(

--- a/tests/cli/test_cron_command.py
+++ b/tests/cli/test_cron_command.py
@@ -29,6 +29,24 @@ def test_cron_add_kind_choices_exclude_sentry_kinds() -> None:
     }
 
 
+def test_cron_add_rejects_work_item_reminder_without_a_work_item() -> None:
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "work_item_reminder",
+            "--cron",
+            "0 9 * * *",
+            "--provider",
+            "interactive_shell",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "opensre work add --remind-at" in result.output
+
+
 def test_cron_list_surfaces_legacy_task_migration_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/scheduler/test_types.py
+++ b/tests/scheduler/test_types.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from infrastructure.scheduling.scheduler.types import (
     Provider,
     ScheduledTask,
@@ -45,6 +48,14 @@ class TestScheduledTask:
         assert task.params == {}
         assert task.last_run is None
         assert task.next_run is None
+
+    def test_work_item_reminder_requires_work_item_id(self) -> None:
+        with pytest.raises(ValidationError, match="params.work_item_id"):
+            ScheduledTask(
+                kind=TaskKind.WORK_ITEM_REMINDER,
+                cron="0 9 * * *",
+                provider=Provider.INTERACTIVE_SHELL,
+            )
 
     def test_all_task_kinds(self) -> None:
         assert TaskKind.MANUAL_LOOP == "manual_loop"


### PR DESCRIPTION
Fixes #6186

  #### Describe the changes you have made in this PR

  Prevents unusable `work_item_reminder` schedules from being created through `opensre cron add`.

  - `cron add --kind work_item_reminder` now fails with guidance to use `opensre work add --remind-at`.
  - `ScheduledTask` now requires a non-empty `params.work_item_id` for work-item reminders, protecting all creation paths.
  - Added regression tests for both the CLI rejection and model invariant.

 
  Explain your implementation approach:

  The generic cron command cannot provide the durable work-item reference required by a reminder. The command now rejects that kind with the supported
  creation path, while the scheduler model enforces the required ID so malformed reminders cannot enter through another caller.

