### PR TITLE
fix(shell): clarify terminal transcript hierarchy

### DIFF
--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -19,7 +19,7 @@ Token reference
   BG         terminal background, never used as foreground
   INPUT_SURFACE  composer/menu plate — visibly lifted vs BG (input box fill)
   BOLD_SKILL fixed green skill-activation label
-  reply marker  assistant ``Ω`` lead-in — Factory/Droid-warm accent via
+  reply label   assistant and working-state lead-in via
                 :func:`reply_marker_style` (not WARNING; must stay vivid)
 
 Usage
@@ -362,7 +362,7 @@ def _parse_hex_color(value: str) -> tuple[int, int, int]:
 
 
 def reply_marker_hex() -> str:
-    """Hex for the assistant ``Ω`` / tool ``⏺`` accent — the active theme's
+    """Hex for transcript lead labels — the active theme's
     ``HIGHLIGHT``, so every component follows the selected palette rather than a
     fixed colour that would read as a copy of another tool."""
     return _ACTIVE_THEME.HIGHLIGHT

--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -19,7 +19,7 @@ Token reference
   BG         terminal background, never used as foreground
   INPUT_SURFACE  composer/menu plate — visibly lifted vs BG (input box fill)
   BOLD_SKILL fixed green skill-activation label
-  reply label   assistant and working-state lead-in via
+  reply marker  assistant circle and working-state lead-in via
                 :func:`reply_marker_style` (not WARNING; must stay vivid)
 
 Usage

--- a/surfaces/interactive_shell/command_registry/session_cmds/resume_rendering.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/resume_rendering.py
@@ -34,9 +34,7 @@ def render_resumed_session_history(
     messages: list[tuple[str, str]],
 ) -> None:
     """Render prior session activity in REPL turn order, including slash commands."""
-    from infrastructure.terminal.markdown import ReplyMarkdown
-    from infrastructure.terminal.theme import MARKDOWN_THEME
-    from surfaces.interactive_shell.ui.streaming import render_response_header
+    from surfaces.interactive_shell.ui.streaming.renderer import render_reply_block
 
     if not history and not messages:
         return
@@ -67,9 +65,7 @@ def render_resumed_session_history(
                 queued = assistant_by_user.get(text)
                 response = queued.popleft() if queued else ""
             if response:
-                render_response_header(console, "assistant")
-                with console.use_theme(MARKDOWN_THEME):
-                    console.print(ReplyMarkdown(response, code_theme="ansi_dark"))
+                render_reply_block(console, response)
         console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
         return
 
@@ -79,9 +75,7 @@ def render_resumed_session_history(
             console.print(f"[bold {HIGHLIGHT}]❯[/] {escape(text)}")
             has_pending_user = True
         elif role == "assistant" and has_pending_user:
-            render_response_header(console, "assistant")
-            with console.use_theme(MARKDOWN_THEME):
-                console.print(ReplyMarkdown(text, code_theme="ansi_dark"))
+            render_reply_block(console, text)
             has_pending_user = False
     console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
 

--- a/surfaces/interactive_shell/runtime/agent_harness_adapters.py
+++ b/surfaces/interactive_shell/runtime/agent_harness_adapters.py
@@ -11,11 +11,14 @@ from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.markup import escape
+from rich.text import Text
 
 from core.agent_harness import OutputSink
 from core.agent_harness.spi.defaults import DefaultErrorReporter
 from core.llm.shared.llm_retry import CREDIT_EXHAUSTED_MARKER
-from surfaces.interactive_shell.ui import DIM
+from infrastructure.safety.terminal_output import strip_terminal_controls
+from surfaces.interactive_shell.ui import DIM, ERROR, TEXT
+from surfaces.interactive_shell.ui.transcript import TranscriptRole, transcript_prefix
 
 if TYPE_CHECKING:
     from surfaces.interactive_shell.session import Session
@@ -72,7 +75,7 @@ class ShellOutputSink:
         self._console.print(message, markup=False)
 
     def render_response_header(self, label: str) -> None:
-        # No leading blank — Droid-dense turn stacking (user row → Ω reply).
+        # No leading blank: the caller owns spacing between the user and reply.
         render_response_header(self._console, label)
 
     def render_plan_breakdown(self, breakdown: str) -> None:
@@ -82,7 +85,11 @@ class ShellOutputSink:
         render_plan_breakdown(self._console, breakdown)
 
     def render_error(self, message: str) -> None:
-        self._console.print(f"[yellow]{escape(message)}[/]")
+        safe_message = strip_terminal_controls(message, keep_whitespace=True)
+        line = Text()
+        line.append(transcript_prefix(TranscriptRole.ERROR), style=str(ERROR))
+        line.append(" ".join(safe_message.split()), style=str(TEXT))
+        self._console.print(line)
         # On a credit/billing wall, add the in-tool recovery hint.
         if CREDIT_EXHAUSTED_MARKER in message:
             self._console.print("[dim]Run /model to switch to another provider.[/]")

--- a/surfaces/interactive_shell/runtime/agent_harness_adapters.py
+++ b/surfaces/interactive_shell/runtime/agent_harness_adapters.py
@@ -26,7 +26,6 @@ from surfaces.interactive_shell.ui.streaming import (
     StreamRenderResult,
     finish_deferred_closer,
     publish_full_response,
-    render_response_header,
     stream_to_console,
     stream_to_console_state,
 )
@@ -75,8 +74,8 @@ class ShellOutputSink:
         self._console.print(message, markup=False)
 
     def render_response_header(self, label: str) -> None:
-        # No leading blank: the caller owns spacing between the user and reply.
-        render_response_header(self._console, label)
+        """Leave terminal headers to the following reply or error renderer."""
+        _ = label
 
     def render_plan_breakdown(self, breakdown: str) -> None:
         """Theme the post-execution checklist: primary steps, dim work notes."""

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -37,7 +37,7 @@ def ready_hint_ansi() -> str:
     reserved = prompt_text_width(lead)
     if reserved >= width:
         visible = clip_prompt_text(f"{lead}{hint}", width)
-        # Soft grey lead — warm accent is reserved for Ω / ⏺ / spinner glyph.
+        # Soft grey lead; the warm accent is reserved for active transcript chrome.
         if visible.startswith("Ready"):
             rest = visible[len("Ready") :]
             return (
@@ -351,7 +351,7 @@ class SpinnerState:
         return ui_theme.reply_marker_hex()
 
     def _phase_accent_ansi(self) -> str:
-        """Spinner glyph: Factory-warm orange (same family as ``Ω`` / ``⏺``)."""
+        """Paint the spinner glyph with the transcript accent."""
         return ui_theme.BOLD_REPLY_MARKER_ANSI
 
     def inline_spinner_ansi(self) -> str:

--- a/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
+++ b/surfaces/interactive_shell/runtime/startup/ci_agent_demo.py
@@ -33,7 +33,8 @@ from integrations.github import (
     schedule_ci_reliability_loop,
 )
 from surfaces.interactive_shell.runtime.loop_scheduler import reload_loop_scheduler, run_loop_now
-from surfaces.interactive_shell.ui.streaming.renderer import render_note_block, reply_gutter
+from surfaces.interactive_shell.ui.streaming.renderer import render_note_block
+from surfaces.interactive_shell.ui.transcript import transcript_gutter
 from surfaces.shared.terminal.components.choice_menu import (
     repl_choose_one,
 )
@@ -104,14 +105,14 @@ def scan_and_show(console: Console | None) -> WorkspaceSnapshot:
         # same gutter, so the demo does not read as a different program.
         console.print()
         render_note_block(console, _SNAPSHOT_LEAD)
-        console.print(reply_gutter(snapshot_renderable(snapshot), lead=False))
+        console.print(transcript_gutter(snapshot_renderable(snapshot), lead=False))
         console.print()
     return snapshot
 
 
 def _warn(console: Console | None, text: str) -> None:
     if console is not None:
-        console.print(reply_gutter(Text(text, style=str(WARNING)), lead=False))
+        console.print(transcript_gutter(Text(text, style=str(WARNING)), lead=False))
 
 
 def start_ci_agent_demo(
@@ -150,7 +151,7 @@ def start_ci_agent_demo(
         console.print()
         render_note_block(console, card.headline)
         bullets = "\n".join(f"- {detail}" for detail in card.details)
-        console.print(reply_gutter(ReplyMarkdown(bullets), lead=False))
+        console.print(transcript_gutter(ReplyMarkdown(bullets), lead=False))
         console.print()
     _record(OPTION_CI_AGENT)
     _run_first_pass(console, scheduled.task_id, owner=owner, repo=repo)
@@ -195,7 +196,7 @@ def _run_first_pass(console: Console | None, task_id: str, *, owner: str, repo: 
     if console is not None:
         console.print()
         render_note_block(console, "The first report, as it will land in /loops messages:")
-        console.print(reply_gutter(ReplyMarkdown(report), lead=False))
+        console.print(transcript_gutter(ReplyMarkdown(report), lead=False))
         console.print()
 
 
@@ -228,7 +229,7 @@ def _install_service(console: Console | None) -> None:
         return
     if console is not None:
         render_note_block(console, _SERVICE_INSTALLED)
-        console.print(reply_gutter(Text(f"Log: {state.log_path}"), lead=False))
+        console.print(transcript_gutter(Text(f"Log: {state.log_path}"), lead=False))
         console.print()
 
 

--- a/surfaces/interactive_shell/ui/action_log.py
+++ b/surfaces/interactive_shell/ui/action_log.py
@@ -16,7 +16,11 @@ from rich.text import Text
 from infrastructure.terminal.theme import DIM, SECONDARY
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.session.terminal_session import ActionLogEntry
-from surfaces.interactive_shell.ui.transcript import TranscriptRole, transcript_prefix
+from surfaces.interactive_shell.ui.transcript import (
+    TranscriptRole,
+    compact_transcript_prefix,
+    transcript_prefix,
+)
 from surfaces.shared.terminal.components.rendering import print_repl_renderable, repl_output_width
 from surfaces.shared.terminal.prompt_layout import terminal_columns
 
@@ -30,6 +34,8 @@ _BR = "╯"
 _BOX_MARGIN = 2
 #: Floor so a short section still reads as a box, not a stub.
 _MIN_INNER = 12
+# Keep enough of the tool identity visible to distinguish narrow rows.
+_MIN_SINGLE_ROW_BODY_WIDTH = 7
 #: Only draw a box once this many same-kind calls run back to back; a lone call
 #: reads as a single dim line, not a one-row box.
 _MIN_GROUP_FOR_BOX = 2
@@ -91,9 +97,11 @@ def _single_row(session: Session, entry: ActionLogEntry, *, width: int) -> Text:
     if entry.detail:
         session.terminal.stash_collapsed_tool_output(entry.detail)
     label = f"{entry.kind} · {entry.concise}" if entry.concise else entry.kind
-    prefix = transcript_prefix(TranscriptRole.TOOL)
-    line = f"{prefix}{label}"
     max_width = max(_MIN_INNER, width - _BOX_MARGIN)
+    prefix = transcript_prefix(TranscriptRole.TOOL)
+    if max_width - len(prefix) < _MIN_SINGLE_ROW_BODY_WIDTH:
+        prefix = compact_transcript_prefix(TranscriptRole.TOOL)
+    line = f"{prefix}{label}"
     if len(line) > max_width:
         line = line[: max_width - 1] + "…"
     row = Text()

--- a/surfaces/interactive_shell/ui/action_log.py
+++ b/surfaces/interactive_shell/ui/action_log.py
@@ -3,8 +3,7 @@
 Tool calls are buffered per turn and flushed here as bordered sections, one per
 run of same-kind calls (all ``GitHub CLI`` calls together, etc.). Each section
 shows concise status lines — never the inline ``key: value ·`` arguments — and
-stashes the full call + result detail for Ctrl+O. The log reads as a secondary
-execution record beneath the reply, the way Cursor and Droid render tool chrome.
+stashes the full call + result detail for Ctrl+O.
 """
 
 from __future__ import annotations
@@ -17,6 +16,7 @@ from rich.text import Text
 from infrastructure.terminal.theme import DIM, SECONDARY
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.session.terminal_session import ActionLogEntry
+from surfaces.interactive_shell.ui.transcript import TranscriptRole, transcript_prefix
 from surfaces.shared.terminal.components.rendering import print_repl_renderable, repl_output_width
 from surfaces.shared.terminal.prompt_layout import terminal_columns
 
@@ -26,7 +26,6 @@ _TL = "╭"
 _TR = "╮"
 _BL = "╰"
 _BR = "╯"
-_MARKER = "⏺"
 #: Never let the box exceed the terminal; keep a small right margin.
 _BOX_MARGIN = 2
 #: Floor so a short section still reads as a box, not a stub.
@@ -92,11 +91,15 @@ def _single_row(session: Session, entry: ActionLogEntry, *, width: int) -> Text:
     if entry.detail:
         session.terminal.stash_collapsed_tool_output(entry.detail)
     label = f"{entry.kind} · {entry.concise}" if entry.concise else entry.kind
-    line = f"{_MARKER} {label}"
+    prefix = transcript_prefix(TranscriptRole.TOOL)
+    line = f"{prefix}{label}"
     max_width = max(_MIN_INNER, width - _BOX_MARGIN)
     if len(line) > max_width:
         line = line[: max_width - 1] + "…"
-    return Text(line, style=str(DIM))
+    row = Text()
+    row.append(line[: len(prefix)], style=str(SECONDARY))
+    row.append(line[len(prefix) :], style=str(DIM))
+    return row
 
 
 def _section_rows(session: Session, group: list[ActionLogEntry], *, width: int) -> list[Text]:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -36,16 +36,17 @@ from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.session.terminal_session import ActionLogEntry
 from surfaces.interactive_shell.ui.action_log import flush_action_log
 from surfaces.interactive_shell.ui.streaming import render_note_block
+from surfaces.interactive_shell.ui.transcript import (
+    TranscriptRole,
+    transcript_line,
+    transcript_prefix,
+)
 from surfaces.shared.terminal.output.console_state import get_turn_spinner
 from tools.interactive_shell.action_names import ActionToolName
 from tools.interactive_shell.shell.display import format_shell_command_for_display
 
 # Tool labels whose payload is a runnable command.
 _COMMAND_TOOL_LABELS: frozenset[str] = frozenset({"Execute", "GitHub CLI", "opensre"})
-
-# Leads every tool-call line so a call reads apart from the ``Ω`` reply and the
-# ``[n] ❯`` user row — the call → result → reply hierarchy Claude Code / Droid use.
-_TOOL_CALL_MARKER = "⏺"
 
 # Tools whose preview is just ``(label, single-arg)``. The display content is the
 # stripped string value of that single argument. Anything that needs to combine
@@ -368,8 +369,8 @@ class ActionRenderObserver:
 
     Self-recording tools (``slash_invoke``, ``shell_run``, etc.) append their own
     history row; chat turns are recorded later by turn accounting when the
-    assistant runs. ``skill_view`` gets a dedicated live event: one
-    ``Skill activated <name>`` (or ``failed to load``) line on ``tool_end``.
+    assistant runs. ``skill_view`` gets a dedicated live event: a labeled skill
+    status line painted on ``tool_end``.
     """
 
     def __init__(self, *, session: Session, console: Console, message: str) -> None:
@@ -468,7 +469,7 @@ class ActionRenderObserver:
         Stacked by tool-call id: the ReAct loop emits every ``tool_start``
         before executing the batch, so a single slot would show the last
         tool and clear on the first ``tool_end``. Scrollback keeps the
-        settled ``⏺`` copy. Only relabels an already-running spinner
+        settled transcript copy. Only relabels an already-running spinner
         (see ``_set_spinner_phase``).
         """
         spinner = get_turn_spinner()
@@ -508,9 +509,8 @@ class ActionRenderObserver:
         if is_plan_diagnosis_prose(content):
             return
         self.console.print()
-        # Intermediate narration is a working note: recessed body + dim ``·`` in
-        # the same gutter column as ``Ω``, so it reads apart from the user row
-        # and the bright final reply without floating as unmarked prose.
+        # Intermediate narration is a labeled working note, visually secondary
+        # to the final reply without floating as unmarked prose.
         # ``render_note_block`` sanitizes model text at ``_build_markdown_block``.
         render_note_block(self.console, content)
 
@@ -532,10 +532,13 @@ class ActionRenderObserver:
         label, content = tool_call_display(name, args if isinstance(args, dict) else {})
         if label in _COMMAND_TOOL_LABELS:
             concise = _collapsed_line(content) if content else ""
-            detail = f"{_TOOL_CALL_MARKER} {label} · {content}" if content else f"{label}"
+            detail = transcript_line(
+                TranscriptRole.TOOL,
+                f"{label} · {content}" if content else label,
+            )
         else:
             concise = ""
-            detail = f"{_TOOL_CALL_MARKER} {label}"
+            detail = transcript_line(TranscriptRole.TOOL, label)
             if content:
                 # Unfold the dotted argument strip into one indented line each.
                 detail += "\n" + "\n".join(f"    {part}" for part in content.split(" · "))
@@ -564,10 +567,10 @@ class ActionRenderObserver:
         self.session.terminal.inline_tool_results = True
 
     def _render_skill_end(self, data: dict[str, Any]) -> None:
-        """Print one ``Skill activated <name>`` line once the skill has loaded.
+        """Print one labeled status line once the skill load finishes.
 
         Opens with its own blank line like every other block; the next block
-        (another call, a note, or the ``Ω`` reply) adds its own — do not add a
+        (another call, a note, or the final reply) adds its own — do not add a
         trailing one here or the gap doubles.
         """
         slug = self._pending_skill_calls.pop(str(data.get("id") or ""), None)
@@ -579,9 +582,11 @@ class ActionRenderObserver:
         # through Rich markup.
         line = Text()
         if activated:
-            line.append("Skill activated ", style=BOLD_SKILL)
+            line.append(transcript_prefix(TranscriptRole.SKILL_LOADED), style=BOLD_SKILL)
+            line.append("Skill · ", style=str(TEXT))
         else:
-            line.append("Skill failed to load ", style=ERROR)
+            line.append(transcript_prefix(TranscriptRole.ERROR), style=str(ERROR))
+            line.append("Could not load skill · ", style=str(TEXT))
         line.append(slug, style=str(TEXT))
         self.console.print()
         self.console.print(line)

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -38,6 +38,7 @@ from surfaces.interactive_shell.ui.action_log import flush_action_log
 from surfaces.interactive_shell.ui.streaming import render_note_block
 from surfaces.interactive_shell.ui.transcript import (
     TranscriptRole,
+    transcript_continuation,
     transcript_line,
     transcript_prefix,
 )
@@ -540,8 +541,9 @@ class ActionRenderObserver:
             concise = ""
             detail = transcript_line(TranscriptRole.TOOL, label)
             if content:
-                # Unfold the dotted argument strip into one indented line each.
-                detail += "\n" + "\n".join(f"    {part}" for part in content.split(" · "))
+                # Unfold the dotted argument strip beneath the labeled body column.
+                indent = transcript_continuation(TranscriptRole.TOOL)
+                detail += "\n" + "\n".join(f"{indent}{part}" for part in content.split(" · "))
         self.session.terminal.push_action_log(
             ActionLogEntry(call_id=_tool_event_id(data), kind=label, concise=concise, detail=detail)
         )
@@ -562,7 +564,8 @@ class ActionRenderObserver:
         if not preview:
             return
         rows = preview.splitlines() or [preview]
-        result = "\n".join([f"  ↳ {rows[0]}", *(f"    {row}" for row in rows[1:])])
+        indent = transcript_continuation(TranscriptRole.TOOL)
+        result = "\n".join([f"{indent}↳ {rows[0]}", *(f"{indent}  {row}" for row in rows[1:])])
         self.session.terminal.append_action_result(_tool_event_id(data), result)
         self.session.terminal.inline_tool_results = True
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -582,8 +582,7 @@ class ActionRenderObserver:
         # through Rich markup.
         line = Text()
         if activated:
-            line.append(transcript_prefix(TranscriptRole.SKILL_LOADED), style=BOLD_SKILL)
-            line.append("Skill · ", style=str(TEXT))
+            line.append("Skill activated ", style=BOLD_SKILL)
         else:
             line.append(transcript_prefix(TranscriptRole.ERROR), style=str(ERROR))
             line.append("Could not load skill · ", style=str(TEXT))

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -134,7 +134,7 @@ def stream_to_console_state(
     defer_want_me_to_closer: bool = False,
 ) -> StreamRenderResult:
     """Like :func:`stream_to_console` but returns render/defer metadata."""
-    del label  # the transcript paints the stable OpenSRE label
+    del label  # the transcript paints the stable assistant marker
     if not console.is_terminal:
         text = "".join(chunks)
         if suppress_if_starts_with is not None and text.lstrip().startswith(
@@ -237,7 +237,7 @@ def stream_to_console_state(
             # for the next standalone block. This matters most after lists,
             # whose renderer adds no trailing blank line.
             console.print()
-        # The first paragraph carries the ``OpenSRE`` label in the gutter; every
+        # The first paragraph carries the assistant marker in the gutter; every
         # paragraph hangs in the same indented body column. Explicit TEXT so
         # body never falls through to terminal white and washes the marker out.
         with console.use_theme(ui_theme.MARKDOWN_THEME):
@@ -428,7 +428,7 @@ def stream_to_console_state(
 
 def publish_full_response(console: Console, text: str, *, label: str = "assistant") -> None:
     """Render a complete assistant answer (non-TTY deferred gather path)."""
-    del label  # the transcript paints the stable OpenSRE label
+    del label  # the transcript paints the stable assistant marker
     body = (text or "").strip()
     if not body:
         return

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -41,9 +41,9 @@ from core.agent_harness.spi.prompt_chrome import WANT_ME_TO_MARKER
 from surfaces.interactive_shell.ui.streaming.renderer import (
     _build_markdown_block,
     render_reply_block,
-    reply_gutter,
     reply_width,
 )
+from surfaces.interactive_shell.ui.transcript import transcript_gutter
 
 # Throttle for the optional ``update_streaming_progress`` hook on the
 # console — caps cross-thread queueing on long bursts of chunks. Same
@@ -134,7 +134,7 @@ def stream_to_console_state(
     defer_want_me_to_closer: bool = False,
 ) -> StreamRenderResult:
     """Like :func:`stream_to_console` but returns render/defer metadata."""
-    del label  # the inline Ω marker replaced the ``Ω OpenSRE`` header
+    del label  # the transcript paints the stable OpenSRE label
     if not console.is_terminal:
         text = "".join(chunks)
         if suppress_if_starts_with is not None and text.lstrip().startswith(
@@ -229,8 +229,7 @@ def stream_to_console_state(
             markdown.parsed and markdown.parsed[0].type in _SELF_SPACING_BLOCK_TOKEN_TYPES
         )
         if not rendered_paragraphs:
-            # One blank row between the user turn and its reply (Droid rhythm):
-            # the echo row and the Ω reply must not sit flush against each other.
+            # One blank row keeps the user turn and its reply distinct.
             console.print()
         if rendered_paragraphs and source_break and not starts_with_self_spacing_block:
             # ``_flush_paragraphs`` consumes the source ``\n\n`` boundary.
@@ -238,12 +237,16 @@ def stream_to_console_state(
             # for the next standalone block. This matters most after lists,
             # whose renderer adds no trailing blank line.
             console.print()
-        # The first paragraph carries the ``Ω`` marker in the gutter; every
+        # The first paragraph carries the ``OpenSRE`` label in the gutter; every
         # paragraph hangs in the same indented body column. Explicit TEXT so
         # body never falls through to terminal white and washes the marker out.
         with console.use_theme(ui_theme.MARKDOWN_THEME):
             console.print(
-                reply_gutter(markdown, lead=rendered_paragraphs == 0),
+                transcript_gutter(
+                    markdown,
+                    lead=rendered_paragraphs == 0,
+                    label_style=ui_theme.reply_marker_style(),
+                ),
                 style=str(ui_theme.TEXT),
                 width=reply_width(console),
             )
@@ -418,15 +421,14 @@ def stream_to_console_state(
             footer_elapsed_s=elapsed,
             footer_total_bytes=total_bytes,
         )
-    # One blank after the reply so the next user row / prompt chrome breathes
-    # like Droid — not flush against the last reply line.
+    # One blank after the reply keeps the next user row off the answer body.
     console.print()
     return StreamRenderResult(text=text, deferred_closer=False)
 
 
 def publish_full_response(console: Console, text: str, *, label: str = "assistant") -> None:
     """Render a complete assistant answer (non-TTY deferred gather path)."""
-    del label  # the inline Ω marker replaced the ``Ω OpenSRE`` header
+    del label  # the transcript paints the stable OpenSRE label
     body = (text or "").strip()
     if not body:
         return

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -7,16 +7,18 @@ import sys
 from typing import TYPE_CHECKING
 
 from rich.console import Console
-from rich.table import Table
 from rich.text import Text
 
 import infrastructure.terminal.theme as ui_theme
 from core.agent_harness.spi.prompt_chrome import normalize_three_tier_spacing
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.text import looks_like_data_blob
+from surfaces.interactive_shell.ui.transcript import (
+    TranscriptRole,
+    transcript_gutter,
+)
 
 if TYPE_CHECKING:
-    from rich.console import RenderableType
     from rich.markdown import Markdown
 
 STREAM_LABEL_ASSISTANT = "assistant"
@@ -34,8 +36,7 @@ def _escape_markdown_dunder_filenames(text: str) -> str:
 
 
 # The model sometimes pastes a tool's raw result (JSON, listings) into its reply
-# instead of answering in prose. Collapse such a block to a compact marker so the
-# reply reads like Claude Code / Droid, regardless of which model echoed it.
+# instead of answering in prose. Collapse such a block to a compact marker.
 _DUMP_TRUNCATED_MARKER = "output truncated"
 _DUMP_MIN_CHARS = 200
 _DUMP_MIN_JSON_KEYS = 3
@@ -137,14 +138,9 @@ def render_markdown_block(console: Console, text: str) -> None:
         console.print(_build_markdown_block(visible))
 
 
-_REPLY_MARKER = "Ω"
-# Quiet lead for mid-turn narration — same 2-cell gutter as ``Ω `` / ``⏺ ``
-# (Droid: one marker column, body text shares a left edge).
-_NOTE_MARKER = "·"
-_GUTTER_WIDTH = 2
 # Reply rows stop short of the last column: a row padded to the full terminal
 # width followed by a newline leaves a blank line and a shifted continuation
-# in Terminal.app. Cursor keeps a similar right margin.
+# in Terminal.app.
 _RIGHT_MARGIN = 2
 _MIN_REPLY_WIDTH = 20
 
@@ -155,83 +151,55 @@ def reply_width(console: Console) -> int:
 
 
 def render_note_block(console: Console, text: str) -> None:
-    """Render intermediate agent narration in the agent marker gutter.
-
-    Droid puts a warm accent on every agent line. Notes use a dimmer ``·`` in
-    that same column as ``Ω`` / Thinking so the left edge stays straight; bold
-    spans (action words) stay bold within the recessed body.
-    """
+    """Render intermediate narration with an explicit working-state label."""
     visible = text
     if not visible.strip():
         return
     with console.use_theme(ui_theme.MARKDOWN_THEME):
         console.print(
-            reply_gutter(
+            transcript_gutter(
                 _build_markdown_block(visible),
                 lead=True,
-                marker=_NOTE_MARKER,
-                # Warm accent like Droid's agent marker — not ghost DIM, or notes
-                # vanish next to Thinking / plan chrome.
-                marker_style=ui_theme.reply_marker_style(),
+                role=TranscriptRole.WORKING,
+                label_style=_transcript_label_style(),
             ),
             style=str(ui_theme.SECONDARY),
             width=reply_width(console),
         )
 
 
-def _reply_marker_style() -> str:
-    """Bold warm accent for the ``Ω`` reply marker — same weight as ``⏺`` / Thinking."""
+def _transcript_label_style() -> str:
+    """Bold accent for the assistant and working-state labels."""
     return ui_theme.reply_marker_style()
 
 
-def reply_gutter(
-    body: RenderableType,
-    *,
-    lead: bool,
-    marker: str = _REPLY_MARKER,
-    marker_style: str | None = None,
-) -> Table:
-    """Lay a reply renderable in a two-column gutter.
-
-    The first paragraph carries the lead marker in the gutter; every other row
-    (wrapped lines and following paragraphs) sits in the same indented body
-    column, so the whole reply reads as one block hanging under the marker.
-    """
-    grid = Table.grid(padding=0)
-    grid.add_column(width=_GUTTER_WIDTH, no_wrap=True)
-    grid.add_column(overflow="fold")
-    style = marker_style if marker_style is not None else _reply_marker_style()
-    pad = " " * (_GUTTER_WIDTH - 1)
-    lead_cell = Text(f"{marker}{pad}", style=style) if lead else Text(" " * _GUTTER_WIDTH)
-    grid.add_row(lead_cell, body)
-    return grid
-
-
 def render_reply_block(console: Console, text: str, *, lead: bool = True) -> None:
-    """Render a whole assistant reply inside the ``Ω`` hanging-indent gutter."""
+    """Render a whole assistant reply inside the labeled transcript gutter."""
     visible = text
     if not visible.strip():
         return
     with console.use_theme(ui_theme.MARKDOWN_THEME):
         # Explicit TEXT on the row so plain paragraphs never fall through to the
-        # terminal default white (which washed out the warm marker in dogfood).
+        # terminal default white, which would flatten the label/body hierarchy.
         console.print(
-            reply_gutter(_build_markdown_block(visible), lead=lead),
+            transcript_gutter(
+                _build_markdown_block(visible),
+                lead=lead,
+                label_style=_transcript_label_style(),
+            ),
             style=str(ui_theme.TEXT),
             width=reply_width(console),
         )
 
 
 def render_response_header(console: Console, label: str) -> None:
-    """Print the ``Ω`` row marker that opens every assistant response.
+    """Print the label that opens every assistant response.
 
-    A single omega is opensre's uniquely identifiable agent marker. Shared
-    with ``action_turn.run_action_tool_turn`` so the planned-actions path and the
-    streaming response path use the exact same prefix.
+    Shared with ``action_turn.run_action_tool_turn`` so the planned-actions path
+    and the streaming response path use the exact same prefix.
 
     ``label`` is accepted for port compatibility (callers still pass
-    ``answer`` / ``assistant``) but is not painted — a dim role word under the
-    marker read as school-project chrome next to Droid's silent replies.
+    ``answer`` / ``assistant``) but is not painted.
     """
     del label
-    console.print(f"[{_reply_marker_style()}]{_REPLY_MARKER}[/]")
+    console.print(Text(TranscriptRole.ASSISTANT.value, style=_transcript_label_style()))

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -169,12 +169,12 @@ def render_note_block(console: Console, text: str) -> None:
 
 
 def _transcript_label_style() -> str:
-    """Bold accent for the assistant and working-state labels."""
+    """Bold accent for the assistant marker and working-state labels."""
     return ui_theme.reply_marker_style()
 
 
 def render_reply_block(console: Console, text: str, *, lead: bool = True) -> None:
-    """Render a whole assistant reply inside the labeled transcript gutter."""
+    """Render a whole assistant reply inside the marked transcript gutter."""
     visible = text
     if not visible.strip():
         return
@@ -193,7 +193,7 @@ def render_reply_block(console: Console, text: str, *, lead: bool = True) -> Non
 
 
 def render_response_header(console: Console, label: str) -> None:
-    """Print the label that opens every assistant response.
+    """Print the marker that opens every assistant response.
 
     Shared with ``action_turn.run_action_tool_turn`` so the planned-actions path
     and the streaming response path use the exact same prefix.

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -139,12 +139,11 @@ def _collapsed_window(plan: TaskPlan) -> tuple[int, int]:
 
 
 def task_plan_overlay_ansi(plan: TaskPlan, *, expanded: bool = False) -> str:
-    """ANSI plan overlay pinned above the prompt (Droid checklist rhythm).
+    """Render the ANSI plan overlay pinned above the prompt.
 
     Header flush left; steps indented two spaces under it (``✓`` / ``●`` /
-    ``○``). Same left edge as note ``·`` / Thinking glyphs in column 0; step
-    glyphs sit under note body text. A short plan (or ``expanded``) shows every
-    step; a longer one collapses to a window around the current step.
+    ``○``). A short plan (or ``expanded``) shows every step; a longer one
+    collapses to a window around the current step.
     """
     width = prompt_line_width()
     header = _overlay_line(format_plan_header(plan), ui_theme.SECONDARY_ANSI, width)

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -118,7 +118,7 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )
-    # Tools already paint a ``⏺`` line into scrollback; the live tool name is
+    # Tools already paint a labeled row into scrollback; the live tool name is
     # folded into the spinner status row (same line as ``Invoking tools…``).
     # Auto stays on the page while busy (DIM) so permission chrome does not
     # vanish for the length of the turn.

--- a/surfaces/interactive_shell/ui/transcript.py
+++ b/surfaces/interactive_shell/ui/transcript.py
@@ -1,0 +1,69 @@
+"""Aligned semantic labels for interactive-shell transcript rows."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from rich.table import Table
+from rich.text import Text
+
+if TYPE_CHECKING:
+    from rich.console import RenderableType
+
+
+class TranscriptRole(StrEnum):
+    """Visible roles used to distinguish transcript rows without icon-only state."""
+
+    ASSISTANT = "OpenSRE"
+    WORKING = "Working"
+    TOOL = "Tool"
+    SKILL_LOADED = "Loaded"
+    ERROR = "Error"
+
+
+# Seven characters fits the longest label; two trailing cells separate the
+# label from its body without relying on a tiny punctuation glyph.
+_TRANSCRIPT_GUTTER_WIDTH = 9
+
+
+def transcript_prefix(role: TranscriptRole) -> str:
+    """Pad a semantic label to the shared transcript body column."""
+    return role.value.ljust(_TRANSCRIPT_GUTTER_WIDTH)
+
+
+def transcript_label(role: TranscriptRole, *, style: str) -> Text:
+    """Build a styled label cell aligned to the shared transcript gutter."""
+    return Text(transcript_prefix(role), style=style)
+
+
+def transcript_line(role: TranscriptRole, body: str) -> str:
+    """Build a plain transcript row for collapsed or non-interactive output."""
+    return f"{transcript_prefix(role)}{body}"
+
+
+def transcript_gutter(
+    body: RenderableType,
+    *,
+    lead: bool,
+    role: TranscriptRole = TranscriptRole.ASSISTANT,
+    label_style: str = "",
+) -> Table:
+    """Lay a renderable in the fixed-width semantic transcript gutter."""
+    grid = Table.grid(padding=0)
+    grid.add_column(width=_TRANSCRIPT_GUTTER_WIDTH, no_wrap=True)
+    grid.add_column(overflow="fold")
+    lead_cell = (
+        transcript_label(role, style=label_style) if lead else Text(" " * _TRANSCRIPT_GUTTER_WIDTH)
+    )
+    grid.add_row(lead_cell, body)
+    return grid
+
+
+__all__ = [
+    "TranscriptRole",
+    "transcript_gutter",
+    "transcript_label",
+    "transcript_line",
+    "transcript_prefix",
+]

--- a/surfaces/interactive_shell/ui/transcript.py
+++ b/surfaces/interactive_shell/ui/transcript.py
@@ -38,6 +38,16 @@ def transcript_prefix(role: TranscriptRole) -> str:
     return role.value.ljust(_gutter_width(role))
 
 
+def compact_transcript_prefix(role: TranscriptRole) -> str:
+    """Return a marker with one trailing cell for constrained rows."""
+    return f"{role.value} "
+
+
+def transcript_continuation(role: TranscriptRole) -> str:
+    """Return whitespace aligned with the start of a role's body text."""
+    return " " * _gutter_width(role)
+
+
 def transcript_label(role: TranscriptRole, *, style: str) -> Text:
     """Build a styled label cell aligned to the shared transcript gutter."""
     return Text(transcript_prefix(role), style=style)
@@ -67,6 +77,8 @@ def transcript_gutter(
 
 __all__ = [
     "TranscriptRole",
+    "compact_transcript_prefix",
+    "transcript_continuation",
     "transcript_gutter",
     "transcript_label",
     "transcript_line",

--- a/surfaces/interactive_shell/ui/transcript.py
+++ b/surfaces/interactive_shell/ui/transcript.py
@@ -13,23 +13,29 @@ if TYPE_CHECKING:
 
 
 class TranscriptRole(StrEnum):
-    """Visible roles used to distinguish transcript rows without icon-only state."""
+    """Visible markers used to distinguish transcript rows."""
 
-    ASSISTANT = "OpenSRE"
+    ASSISTANT = "●"
     WORKING = "Working"
     TOOL = "Tool"
-    SKILL_LOADED = "Loaded"
     ERROR = "Error"
 
 
-# Seven characters fits the longest label; two trailing cells separate the
-# label from its body without relying on a tiny punctuation glyph.
-_TRANSCRIPT_GUTTER_WIDTH = 9
+# Status rows share a body column, while replies keep the compact marker gutter.
+_STATUS_GUTTER_WIDTH = 9
+_ASSISTANT_GUTTER_WIDTH = 2
+
+
+def _gutter_width(role: TranscriptRole) -> int:
+    """Return the gutter width appropriate for *role*."""
+    if role is TranscriptRole.ASSISTANT:
+        return _ASSISTANT_GUTTER_WIDTH
+    return _STATUS_GUTTER_WIDTH
 
 
 def transcript_prefix(role: TranscriptRole) -> str:
-    """Pad a semantic label to the shared transcript body column."""
-    return role.value.ljust(_TRANSCRIPT_GUTTER_WIDTH)
+    """Pad a transcript marker to its role's body column."""
+    return role.value.ljust(_gutter_width(role))
 
 
 def transcript_label(role: TranscriptRole, *, style: str) -> Text:
@@ -49,13 +55,12 @@ def transcript_gutter(
     role: TranscriptRole = TranscriptRole.ASSISTANT,
     label_style: str = "",
 ) -> Table:
-    """Lay a renderable in the fixed-width semantic transcript gutter."""
+    """Lay a renderable in the gutter appropriate for its transcript role."""
+    gutter_width = _gutter_width(role)
     grid = Table.grid(padding=0)
-    grid.add_column(width=_TRANSCRIPT_GUTTER_WIDTH, no_wrap=True)
+    grid.add_column(width=gutter_width, no_wrap=True)
     grid.add_column(overflow="fold")
-    lead_cell = (
-        transcript_label(role, style=label_style) if lead else Text(" " * _TRANSCRIPT_GUTTER_WIDTH)
-    )
+    lead_cell = transcript_label(role, style=label_style) if lead else Text(" " * gutter_width)
     grid.add_row(lead_cell, body)
     return grid
 

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -131,8 +131,8 @@ def test_shimmer_text_ansi_paints_a_traveling_metallic_wave() -> None:
     assert " tools" in spaced or "tools" in re.sub(r"\x1b\[[0-9;]*m", "", spaced)
 
 
-def test_tool_marker_follows_the_active_theme_highlight() -> None:
-    """The bold tool marker follows each palette's highlight colour."""
+def test_transcript_label_follows_the_active_theme_highlight() -> None:
+    """The bold transcript label follows each palette's highlight colour."""
     from infrastructure.terminal import theme as ui_theme
 
     for name in ("blue", "purple", "green", "mono"):
@@ -140,12 +140,12 @@ def test_tool_marker_follows_the_active_theme_highlight() -> None:
         assert ui_theme.reply_marker_style() == f"bold {ui_theme.get_theme(name).HIGHLIGHT}"
 
 
-def test_reply_block_paints_orange_marker_and_themed_body() -> None:
-    """Regression: marker washed out when body fell through to terminal white."""
+def test_reply_block_paints_accent_label_and_themed_body() -> None:
+    """Regression: label washed out when body fell through to terminal white."""
     import os
 
     from surfaces.interactive_shell.ui.streaming.renderer import (
-        _reply_marker_style,
+        _transcript_label_style,
         render_reply_block,
     )
 
@@ -160,13 +160,13 @@ def test_reply_block_paints_orange_marker_and_themed_body() -> None:
     with console.capture() as capture:
         render_reply_block(console, "Hey! How can I help?")
     output = capture.get()
-    assert "Ω" in output
-    assert _reply_marker_style() == f"bold {get_theme('blue').HIGHLIGHT}"
-    # Marker follows the active theme's HIGHLIGHT (whatever the palette sets).
+    assert "OpenSRE" in output
+    assert _transcript_label_style() == f"bold {get_theme('blue').HIGHLIGHT}"
+    # Label follows the active theme's HIGHLIGHT (whatever the palette sets).
     highlight = get_theme("blue").HIGHLIGHT.lstrip("#")
     r, g, b = (int(highlight[i : i + 2], 16) for i in (0, 2, 4))
     assert f"38;2;{r};{g};{b}m" in output
-    # Body uses the sunny Droid-like agent grey (#D0D0D0).
+    # Body uses the palette's primary agent grey (#D0D0D0).
     assert "38;2;208;208;208m" in output
 
 

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -131,8 +131,8 @@ def test_shimmer_text_ansi_paints_a_traveling_metallic_wave() -> None:
     assert " tools" in spaced or "tools" in re.sub(r"\x1b\[[0-9;]*m", "", spaced)
 
 
-def test_transcript_label_follows_the_active_theme_highlight() -> None:
-    """The bold transcript label follows each palette's highlight colour."""
+def test_transcript_marker_follows_the_active_theme_highlight() -> None:
+    """The bold transcript marker follows each palette's highlight colour."""
     from infrastructure.terminal import theme as ui_theme
 
     for name in ("blue", "purple", "green", "mono"):
@@ -160,9 +160,9 @@ def test_reply_block_paints_accent_label_and_themed_body() -> None:
     with console.capture() as capture:
         render_reply_block(console, "Hey! How can I help?")
     output = capture.get()
-    assert "OpenSRE" in output
+    assert "●" in output
     assert _transcript_label_style() == f"bold {get_theme('blue').HIGHLIGHT}"
-    # Label follows the active theme's HIGHLIGHT (whatever the palette sets).
+    # Marker follows the active theme's HIGHLIGHT (whatever the palette sets).
     highlight = get_theme("blue").HIGHLIGHT.lstrip("#")
     r, g, b = (int(highlight[i : i + 2], 16) for i in (0, 2, 4))
     assert f"38;2;{r};{g};{b}m" in output

--- a/tests/interactive_shell/runtime/test_agent_harness_adapters.py
+++ b/tests/interactive_shell/runtime/test_agent_harness_adapters.py
@@ -35,7 +35,8 @@ def test_render_error_shows_auth_login_hint_on_credit_exhaustion() -> None:
 
 
 def test_render_error_no_hint_for_generic_error() -> None:
-    output = _render_error("some other failure")
+    output = _render_error("some\nother failure")
+    assert output.startswith("Error    some other failure")
     assert "/model" not in output
     assert "/auth login" not in output
 
@@ -76,11 +77,10 @@ def test_finalize_satisfies_the_host_contract_while_staying_silent() -> None:
 
 
 def test_response_header_opens_without_a_leading_blank() -> None:
-    """The sink used to print a blank before ``Ω``; that padded turns vs Droid.
+    """The sink does not add a blank before the assistant label.
 
     ``_show_response`` used to own that spacer in the shared turn engine.
-    Chat sinks never wanted it; keeping a blank in the shell sink only was
-    the remaining gap between user row and reply marker.
+    Chat sinks never wanted it, so the shell surface owns its spacing too.
     """
     # Arrange
     console = _RecordingConsole()
@@ -88,7 +88,7 @@ def test_response_header_opens_without_a_leading_blank() -> None:
     # Act
     ShellOutputSink(console).render_response_header("assistant")  # type: ignore[arg-type]
 
-    # Assert: marker on the first painted line — no spacer row above.
+    # Assert: label on the first painted line — no spacer row above.
     assert console.lines
-    assert "Ω" in console.lines[0]
+    assert "OpenSRE" in console.lines[0]
     assert console.lines[0] != ""

--- a/tests/interactive_shell/runtime/test_agent_harness_adapters.py
+++ b/tests/interactive_shell/runtime/test_agent_harness_adapters.py
@@ -76,19 +76,20 @@ def test_finalize_satisfies_the_host_contract_while_staying_silent() -> None:
     assert isinstance(sink, TurnOutput)
 
 
-def test_response_header_opens_without_a_leading_blank() -> None:
-    """The sink does not add a blank before the assistant label.
-
-    ``_show_response`` used to own that spacer in the shared turn engine.
-    Chat sinks never wanted it, so the shell surface owns its spacing too.
-    """
-    # Arrange
+def test_response_header_waits_for_the_following_terminal_renderer() -> None:
+    """The body or error row owns the terminal marker, so no empty row appears."""
     console = _RecordingConsole()
 
-    # Act
     ShellOutputSink(console).render_response_header("assistant")  # type: ignore[arg-type]
 
-    # Assert: marker on the first painted line — no spacer row above.
-    assert console.lines
-    assert "●" in console.lines[0]
-    assert console.lines[0] != ""
+    assert console.lines == []
+
+
+def test_error_after_response_header_emits_only_the_labeled_error() -> None:
+    console = _RecordingConsole()
+    sink = ShellOutputSink(console)  # type: ignore[arg-type]
+
+    sink.render_response_header("assistant")
+    sink.render_error("tool call failed")
+
+    assert console.lines == ["Error    tool call failed"]

--- a/tests/interactive_shell/runtime/test_agent_harness_adapters.py
+++ b/tests/interactive_shell/runtime/test_agent_harness_adapters.py
@@ -88,7 +88,7 @@ def test_response_header_opens_without_a_leading_blank() -> None:
     # Act
     ShellOutputSink(console).render_response_header("assistant")  # type: ignore[arg-type]
 
-    # Assert: label on the first painted line — no spacer row above.
+    # Assert: marker on the first painted line — no spacer row above.
     assert console.lines
-    assert "OpenSRE" in console.lines[0]
+    assert "●" in console.lines[0]
     assert console.lines[0] != ""

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -1479,7 +1479,7 @@ class TestResumeCommand:
 
         output = buf.getvalue()
         assert "❯" in output
-        assert "Ω" in output
+        assert "OpenSRE" in output
         assert "$ /status" in output
         assert "you  " not in output
         assert "sre  " not in output
@@ -1513,7 +1513,7 @@ class TestResumeCommand:
 
         output = buf.getvalue()
         assert output.count("❯ repeat") == 2
-        assert output.count("Ω") == 2
+        assert output.count("OpenSRE") == 2
         assert "first answer" in output
         assert "second answer" in output
 

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -1479,7 +1479,7 @@ class TestResumeCommand:
 
         output = buf.getvalue()
         assert "❯" in output
-        assert "OpenSRE" in output
+        assert "●" in output
         assert "$ /status" in output
         assert "you  " not in output
         assert "sre  " not in output
@@ -1513,7 +1513,7 @@ class TestResumeCommand:
 
         output = buf.getvalue()
         assert output.count("❯ repeat") == 2
-        assert output.count("OpenSRE") == 2
+        assert output.count("●") == 2
         assert "first answer" in output
         assert "second answer" in output
 

--- a/tests/interactive_shell/ui/test_action_log.py
+++ b/tests/interactive_shell/ui/test_action_log.py
@@ -49,7 +49,9 @@ def test_no_inline_dotted_arguments_on_a_single_call() -> None:
         "1",
         "list github actions workflow runs",
         "",
-        "Tool     list github actions workflow runs\n    owner: Tracer-Cloud\n    per_page: 100",
+        "Tool     list github actions workflow runs\n"
+        "         owner: Tracer-Cloud\n"
+        "         per_page: 100",
     )
     buffer = io.StringIO()
 
@@ -113,7 +115,7 @@ def test_non_tty_inlines_the_detail() -> None:
         "1",
         "GitHub CLI",
         "gh pr list",
-        "Tool     GitHub CLI · gh pr list\n  ↳ 4 open PRs",
+        "Tool     GitHub CLI · gh pr list\n         ↳ 4 open PRs",
     )
     buffer = io.StringIO()
 
@@ -237,6 +239,7 @@ def test_a_window_too_narrow_for_any_box_prints_plain_rows(monkeypatch) -> None:
     plain = [Text.from_ansi(line).plain for line in buffer.getvalue().splitlines() if line.strip()]
     assert not any(row[0] in "╭│╰" for row in plain)
     assert len(plain) == 2 and all(len(row) <= 13 for row in plain), plain
+    assert all(row.startswith("Tool GitHub") for row in plain), plain
 
 
 def test_a_tool_that_painted_its_own_output_leaves_no_row() -> None:

--- a/tests/interactive_shell/ui/test_action_log.py
+++ b/tests/interactive_shell/ui/test_action_log.py
@@ -24,8 +24,8 @@ def _push(session: Session, call_id: str, kind: str, concise: str, detail: str) 
 
 def test_consecutive_same_kind_calls_group_into_one_bordered_section() -> None:
     session = Session()
-    _push(session, "1", "GitHub CLI", "gh repo view", "⏺ GitHub CLI · gh repo view")
-    _push(session, "2", "GitHub CLI", "gh pr list", "⏺ GitHub CLI · gh pr list")
+    _push(session, "1", "GitHub CLI", "gh repo view", "Tool     GitHub CLI · gh repo view")
+    _push(session, "2", "GitHub CLI", "gh pr list", "Tool     GitHub CLI · gh pr list")
     buffer = io.StringIO()
 
     flush_action_log(_tty(buffer), session)
@@ -49,7 +49,7 @@ def test_no_inline_dotted_arguments_on_a_single_call() -> None:
         "1",
         "list github actions workflow runs",
         "",
-        "⏺ list github actions workflow runs\n    owner: Tracer-Cloud\n    per_page: 100",
+        "Tool     list github actions workflow runs\n    owner: Tracer-Cloud\n    per_page: 100",
     )
     buffer = io.StringIO()
 
@@ -66,7 +66,7 @@ def test_a_long_collapsed_command_is_clipped_only_at_render_width() -> None:
         ",".join(f"field{index}" for index in range(40))
     )
     session = Session()
-    _push(session, "1", "GitHub CLI", command, f"⏺ GitHub CLI · {command}")
+    _push(session, "1", "GitHub CLI", command, f"Tool     GitHub CLI · {command}")
     buffer = io.StringIO()
     console = Console(
         file=buffer, force_terminal=True, highlight=False, color_system="truecolor", width=80
@@ -82,7 +82,7 @@ def test_a_long_collapsed_command_is_clipped_only_at_render_width() -> None:
 
 def test_a_lone_call_is_a_dim_line_not_a_one_row_box() -> None:
     session = Session()
-    _push(session, "1", "GitHub CLI", "gh pr list", "⏺ GitHub CLI · gh pr list")
+    _push(session, "1", "GitHub CLI", "gh pr list", "Tool     GitHub CLI · gh pr list")
     buffer = io.StringIO()
 
     flush_action_log(_tty(buffer), session)
@@ -108,7 +108,13 @@ def test_two_different_lone_kinds_render_as_two_dim_lines_no_box() -> None:
 
 def test_non_tty_inlines_the_detail() -> None:
     session = Session()
-    _push(session, "1", "GitHub CLI", "gh pr list", "⏺ GitHub CLI · gh pr list\n  ↳ 4 open PRs")
+    _push(
+        session,
+        "1",
+        "GitHub CLI",
+        "gh pr list",
+        "Tool     GitHub CLI · gh pr list\n  ↳ 4 open PRs",
+    )
     buffer = io.StringIO()
 
     flush_action_log(Console(file=buffer, force_terminal=False, highlight=False), session)
@@ -169,8 +175,8 @@ def test_a_tty_flush_is_one_buffered_write_of_every_row(monkeypatch) -> None:  #
     assert len(writes) == 1
     rendered = [str(row) for row in writes[0].renderables]  # type: ignore[attr-defined]
     assert rendered[0] == ""
-    assert rendered[1] == "⏺ summarize github pr status"
-    assert rendered[2] == "⏺ propose scheduled delivery"
+    assert rendered[1] == "Tool     summarize github pr status"
+    assert rendered[2] == "Tool     propose scheduled delivery"
 
 
 def test_box_rows_fit_the_render_width_so_none_wraps() -> None:

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -375,6 +375,26 @@ def test_generic_tool_call_display_is_bounded_and_omits_execution_controls() -> 
     assert "secret-token" not in content
 
 
+def test_generic_tool_detail_children_align_beneath_the_body_column() -> None:
+    observer, _buffer = _observer_with_buffer()
+
+    observer(
+        "tool_start",
+        {
+            "id": "t1",
+            "name": "custom_registry_tool",
+            "input": {"query": "incidents", "limit": 25},
+        },
+    )
+
+    detail = observer.session.terminal.action_log_entries[0].detail
+    assert detail.splitlines() == [
+        "Tool     custom registry tool",
+        "         limit: 25",
+        "         query: incidents",
+    ]
+
+
 def test_intermediate_message_strips_terminal_controls_before_markdown() -> None:
     # Arrange: a real terminal, where Rich would otherwise pass the model's
     # control bytes straight through (a non-terminal console strips them anyway,
@@ -513,7 +533,7 @@ def test_generic_tool_end_nests_the_result_under_the_call() -> None:
     entries = observer.session.terminal.action_log_entries
     assert len(entries) == 1
     assert entries[0].kind == "GitHub CLI"
-    assert "↳ GitHub API call succeeded" in entries[0].detail
+    assert "\n         ↳ GitHub API call succeeded" in entries[0].detail
     assert observer.session.terminal.inline_tool_results is True
 
     observer("agent_end", {})

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -170,7 +170,7 @@ def test_skill_view_renders_single_activation_line() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nLoaded   Skill · install-code-review\n"
+    assert buffer.getvalue() == "\nSkill activated install-code-review\n"
 
 
 def test_two_skills_in_one_batch_each_get_their_own_line() -> None:
@@ -191,8 +191,8 @@ def test_two_skills_in_one_batch_each_get_their_own_line() -> None:
         )
 
     assert buffer.getvalue() == (
-        "\nLoaded   Skill · reporting-github-ci-failures\n"
-        "\nLoaded   Skill · github-ci-fix-onboarding\n"
+        "\nSkill activated reporting-github-ci-failures\n"
+        "\nSkill activated github-ci-fix-onboarding\n"
     )
 
 
@@ -204,8 +204,8 @@ def test_skill_view_renders_bold_green_activation_label() -> None:
 
     heading = console.print.call_args_list[1].args[0]
     assert isinstance(heading, Text)
-    assert heading.plain == "Loaded   Skill · install-code-review"
-    assert len(heading.spans) == 3
+    assert heading.plain == "Skill activated install-code-review"
+    assert len(heading.spans) == 2
     assert str(heading.spans[0].style) == BOLD_SKILL
     assert str(heading.spans[1].style) == str(TEXT)
 
@@ -576,7 +576,7 @@ def test_skill_block_renders_live_not_buffered() -> None:
     )
 
     out = buffer.getvalue()
-    assert "\nLoaded   Skill · install-code-review\n" in out
+    assert "\nSkill activated install-code-review\n" in out
     assert "\n\n\n" not in out
     # The github call is buffered for the grouped log, not printed inline yet.
     assert any(e.kind == "GitHub CLI" for e in observer.session.terminal.action_log_entries)

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -151,7 +151,7 @@ def _load_skill(observer: ActionRenderObserver, call_id: str, name: str) -> None
 
 
 def test_skill_view_renders_single_activation_line() -> None:
-    """Loading a skill shows one ``Skill activated <name>`` line, nothing underneath."""
+    """Loading a skill shows one labeled status line, nothing underneath."""
     observer, buffer = _skill_observer()
 
     observer(
@@ -170,7 +170,7 @@ def test_skill_view_renders_single_activation_line() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nSkill activated install-code-review\n"
+    assert buffer.getvalue() == "\nLoaded   Skill · install-code-review\n"
 
 
 def test_two_skills_in_one_batch_each_get_their_own_line() -> None:
@@ -191,8 +191,8 @@ def test_two_skills_in_one_batch_each_get_their_own_line() -> None:
         )
 
     assert buffer.getvalue() == (
-        "\nSkill activated reporting-github-ci-failures\n"
-        "\nSkill activated github-ci-fix-onboarding\n"
+        "\nLoaded   Skill · reporting-github-ci-failures\n"
+        "\nLoaded   Skill · github-ci-fix-onboarding\n"
     )
 
 
@@ -204,8 +204,8 @@ def test_skill_view_renders_bold_green_activation_label() -> None:
 
     heading = console.print.call_args_list[1].args[0]
     assert isinstance(heading, Text)
-    assert heading.plain == "Skill activated install-code-review"
-    assert len(heading.spans) == 2
+    assert heading.plain == "Loaded   Skill · install-code-review"
+    assert len(heading.spans) == 3
     assert str(heading.spans[0].style) == BOLD_SKILL
     assert str(heading.spans[1].style) == str(TEXT)
 
@@ -420,7 +420,7 @@ def test_skill_view_failure_renders_failure_child() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nSkill failed to load no-such-skill\n"
+    assert buffer.getvalue() == "\nError    Could not load skill · no-such-skill\n"
 
 
 def test_skill_view_tool_end_without_start_prints_nothing() -> None:
@@ -492,7 +492,7 @@ def test_non_skill_tool_end_prints_nothing() -> None:
 
 
 def test_generic_tool_end_nests_the_result_under_the_call() -> None:
-    """Droid / Claude Code / Cursor attach the result to the call as a ``↳`` child."""
+    """Attach a concise result to its tool call as a ``↳`` child."""
     observer, buffer = _observer_with_buffer()
 
     observer(
@@ -576,7 +576,7 @@ def test_skill_block_renders_live_not_buffered() -> None:
     )
 
     out = buffer.getvalue()
-    assert "\nSkill activated install-code-review\n" in out
+    assert "\nLoaded   Skill · install-code-review\n" in out
     assert "\n\n\n" not in out
     # The github call is buffered for the grouped log, not printed inline yet.
     assert any(e.kind == "GitHub CLI" for e in observer.session.terminal.action_log_entries)

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -78,7 +78,7 @@ def test_prose_reply_keeps_the_inline_label() -> None:
 
     publish_full_response(console, "Root disk is 44% full.")
 
-    assert "OpenSRE  Root disk is 44% full." in buf.getvalue()
+    assert "● Root disk is 44% full." in buf.getvalue()
 
 
 def _tty_console() -> tuple[Console, io.StringIO]:
@@ -113,7 +113,7 @@ class TestNonTtyFallback:
         output = buf.getvalue()
         assert result == "Hello, world"
         # The inline label + text reach piped output so captured logs are useful.
-        assert "OpenSRE" in output
+        assert "●" in output
         assert "Hello, world" in output
         # No spinner / Live cursor-movement artifacts in non-TTY captures.
         assert "thinking" not in output
@@ -144,7 +144,7 @@ class TestNonTtyFallback:
         assert result == '{"actions":[]}'
         output = buf.getvalue()
         # No assistant label for suppressed responses.
-        assert "OpenSRE" not in output
+        assert "●" not in output
         assert '{"actions"' not in output
 
 
@@ -186,7 +186,7 @@ class TestTtyParagraphRender:
         output = _strip_ansi(buf.getvalue())
         assert result == "Run **opensre setup** to start."
         # The assistant label is pinned beside the rendered paragraph.
-        assert "OpenSRE" in output
+        assert "●" in output
         # End-of-stream force-flush rendered Markdown — ``**`` stripped.
         assert "**opensre" not in output
         assert "opensre setup" in output
@@ -228,12 +228,7 @@ class TestTtyParagraphRender:
         stream_to_console(console, label="OpenSRE", chunks=_yield_chunks([text]))
 
         visible = "\n".join(line.rstrip() for line in _strip_ansi(buf.getvalue()).splitlines())
-        assert (
-            "OpenSRE  Ready:\n\n"
-            "          • first\n"
-            "          • second\n\n"
-            "         Blocked pending a choice."
-        ) in visible
+        assert ("● Ready:\n\n   • first\n   • second\n\n  Blocked pending a choice.") in visible
 
     def test_reply_hangs_indented_under_the_label(self) -> None:
         """A wrapped reply hangs in the gutter: line one carries the label,
@@ -244,9 +239,9 @@ class TestTtyParagraphRender:
         stream_to_console(console, label="assistant", chunks=_yield_chunks([text]))
 
         lines = [line for line in _strip_ansi(buf.getvalue()).splitlines() if line.strip()]
-        assert lines[0].startswith("OpenSRE  ")
+        assert lines[0].startswith("● ")
         assert len(lines) > 1  # the reply actually wrapped
-        assert all(line.startswith(" " * 9) for line in lines[1:])
+        assert all(line.startswith(" " * 2) for line in lines[1:])
 
     def test_paragraph_break_across_chunk_boundary_flushes(self) -> None:
         """The cross-chunk seam — chunk N ends with ``\\n``, chunk N+1
@@ -647,7 +642,7 @@ class TestTtyParagraphRender:
         assert result == ""
         # The label is inline on the first paragraph, so an empty stream prints
         # no label at all — and no spinner residue at finalize.
-        assert "OpenSRE" not in _strip_ansi(buf.getvalue())
+        assert "●" not in _strip_ansi(buf.getvalue())
 
 
 class TestMidStreamError:
@@ -757,16 +752,16 @@ class TestTimingFooter:
 
 
 class TestRenderResponseHeader:
-    """``render_response_header`` is the assistant label shared with
+    """``render_response_header`` is the assistant marker shared with
     ``action_turn.run_action_tool_turn`` — three call sites collapsed
     to one helper, so we lock in the visible output here.
     """
 
-    def test_emits_product_label_without_internal_role(self) -> None:
+    def test_emits_marker_without_internal_role(self) -> None:
         console, buf = _tty_console()
         render_response_header(console, "assistant")
         output = _strip_ansi(buf.getvalue())
-        assert "OpenSRE" in output
+        assert "●" in output
         assert "assistant" not in output
 
     def test_role_label_is_accepted_but_not_painted(self) -> None:
@@ -775,7 +770,7 @@ class TestRenderResponseHeader:
         console, buf = _tty_console()
         render_response_header(console, "answer")
         assert "answer" not in _strip_ansi(buf.getvalue())
-        assert "OpenSRE" in _strip_ansi(buf.getvalue())
+        assert "●" in _strip_ansi(buf.getvalue())
 
 
 class TestFormatTokenCountShort:
@@ -1078,7 +1073,7 @@ class TestSuppressionPeek:
         assert result == '{"actions":[]}'
         # No assistant label, no markdown, no live-region artifacts.
         output = _strip_ansi(buf.getvalue())
-        assert "OpenSRE" not in output
+        assert "●" not in output
         assert '{"actions"' not in output
 
     def test_renders_normally_when_first_char_does_not_match(self) -> None:
@@ -1092,7 +1087,7 @@ class TestSuppressionPeek:
 
         assert result == "Hello, world"
         output = _strip_ansi(buf.getvalue())
-        assert "OpenSRE" in output
+        assert "●" in output
         assert "Hello, world" in output
 
     def test_skips_leading_whitespace_before_deciding(self) -> None:
@@ -1107,7 +1102,7 @@ class TestSuppressionPeek:
 
         assert result == '  \n{"action":"slash"}'
         output = _strip_ansi(buf.getvalue())
-        assert "OpenSRE" not in output
+        assert "●" not in output
 
 
 class TestRenderMarkdownBlock:

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -28,8 +28,7 @@ def _strip_ansi(text: str) -> str:
 
 
 def test_render_note_block_is_recessed_and_indented_but_keeps_bold() -> None:
-    # Droid rhythm: warm ``·`` in the shared agent column, recessed body, bold
-    # action words still bold.
+    # A visible working-state label leads the recessed body; action words stay bold.
     from infrastructure.terminal import theme as ui_theme
 
     ui_theme.set_active_theme("amber")
@@ -51,15 +50,14 @@ def test_render_note_block_is_recessed_and_indented_but_keeps_bold() -> None:
     assert "38;2;" in raw or "38;5;" in raw
     assert re.search(r"\x1b\[[0-9;]*1[;m]", raw)  # bold action word survives
     first_line = _strip_ansi(raw).splitlines()[0]
-    assert first_line.startswith("· ")  # warm · in the shared agent marker column
+    assert first_line.startswith("Working  ")
     assert "load the workflow" in first_line
 
 
 def test_table_reply_renders_as_a_table_not_flattened_pipes() -> None:
     # A reply that leads with a Markdown table must render as an aligned table. The
-    # inline ``Ω `` marker fused onto the header row breaks CommonMark block parsing
-    # and flattens the table to one line of raw pipes, so the marker goes on its own
-    # line before a leading block.
+    # transcript label stays in its own column so it cannot become part of the
+    # CommonMark source and flatten the table to a line of raw pipes.
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False, width=60, highlight=False)
 
@@ -73,14 +71,14 @@ def test_table_reply_renders_as_a_table_not_flattened_pipes() -> None:
     assert "━" in out and "│" in out  # rendered as a table with header rule and column rules
 
 
-def test_prose_reply_keeps_the_inline_marker() -> None:
-    # Prose still carries the marker inline on the first line.
+def test_prose_reply_keeps_the_inline_label() -> None:
+    # Prose carries the assistant label inline on the first line.
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False, width=60, highlight=False)
 
     publish_full_response(console, "Root disk is 44% full.")
 
-    assert "Ω Root disk is 44% full." in buf.getvalue()
+    assert "OpenSRE  Root disk is 44% full." in buf.getvalue()
 
 
 def _tty_console() -> tuple[Console, io.StringIO]:
@@ -114,9 +112,8 @@ class TestNonTtyFallback:
 
         output = buf.getvalue()
         assert result == "Hello, world"
-        # The inline ``Ω`` marker + text reach piped output so captured logs
-        # are useful (the standalone label header was removed).
-        assert "Ω" in output
+        # The inline label + text reach piped output so captured logs are useful.
+        assert "OpenSRE" in output
         assert "Hello, world" in output
         # No spinner / Live cursor-movement artifacts in non-TTY captures.
         assert "thinking" not in output
@@ -146,8 +143,8 @@ class TestNonTtyFallback:
 
         assert result == '{"actions":[]}'
         output = buf.getvalue()
-        # No bullet header for suppressed responses.
-        assert "Ω" not in output
+        # No assistant label for suppressed responses.
+        assert "OpenSRE" not in output
         assert '{"actions"' not in output
 
 
@@ -188,8 +185,8 @@ class TestTtyParagraphRender:
 
         output = _strip_ansi(buf.getvalue())
         assert result == "Run **opensre setup** to start."
-        # Bullet row marker pinned above the rendered paragraph.
-        assert "Ω" in output
+        # The assistant label is pinned beside the rendered paragraph.
+        assert "OpenSRE" in output
         # End-of-stream force-flush rendered Markdown — ``**`` stripped.
         assert "**opensre" not in output
         assert "opensre setup" in output
@@ -222,7 +219,7 @@ class TestTtyParagraphRender:
     def test_preserves_blank_line_between_list_and_following_paragraph(self) -> None:
         """One blank line between a list and the next paragraph — no double gap.
 
-        The whole reply hangs in the ``Ω`` gutter, so the list and the following
+        The whole reply hangs in the labeled gutter, so the list and the following
         paragraph sit in the indented body column.
         """
         console, buf = _tty_console()
@@ -231,10 +228,15 @@ class TestTtyParagraphRender:
         stream_to_console(console, label="OpenSRE", chunks=_yield_chunks([text]))
 
         visible = "\n".join(line.rstrip() for line in _strip_ansi(buf.getvalue()).splitlines())
-        assert "Ω Ready:\n\n   • first\n   • second\n\n  Blocked pending a choice." in visible
+        assert (
+            "OpenSRE  Ready:\n\n"
+            "          • first\n"
+            "          • second\n\n"
+            "         Blocked pending a choice."
+        ) in visible
 
-    def test_reply_hangs_indented_under_the_marker(self) -> None:
-        """A wrapped reply hangs in the Ω gutter: line one carries the marker,
+    def test_reply_hangs_indented_under_the_label(self) -> None:
+        """A wrapped reply hangs in the gutter: line one carries the label,
         every continuation line aligns in the indented body column."""
         console, buf = _tty_console()
         text = "A fairly long assistant reply that has to wrap across several lines. " * 3
@@ -242,9 +244,9 @@ class TestTtyParagraphRender:
         stream_to_console(console, label="assistant", chunks=_yield_chunks([text]))
 
         lines = [line for line in _strip_ansi(buf.getvalue()).splitlines() if line.strip()]
-        assert lines[0].startswith("Ω ")  # marker leads the first line
+        assert lines[0].startswith("OpenSRE  ")
         assert len(lines) > 1  # the reply actually wrapped
-        assert all(line.startswith("  ") for line in lines[1:])  # hang-indent at col 2
+        assert all(line.startswith(" " * 9) for line in lines[1:])
 
     def test_paragraph_break_across_chunk_boundary_flushes(self) -> None:
         """The cross-chunk seam — chunk N ends with ``\\n``, chunk N+1
@@ -643,9 +645,9 @@ class TestTtyParagraphRender:
         )
 
         assert result == ""
-        # The marker is inline on the first paragraph, so an empty stream prints
-        # no marker at all — and no spinner residue at finalize.
-        assert "Ω" not in _strip_ansi(buf.getvalue())
+        # The label is inline on the first paragraph, so an empty stream prints
+        # no label at all — and no spinner residue at finalize.
+        assert "OpenSRE" not in _strip_ansi(buf.getvalue())
 
 
 class TestMidStreamError:
@@ -755,16 +757,16 @@ class TestTimingFooter:
 
 
 class TestRenderResponseHeader:
-    """``render_response_header`` is the bullet-row marker shared with
+    """``render_response_header`` is the assistant label shared with
     ``action_turn.run_action_tool_turn`` — three call sites collapsed
     to one helper, so we lock in the visible output here.
     """
 
-    def test_emits_bullet_glyph_without_role_label(self) -> None:
+    def test_emits_product_label_without_internal_role(self) -> None:
         console, buf = _tty_console()
         render_response_header(console, "assistant")
         output = _strip_ansi(buf.getvalue())
-        assert "Ω" in output
+        assert "OpenSRE" in output
         assert "assistant" not in output
 
     def test_role_label_is_accepted_but_not_painted(self) -> None:
@@ -773,7 +775,7 @@ class TestRenderResponseHeader:
         console, buf = _tty_console()
         render_response_header(console, "answer")
         assert "answer" not in _strip_ansi(buf.getvalue())
-        assert "Ω" in _strip_ansi(buf.getvalue())
+        assert "OpenSRE" in _strip_ansi(buf.getvalue())
 
 
 class TestFormatTokenCountShort:
@@ -1074,9 +1076,9 @@ class TestSuppressionPeek:
         )
 
         assert result == '{"actions":[]}'
-        # No bullet header, no markdown, no live-region artifacts.
+        # No assistant label, no markdown, no live-region artifacts.
         output = _strip_ansi(buf.getvalue())
-        assert "Ω" not in output
+        assert "OpenSRE" not in output
         assert '{"actions"' not in output
 
     def test_renders_normally_when_first_char_does_not_match(self) -> None:
@@ -1090,7 +1092,7 @@ class TestSuppressionPeek:
 
         assert result == "Hello, world"
         output = _strip_ansi(buf.getvalue())
-        assert "Ω" in output
+        assert "OpenSRE" in output
         assert "Hello, world" in output
 
     def test_skips_leading_whitespace_before_deciding(self) -> None:
@@ -1105,7 +1107,7 @@ class TestSuppressionPeek:
 
         assert result == '  \n{"action":"slash"}'
         output = _strip_ansi(buf.getvalue())
-        assert "Ω" not in output
+        assert "OpenSRE" not in output
 
 
 class TestRenderMarkdownBlock:


### PR DESCRIPTION
N/A — direct terminal UI polish; no issue was provided.

#### Describe the changes you have made in this PR -

- Replace undersized transcript glyphs with clearer `Working`, `Tool`, and `Error` states, plus a compact theme-coloured `●` assistant marker.
- Keep successful skill status copy as `Skill activated <name>` and centralize transcript gutters, wrapping, continuations, and narrow-terminal fallbacks in focused UI helpers.
- Reuse the formatting across streamed replies, resumed history, tool rows, skill status, errors, and demo output without changing agent, skill, prompt, tool-execution, or container behavior.

### Demo/Screenshot for feature changes and bug fixes -

```text
Working  I’ll check the repo star history and summarize the trend.

Error    Could not load skill · measuring-github-star-velocity
Working  I’ll fall back to the GitHub CLI.

Tool     memory recall
Tool     Python

Skill activated reporting-github-ci-failures

● The exact count is ready.
```

Validation:

- `make lint`
- `make format-check`
- `make typecheck`
- `env -u NO_COLOR uv run python -m pytest tests/interactive_shell/ tests/infrastructure/terminal/test_theme.py -q` — 1,594 passed, 1 skipped
- Focused terminal rendering suite — 120 passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

A typed transcript UI component owns role markers and indentation. Assistant replies use the compact filled-circle gutter and the active theme highlight; status rows use aligned textual labels. Expanded tool children align beneath their parent body, narrow rows retain a useful tool-name budget, and errors render without an empty assistant row. Existing Rich panels and execution paths are unchanged.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue — no issue was provided
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests — not a core feature; UI regressions are covered
- [x] My code follows the project's style guidelines and conventions
