### PR TITLE
feat(cli): show live progress for ask

### DIFF
--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from core.agent_harness.ports import (
         OutputSink,
         PromptContextProvider,
+        ToolEventObserver,
         ToolProvider,
         TurnBinding,
     )
@@ -145,6 +146,7 @@ class AgentSession:
         surface: str | None = None,
         is_tty: bool | None = None,
         tool_hooks: ToolExecutionHooks | None = None,
+        tool_event_observer: ToolEventObserver | None = None,
         unattended: bool = False,
     ) -> AgentSession:
         """Return a session that is ready to :meth:`chat`.
@@ -169,8 +171,9 @@ class AgentSession:
         are the :class:`~core.agent_harness.turns.headless_build.DefaultHeadlessBuild`
         fields; ``tools`` the port its ``agent()`` takes;
         ``is_tty`` and ``tool_hooks`` (the turn's approval hooks) are bound on
-        the first turn. A host that needs more (its own sink, prompts, error
-        reporter, an action ``llm_factory``) builds through
+        the first turn. ``tool_event_observer`` receives action-tool lifecycle
+        events from the default tool provider. A host that needs more (its own
+        sink, prompts, error reporter, an action ``llm_factory``) builds through
         :class:`DefaultHeadlessBuild` itself and calls :meth:`attach_agent`.
         """
         from core.agent_harness.turns.headless_adapters import BufferOutputSink
@@ -190,6 +193,7 @@ class AgentSession:
             surface=surface,
             is_tty=is_tty,
             tool_hooks=tool_hooks,
+            tool_event_observer=tool_event_observer,
             unattended=unattended,
         )
         return agent_session
@@ -333,6 +337,7 @@ class AgentSession:
         surface: str | None = None,
         is_tty: bool | None = None,
         tool_hooks: ToolExecutionHooks | None = None,
+        tool_event_observer: ToolEventObserver | None = None,
         unattended: bool = False,
     ) -> None:
         """Attach the agent built on the default port family (one construction recipe).
@@ -350,6 +355,7 @@ class AgentSession:
             console=console,
             logger=logger,
             surface=surface,
+            tool_event_observer=tool_event_observer,
             unattended=unattended,
         ).agent(tools=tools, prompts=prompts)
         agent.bind_turn(TurnBinding(is_tty=is_tty, tool_hooks=tool_hooks))

--- a/core/agent_harness/turns/headless_build.py
+++ b/core/agent_harness/turns/headless_build.py
@@ -116,6 +116,8 @@ class DefaultHeadlessBuild:
     error_reporter: ErrorReporter | None = None
     #: Restrict unattended ticks to NONE / READ_ONLY tools.
     unattended: bool = False
+    #: Optional surface callback for action-tool lifecycle events.
+    tool_event_observer: ToolEventObserver | None = None
 
     @cached_property
     def _console(self) -> Any:
@@ -144,9 +146,21 @@ class DefaultHeadlessBuild:
         ``shell_run`` can execute. A host that wants a different presenter
         passes its own :class:`DefaultToolProvider`.
         """
+        observer = self.tool_event_observer
+        observer_factory: Callable[[str], ToolEventObserver] | None
+        if observer is None:
+            observer_factory = None
+        else:
+
+            def _observer_factory(_message: str) -> ToolEventObserver:
+                return observer
+
+            observer_factory = _observer_factory
+
         return DefaultToolProvider(
             self.session,
             self._console,
+            observer_factory=observer_factory,
             tool_action_logger=self._logger,
             subprocess_presenter_factory=resolve_subprocess_presenter(),
             unattended=self.unattended,

--- a/docs/headless-cli.mdx
+++ b/docs/headless-cli.mdx
@@ -13,6 +13,13 @@ It uses the LLM provider from `opensre onboard` and any tools configured with
 opensre ask "why did checkout latency increase today?"
 ```
 
+## Live activity
+
+When both output streams are attached to a terminal, `ask` shows an ephemeral
+status spinner with elapsed time and names each diagnostic tool as it starts.
+The final answer remains on standard output. Piped and `--json` runs do not
+emit progress, so their output remains machine-readable.
+
 Pass `-` as the prompt to read all of standard input:
 
 ```bash

--- a/docs/headless-cli.mdx
+++ b/docs/headless-cli.mdx
@@ -15,10 +15,11 @@ opensre ask "why did checkout latency increase today?"
 
 ## Live activity
 
-When both output streams are attached to a terminal, `ask` shows an ephemeral
-status spinner with elapsed time and names each diagnostic tool as it starts.
-The final answer remains on standard output. Piped and `--json` runs do not
-emit progress, so their output remains machine-readable.
+When both output streams are attached to a terminal, `ask` starts with a
+`Thinking…` spinner with elapsed time. It switches to the active diagnostic
+tool (or a neutral tool count for a batch) when tools are invoked. The final
+answer remains on standard output. Piped and `--json` runs do not emit progress,
+so their output remains machine-readable.
 
 Pass `-` as the prompt to read all of standard input:
 

--- a/surfaces/cli/ask/progress.py
+++ b/surfaces/cli/ask/progress.py
@@ -1,0 +1,65 @@
+"""Terminal-only activity display for interactive ``opensre ask`` runs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+from core.agent_harness.ports import ToolEventObserver
+from infrastructure.safety.terminal_output import strip_terminal_controls
+
+_INITIAL_STATUS = "Investigating…"
+
+
+def status_for_tool_event(kind: str, data: dict[str, Any]) -> str | None:
+    """Return safe status copy for a tool-start event, if it names a tool."""
+    if kind != "tool_start":
+        return None
+    tool_name = " ".join(strip_terminal_controls(str(data.get("name") or "")).split())
+    if not tool_name:
+        return None
+    return f"Running {tool_name.replace('_', ' ')}…"
+
+
+class AskProgress:
+    """Render one ephemeral spinner and update it as the agent starts tools."""
+
+    def __init__(self) -> None:
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}", markup=False),
+            TimeElapsedColumn(),
+            console=Console(stderr=True, highlight=False),
+            refresh_per_second=12,
+            transient=True,
+        )
+        self._task_id = self._progress.add_task(_INITIAL_STATUS, total=None)
+
+    def __enter__(self) -> AskProgress:
+        self._progress.start()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self._progress.stop()
+
+    def __call__(self, kind: str, data: dict[str, Any]) -> None:
+        status = status_for_tool_event(kind, data)
+        if status is not None:
+            self._progress.update(self._task_id, description=status)
+
+
+@contextmanager
+def ask_progress_scope(*, enabled: bool) -> Iterator[ToolEventObserver | None]:
+    """Yield a live tool observer only for an interactive terminal invocation."""
+    if not enabled:
+        yield None
+        return
+    with AskProgress() as progress:
+        yield progress
+
+
+__all__ = ["AskProgress", "ask_progress_scope", "status_for_tool_event"]

--- a/surfaces/cli/ask/progress.py
+++ b/surfaces/cli/ask/progress.py
@@ -16,16 +16,31 @@ _INITIAL_STATUS = "Investigating…"
 _ANALYZING_STATUS = "Analyzing results…"
 
 
+def _status_for_tool_start(data: dict[str, Any]) -> str | None:
+    """Describe a requested tool batch without overstating execution order."""
+    tool_call_count = data.get("tool_call_count")
+    if (
+        isinstance(tool_call_count, int)
+        and not isinstance(tool_call_count, bool)
+        and tool_call_count > 1
+    ):
+        if data.get("tool_call_index") != 0:
+            return None
+        return f"Running {tool_call_count} tools…"
+
+    tool_name = " ".join(strip_terminal_controls(str(data.get("name") or "")).split())
+    if not tool_name:
+        return None
+    return f"Running {tool_name.replace('_', ' ')}…"
+
+
 def status_for_tool_event(kind: str, data: dict[str, Any]) -> str | None:
     """Return safe status copy for a tool lifecycle event."""
     if kind == "tool_end":
         return _ANALYZING_STATUS
     if kind != "tool_start":
         return None
-    tool_name = " ".join(strip_terminal_controls(str(data.get("name") or "")).split())
-    if not tool_name:
-        return None
-    return f"Running {tool_name.replace('_', ' ')}…"
+    return _status_for_tool_start(data)
 
 
 class AskProgress:

--- a/surfaces/cli/ask/progress.py
+++ b/surfaces/cli/ask/progress.py
@@ -13,10 +13,13 @@ from core.agent_harness.ports import ToolEventObserver
 from infrastructure.safety.terminal_output import strip_terminal_controls
 
 _INITIAL_STATUS = "Investigating…"
+_ANALYZING_STATUS = "Analyzing results…"
 
 
 def status_for_tool_event(kind: str, data: dict[str, Any]) -> str | None:
-    """Return safe status copy for a tool-start event, if it names a tool."""
+    """Return safe status copy for a tool lifecycle event."""
+    if kind == "tool_end":
+        return _ANALYZING_STATUS
     if kind != "tool_start":
         return None
     tool_name = " ".join(strip_terminal_controls(str(data.get("name") or "")).split())

--- a/surfaces/cli/ask/progress.py
+++ b/surfaces/cli/ask/progress.py
@@ -2,18 +2,46 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from datetime import timedelta
 from typing import Any
 
 from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.progress import Progress, ProgressColumn, Task, TextColumn
+from rich.table import Column
+from rich.text import Text
 
-from core.agent_harness.ports import ToolEventObserver
 from infrastructure.safety.terminal_output import strip_terminal_controls
+from infrastructure.terminal.spinner_frames import spinner_frames
+from infrastructure.terminal.theme import BRAND, DIM, HIGHLIGHT, TEXT
 
-_INITIAL_STATUS = "Investigating…"
-_ANALYZING_STATUS = "Analyzing results…"
+_THINKING_STATUS = "Thinking…"
+_FRAME_INTERVAL_SECONDS = 0.1
+
+ToolEventObserver = Callable[[str, dict[str, Any]], None]
+
+
+class _ActivitySpinnerColumn(ProgressColumn):
+    """Render the shared one-cell spinner in the appropriate activity color."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._frames = spinner_frames()
+
+    def render(self, task: Task) -> Text:
+        elapsed = task.elapsed or 0.0
+        frame = self._frames[int(elapsed / _FRAME_INTERVAL_SECONDS) % len(self._frames)]
+        style = BRAND if task.fields.get("tool_active", False) else HIGHLIGHT
+        return Text(frame, style=style)
+
+
+class _ElapsedColumn(ProgressColumn):
+    """Render elapsed time with the shared muted terminal token."""
+
+    def render(self, task: Task) -> Text:
+        elapsed = task.elapsed or 0.0
+        return Text(str(timedelta(seconds=max(0, int(elapsed)))), style=DIM)
 
 
 def _status_for_tool_start(data: dict[str, Any]) -> str | None:
@@ -26,18 +54,18 @@ def _status_for_tool_start(data: dict[str, Any]) -> str | None:
     ):
         if data.get("tool_call_index") != 0:
             return None
-        return f"Running {tool_call_count} tools…"
+        return f"Invoking {tool_call_count} tools…"
 
     tool_name = " ".join(strip_terminal_controls(str(data.get("name") or "")).split())
     if not tool_name:
         return None
-    return f"Running {tool_name.replace('_', ' ')}…"
+    return f"Invoking tools… · {tool_name.replace('_', ' ')}"
 
 
 def status_for_tool_event(kind: str, data: dict[str, Any]) -> str | None:
     """Return safe status copy for a tool lifecycle event."""
     if kind == "tool_end":
-        return _ANALYZING_STATUS
+        return _THINKING_STATUS
     if kind != "tool_start":
         return None
     return _status_for_tool_start(data)
@@ -47,17 +75,24 @@ class AskProgress:
     """Render one ephemeral spinner and update it as the agent starts tools."""
 
     def __init__(self) -> None:
+        self._console = Console(stderr=True, highlight=False)
         self._progress = Progress(
-            SpinnerColumn(),
-            TextColumn("{task.description}", markup=False),
-            TimeElapsedColumn(),
-            console=Console(stderr=True, highlight=False),
+            _ActivitySpinnerColumn(),
+            TextColumn(
+                "{task.description}",
+                markup=False,
+                style=TEXT,
+                table_column=Column(no_wrap=True, overflow="ellipsis"),
+            ),
+            _ElapsedColumn(),
+            console=self._console,
             refresh_per_second=12,
             transient=True,
         )
-        self._task_id = self._progress.add_task(_INITIAL_STATUS, total=None)
+        self._task_id = self._progress.add_task(_THINKING_STATUS, total=None, tool_active=False)
 
     def __enter__(self) -> AskProgress:
+        self._console.print()
         self._progress.start()
         return self
 
@@ -67,7 +102,11 @@ class AskProgress:
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
         status = status_for_tool_event(kind, data)
         if status is not None:
-            self._progress.update(self._task_id, description=status)
+            self._progress.update(
+                self._task_id,
+                description=status,
+                tool_active=kind == "tool_start",
+            )
 
 
 @contextmanager

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -21,6 +21,7 @@ from core.agent_harness import (
     SessionManager,
     TurnResult,
 )
+from core.agent_harness.ports import ToolEventObserver
 from core.agent_harness.spi.cancel import ensure_turn_cancel
 from core.tool import ToolExecutionHooks
 from infrastructure.errors import OpenSREError
@@ -150,7 +151,12 @@ def _restrict_ask_capabilities(session: SessionCore) -> None:
         session.available_capabilities[capability] = ()
 
 
-def _run_agent_turn(prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
+def _run_agent_turn(
+    prompt: str,
+    hooks: ToolExecutionHooks,
+    *,
+    tool_event_observer: ToolEventObserver | None = None,
+) -> TurnResult:
     manager = SessionManager()
     output = _AskOutputSink()
     cancel_event = ensure_turn_cancel(output)
@@ -172,6 +178,7 @@ def _run_agent_turn(prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
                 console=console,
                 is_tty=False,
                 tool_hooks=hooks,
+                tool_event_observer=tool_event_observer,
             )
             session = agent_session.bound_session
             # chat_until_goal, not chat: the agent can attach a session goal,
@@ -244,6 +251,7 @@ def run_ask(
     *,
     allowed_tools: tuple[str, ...],
     bypass_approvals: bool,
+    tool_event_observer: ToolEventObserver | None = None,
 ) -> AskOutcome:
     """Execute one ask turn with invocation-scoped approval authority."""
     tracker = ApprovalTracker()
@@ -253,7 +261,7 @@ def run_ask(
         tracker=tracker,
     )
     try:
-        result = _run_agent_turn(prompt, hooks)
+        result = _run_agent_turn(prompt, hooks, tool_event_observer=tool_event_observer)
     except AskSignal as exc:
         return cancelled_outcome(exc.signum)
     except OpenSREError as exc:

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import signal
 import threading
-from collections.abc import Iterable, Iterator
-from contextlib import contextmanager
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from io import StringIO
-from types import FrameType
 from typing import Any
 
 from rich.console import Console
@@ -26,6 +24,7 @@ from core.agent_harness.spi.cancel import ensure_turn_cancel
 from core.tool import ToolExecutionHooks
 from infrastructure.errors import OpenSREError
 from surfaces.cli.ask.approval import ApprovalTracker, build_approval_hooks
+from surfaces.cli.ask.signals import AskSignal, ask_signal_scope
 
 #: Capabilities the one-shot ``ask`` agent must not reach — it answers or runs a
 #: bounded action, not slash commands or task cancellation.
@@ -77,14 +76,6 @@ class AskOutcome:
         }
 
 
-class AskSignal(BaseException):
-    """Signal raised inside the command so session cleanup can finish."""
-
-    def __init__(self, signum: int) -> None:
-        super().__init__(signum)
-        self.signum = signum
-
-
 class _CancellableConsole:
     def __init__(self, cancel_event: threading.Event) -> None:
         self._cancel_event = cancel_event
@@ -123,26 +114,6 @@ class _AskOutputSink:
 
     def finish_streamed_response(self, answer: str) -> None:
         _ = answer
-
-
-@contextmanager
-def ask_signal_scope(cancel_event: threading.Event | None = None) -> Iterator[None]:
-    """Map process termination signals to ``AskSignal`` within one CLI scope."""
-    event = cancel_event or threading.Event()
-    previous: dict[signal.Signals, Any] = {}
-
-    def handle(signum: int, _frame: FrameType | None) -> None:
-        event.set()
-        raise AskSignal(signum)
-
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        previous[sig] = signal.getsignal(sig)
-        signal.signal(sig, handle)
-    try:
-        yield
-    finally:
-        for sig, handler in previous.items():
-            signal.signal(sig, handler)
 
 
 def _restrict_ask_capabilities(session: SessionCore) -> None:

--- a/surfaces/cli/ask/signals.py
+++ b/surfaces/cli/ask/signals.py
@@ -1,0 +1,41 @@
+"""Signal-to-cancellation mapping for one-shot ``opensre ask`` invocations."""
+
+from __future__ import annotations
+
+import signal
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import FrameType
+from typing import Any
+
+
+class AskSignal(BaseException):
+    """Signal raised inside the command so session cleanup can finish."""
+
+    def __init__(self, signum: int) -> None:
+        super().__init__(signum)
+        self.signum = signum
+
+
+@contextmanager
+def ask_signal_scope(cancel_event: threading.Event | None = None) -> Iterator[None]:
+    """Map process termination signals to ``AskSignal`` within one CLI scope."""
+    event = cancel_event or threading.Event()
+    previous: dict[signal.Signals, Any] = {}
+
+    def handle(signum: int, _frame: FrameType | None) -> None:
+        event.set()
+        raise AskSignal(signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        previous[sig] = signal.getsignal(sig)
+        signal.signal(sig, handle)
+    try:
+        yield
+    finally:
+        for sig, handler in previous.items():
+            signal.signal(sig, handler)
+
+
+__all__ = ["AskSignal", "ask_signal_scope"]

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -91,34 +91,41 @@ def ask_command(
     dangerously_bypass_approvals: bool,
 ) -> None:
     """Run one configured OpenSRE agent request and exit."""
-    from surfaces.cli.ask import approval as ask_approval
-    from surfaces.cli.ask import service as ask_service
-
     if allowed_tools and dangerously_bypass_approvals:
         raise click.UsageError(
             "--allowed-tool cannot be combined with --dangerously-bypass-approvals."
         )
-    unknown = ask_approval.unknown_allowed_tools(allowed_tools)
-    if unknown:
-        names = ", ".join(unknown)
-        raise click.BadParameter(
-            f"unknown registered tool name(s): {names}",
-            param_hint="--allowed-tool",
-        )
-    try:
-        with ask_service.ask_signal_scope():
-            from surfaces.cli.ask.progress import ask_progress_scope
 
+    if allowed_tools:
+        from surfaces.cli.ask import approval as ask_approval
+
+        unknown = ask_approval.unknown_allowed_tools(allowed_tools)
+        if unknown:
+            names = ", ".join(unknown)
+            raise click.BadParameter(
+                f"unknown registered tool name(s): {names}",
+                param_hint="--allowed-tool",
+            )
+
+    from surfaces.cli.ask.progress import ask_progress_scope
+    from surfaces.cli.ask.signals import AskSignal, ask_signal_scope
+
+    try:
+        with ask_signal_scope():
             resolved_prompt = _resolve_prompt(prompt)
             with ask_progress_scope(enabled=_show_live_progress()) as tool_event_observer:
+                from surfaces.cli.ask import service as ask_service
+
                 outcome = ask_service.run_ask(
                     resolved_prompt,
                     allowed_tools=allowed_tools,
                     bypass_approvals=dangerously_bypass_approvals,
                     tool_event_observer=tool_event_observer,
                 )
-    except ask_service.AskSignal as exc:
-        outcome = ask_service.cancelled_outcome(exc.signum)
+    except AskSignal as exc:
+        from surfaces.cli.ask.service import cancelled_outcome
+
+        outcome = cancelled_outcome(exc.signum)
     _render_outcome(outcome)
     if outcome.exit_code:
         raise SystemExit(int(outcome.exit_code))

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -66,6 +66,11 @@ def _render_outcome(outcome: AskOutcome) -> None:
             click.echo(f"Suggestion: {outcome.error.suggestion}", err=True)
 
 
+def _show_live_progress() -> bool:
+    """Show activity only when it cannot alter a machine-readable result."""
+    return not is_json_output() and sys.stdout.isatty() and sys.stderr.isatty()
+
+
 @click.command(name="ask")
 @click.argument("prompt")
 @click.option(
@@ -102,11 +107,16 @@ def ask_command(
         )
     try:
         with ask_service.ask_signal_scope():
-            outcome = ask_service.run_ask(
-                _resolve_prompt(prompt),
-                allowed_tools=allowed_tools,
-                bypass_approvals=dangerously_bypass_approvals,
-            )
+            from surfaces.cli.ask.progress import ask_progress_scope
+
+            resolved_prompt = _resolve_prompt(prompt)
+            with ask_progress_scope(enabled=_show_live_progress()) as tool_event_observer:
+                outcome = ask_service.run_ask(
+                    resolved_prompt,
+                    allowed_tools=allowed_tools,
+                    bypass_approvals=dangerously_bypass_approvals,
+                    tool_event_observer=tool_event_observer,
+                )
     except ask_service.AskSignal as exc:
         outcome = ask_service.cancelled_outcome(exc.signum)
     _render_outcome(outcome)

--- a/tests/cli/test_ask_command.py
+++ b/tests/cli/test_ask_command.py
@@ -79,7 +79,50 @@ def test_ask_passes_prompt_and_invocation_authority(monkeypatch) -> None:
         "prompt": "check latency",
         "allowed_tools": ("grafana_query",),
         "bypass_approvals": False,
+        "tool_event_observer": None,
     }
+
+
+def test_ask_passes_a_live_observer_only_for_an_interactive_text_terminal(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    enabled_values: list[bool] = []
+    observer = object()
+
+    @contextlib.contextmanager
+    def fake_progress_scope(*, enabled: bool):
+        enabled_values.append(enabled)
+        yield observer
+
+    def fake_run(prompt: str, **kwargs: object) -> AskOutcome:
+        captured.update(prompt=prompt, **kwargs)
+        return _success()
+
+    monkeypatch.setattr("surfaces.cli.ask.approval.unknown_allowed_tools", lambda _v: ())
+    monkeypatch.setattr("surfaces.cli.ask.progress.ask_progress_scope", fake_progress_scope)
+    monkeypatch.setattr("surfaces.cli.ask.service.run_ask", fake_run)
+    monkeypatch.setattr("surfaces.cli.commands.ask._show_live_progress", lambda: True)
+
+    result = CliRunner().invoke(ask_command, ["check latency"])
+
+    assert result.exit_code == 0
+    assert enabled_values == [True]
+    assert captured["tool_event_observer"] is observer
+
+
+def test_live_progress_is_disabled_for_json_or_redirected_output(monkeypatch) -> None:
+    from surfaces.cli.commands.ask import _show_live_progress
+
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+    monkeypatch.setattr("surfaces.cli.commands.ask.is_json_output", lambda: False)
+    assert _show_live_progress() is True
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.is_json_output", lambda: True)
+    assert _show_live_progress() is False
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.is_json_output", lambda: False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    assert _show_live_progress() is False
 
 
 def test_root_yes_does_not_bypass_ask_approvals(monkeypatch) -> None:

--- a/tests/cli/test_ask_progress.py
+++ b/tests/cli/test_ask_progress.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
+from infrastructure.terminal.spinner_frames import DOT_SPINNER_FRAMES
+from infrastructure.terminal.theme import BRAND, HIGHLIGHT
 from surfaces.cli.ask import progress
 from surfaces.cli.ask.progress import status_for_tool_event
 
@@ -14,12 +17,12 @@ def test_tool_progress_names_the_active_tool_without_its_input() -> None:
         {"name": "grafana_query", "input": {"query": "secret label value"}},
     )
 
-    assert status == "Running grafana query…"
+    assert status == "Invoking tools… · grafana query"
     assert "secret" not in status
 
 
 def test_tool_progress_ignores_non_tool_or_unnamed_events() -> None:
-    assert status_for_tool_event("tool_end", {"name": "grafana_query"}) == "Analyzing results…"
+    assert status_for_tool_event("tool_end", {"name": "grafana_query"}) == "Thinking…"
     assert status_for_tool_event("message_update", {}) is None
     assert status_for_tool_event("tool_start", {}) is None
 
@@ -28,7 +31,7 @@ def test_tool_progress_uses_a_neutral_label_for_batched_tool_starts() -> None:
     first_start = {"name": "grafana_query", "tool_call_count": 2, "tool_call_index": 0}
     second_start = {"name": "logs_search", "tool_call_count": 2, "tool_call_index": 1}
 
-    assert status_for_tool_event("tool_start", first_start) == "Running 2 tools…"
+    assert status_for_tool_event("tool_start", first_start) == "Invoking 2 tools…"
     assert status_for_tool_event("tool_start", second_start) is None
 
 
@@ -55,6 +58,31 @@ def test_progress_scope_starts_before_the_agent_turn_and_stops_afterward(monkeyp
     assert events == ["start", "stop"]
 
 
+def test_progress_leaves_a_blank_line_before_the_activity_row(monkeypatch) -> None:
+    events: list[str] = []
+
+    class _Console:
+        def print(self) -> None:
+            events.append("spacing")
+
+    class _Progress:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            """Record construction without rendering a terminal."""
+
+        def add_task(self, _description: str, **_kwargs: object) -> object:
+            return "ask"
+
+        def start(self) -> None:
+            events.append("start")
+
+    monkeypatch.setattr(progress, "Console", lambda **_kwargs: _Console())
+    monkeypatch.setattr(progress, "Progress", _Progress)
+
+    progress.AskProgress().__enter__()
+
+    assert events == ["spacing", "start"]
+
+
 def test_progress_updates_the_visible_status_when_a_tool_starts(monkeypatch) -> None:
     updates: list[tuple[object, str]] = []
 
@@ -62,8 +90,9 @@ def test_progress_updates_the_visible_status_when_a_tool_starts(monkeypatch) -> 
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             """Record progress construction without rendering a terminal."""
 
-        def add_task(self, _description: str, *, total: object) -> object:
+        def add_task(self, _description: str, *, total: object, tool_active: bool) -> object:
             assert total is None
+            assert tool_active is False
             return "ask"
 
         def start(self) -> None:
@@ -72,8 +101,8 @@ def test_progress_updates_the_visible_status_when_a_tool_starts(monkeypatch) -> 
         def stop(self) -> None:
             """Stop progress rendering."""
 
-        def update(self, task_id: object, *, description: str) -> None:
-            updates.append((task_id, description))
+        def update(self, task_id: object, *, description: str, tool_active: bool) -> None:
+            updates.append((task_id, description, tool_active))
 
     monkeypatch.setattr(progress, "Progress", _Progress)
     reporter = progress.AskProgress()
@@ -81,6 +110,18 @@ def test_progress_updates_the_visible_status_when_a_tool_starts(monkeypatch) -> 
     reporter("tool_end", {"name": "grafana_query"})
 
     assert updates == [
-        ("ask", "Running grafana query…"),
-        ("ask", "Analyzing results…"),
+        ("ask", "Invoking tools… · grafana query", True),
+        ("ask", "Thinking…", False),
     ]
+
+
+def test_progress_uses_shared_terminal_spinner_frames_and_activity_colors(monkeypatch) -> None:
+    monkeypatch.setattr(progress, "spinner_frames", lambda: DOT_SPINNER_FRAMES)
+    spinner = progress._ActivitySpinnerColumn()
+
+    thinking = spinner.render(SimpleNamespace(elapsed=0.0, fields={}))
+    running_tool = spinner.render(SimpleNamespace(elapsed=0.0, fields={"tool_active": True}))
+
+    assert thinking.plain == DOT_SPINNER_FRAMES[0]
+    assert str(thinking.style) == str(HIGHLIGHT)
+    assert str(running_tool.style) == str(BRAND)

--- a/tests/cli/test_ask_progress.py
+++ b/tests/cli/test_ask_progress.py
@@ -1,0 +1,73 @@
+"""Tests for terminal-only progress during ``opensre ask``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surfaces.cli.ask import progress
+from surfaces.cli.ask.progress import status_for_tool_event
+
+
+def test_tool_progress_names_the_active_tool_without_its_input() -> None:
+    status = status_for_tool_event(
+        "tool_start",
+        {"name": "grafana_query", "input": {"query": "secret label value"}},
+    )
+
+    assert status == "Running grafana query…"
+    assert "secret" not in status
+
+
+def test_tool_progress_ignores_non_tool_or_unnamed_events() -> None:
+    assert status_for_tool_event("tool_end", {"name": "grafana_query"}) is None
+    assert status_for_tool_event("tool_start", {}) is None
+
+
+def test_progress_scope_starts_before_the_agent_turn_and_stops_afterward(monkeypatch) -> None:
+    events: list[str] = []
+
+    class _Progress:
+        def __enter__(self) -> _Progress:
+            events.append("start")
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            events.append("stop")
+
+        def __call__(self, _kind: str, _data: dict[str, Any]) -> None:
+            """Observe tool lifecycle events."""
+
+    monkeypatch.setattr(progress, "AskProgress", _Progress)
+
+    with progress.ask_progress_scope(enabled=True) as observer:
+        assert observer is not None
+        assert events == ["start"]
+
+    assert events == ["start", "stop"]
+
+
+def test_progress_updates_the_visible_status_when_a_tool_starts(monkeypatch) -> None:
+    updates: list[tuple[object, str]] = []
+
+    class _Progress:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            """Record progress construction without rendering a terminal."""
+
+        def add_task(self, _description: str, *, total: object) -> object:
+            assert total is None
+            return "ask"
+
+        def start(self) -> None:
+            """Start progress rendering."""
+
+        def stop(self) -> None:
+            """Stop progress rendering."""
+
+        def update(self, task_id: object, *, description: str) -> None:
+            updates.append((task_id, description))
+
+    monkeypatch.setattr(progress, "Progress", _Progress)
+    reporter = progress.AskProgress()
+    reporter("tool_start", {"name": "grafana_query"})
+
+    assert updates == [("ask", "Running grafana query…")]

--- a/tests/cli/test_ask_progress.py
+++ b/tests/cli/test_ask_progress.py
@@ -19,7 +19,8 @@ def test_tool_progress_names_the_active_tool_without_its_input() -> None:
 
 
 def test_tool_progress_ignores_non_tool_or_unnamed_events() -> None:
-    assert status_for_tool_event("tool_end", {"name": "grafana_query"}) is None
+    assert status_for_tool_event("tool_end", {"name": "grafana_query"}) == "Analyzing results…"
+    assert status_for_tool_event("message_update", {}) is None
     assert status_for_tool_event("tool_start", {}) is None
 
 
@@ -69,5 +70,9 @@ def test_progress_updates_the_visible_status_when_a_tool_starts(monkeypatch) -> 
     monkeypatch.setattr(progress, "Progress", _Progress)
     reporter = progress.AskProgress()
     reporter("tool_start", {"name": "grafana_query"})
+    reporter("tool_end", {"name": "grafana_query"})
 
-    assert updates == [("ask", "Running grafana query…")]
+    assert updates == [
+        ("ask", "Running grafana query…"),
+        ("ask", "Analyzing results…"),
+    ]

--- a/tests/cli/test_ask_progress.py
+++ b/tests/cli/test_ask_progress.py
@@ -24,6 +24,14 @@ def test_tool_progress_ignores_non_tool_or_unnamed_events() -> None:
     assert status_for_tool_event("tool_start", {}) is None
 
 
+def test_tool_progress_uses_a_neutral_label_for_batched_tool_starts() -> None:
+    first_start = {"name": "grafana_query", "tool_call_count": 2, "tool_call_index": 0}
+    second_start = {"name": "logs_search", "tool_call_count": 2, "tool_call_index": 1}
+
+    assert status_for_tool_event("tool_start", first_start) == "Running 2 tools…"
+    assert status_for_tool_event("tool_start", second_start) is None
+
+
 def test_progress_scope_starts_before_the_agent_turn_and_stops_afterward(monkeypatch) -> None:
     events: list[str] = []
 

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -106,13 +106,36 @@ class _GoalRun:
 
 
 def test_run_ask_returns_success(monkeypatch) -> None:
-    monkeypatch.setattr(service, "_run_agent_turn", lambda _prompt, _hooks: _turn())
+    monkeypatch.setattr(service, "_run_agent_turn", lambda _prompt, _hooks, **_kwargs: _turn())
 
     outcome = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
 
     assert outcome.status is AskStatus.SUCCESS
     assert outcome.response == "answer"
     assert outcome.exit_code is AskExitCode.SUCCESS
+
+
+def test_run_ask_forwards_a_tool_event_observer(monkeypatch) -> None:
+    recorded: dict[str, object] = {}
+
+    def observer(_kind: str, _data: dict[str, object]) -> None:
+        """Observe agent tool lifecycle events."""
+
+    def run_turn(_prompt: str, _hooks: ToolExecutionHooks, **kwargs: object) -> TurnResult:
+        recorded.update(kwargs)
+        return _turn()
+
+    monkeypatch.setattr(service, "_run_agent_turn", run_turn)
+
+    outcome = service.run_ask(
+        "prompt",
+        allowed_tools=(),
+        bypass_approvals=False,
+        tool_event_observer=observer,
+    )
+
+    assert outcome.status is AskStatus.SUCCESS
+    assert recorded["tool_event_observer"] is observer
 
 
 def test_agent_turn_closes_ephemeral_session_after_failure(monkeypatch) -> None:
@@ -177,8 +200,38 @@ def test_agent_turn_binds_hooks_and_restricts_capabilities_via_start(monkeypatch
     assert manager.closed == [(session, False)]
 
 
+def test_agent_turn_passes_tool_events_to_the_default_agent_build(monkeypatch) -> None:
+    manager = _FakeSessionManager()
+    session = _FakeSession()
+    recorded: dict[str, object] = {}
+
+    class _RecordingAgentSession:
+        @classmethod
+        def start(cls, _config: object, **kwargs: object) -> _RecordingAgentSession:
+            recorded.update(kwargs)
+            return cls()
+
+        @property
+        def bound_session(self) -> _FakeSession:
+            return session
+
+        def chat_until_goal(self, _prompt: str) -> _GoalRun:
+            return _GoalRun(_turn())
+
+    def observer(_kind: str, _data: dict[str, object]) -> None:
+        """Observe agent tool lifecycle events."""
+
+    monkeypatch.setattr(service, "SessionManager", lambda: manager)
+    monkeypatch.setattr(service, "AgentSession", _RecordingAgentSession)
+
+    service._run_agent_turn("hello", ToolExecutionHooks(), tool_event_observer=observer)
+
+    assert recorded["tool_event_observer"] is observer
+    assert manager.closed == [(session, False)]
+
+
 def test_run_ask_reports_denial_before_agent_failure(monkeypatch) -> None:
-    def deny_then_fail(_prompt: str, hooks) -> TurnResult:
+    def deny_then_fail(_prompt: str, hooks, **_kwargs: object) -> TurnResult:
         assert hooks.before_tool_call is not None
         decision = hooks.before_tool_call(_risky_request())
         assert decision is not None and decision.blocked
@@ -200,7 +253,7 @@ def test_run_ask_reports_denial_before_agent_failure(monkeypatch) -> None:
 def test_chat_only_tool_denial_suggests_valid_authorized_rerun(monkeypatch) -> None:
     request = _chat_only_request()
 
-    def run_tool(_prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
+    def run_tool(_prompt: str, hooks: ToolExecutionHooks, **_kwargs: object) -> TurnResult:
         assert hooks.before_tool_call is not None
         decision = hooks.before_tool_call(request)
         assert decision is not None
@@ -235,7 +288,7 @@ def test_run_ask_maps_hosted_credit_exhaustion_to_nonzero_upgrade_error(
 
     upgrade_url = "https://app.opensre.test/usage"
 
-    def exhaust_credits(_prompt: str, _hooks: ToolExecutionHooks) -> TurnResult:
+    def exhaust_credits(_prompt: str, _hooks: ToolExecutionHooks, **_kwargs: object) -> TurnResult:
         raise OpenSRECreditsExhaustedError(
             "OpenSRE hosted credits are exhausted.",
             upgrade_url=upgrade_url,
@@ -256,14 +309,14 @@ def test_run_ask_maps_incomplete_and_cancelled_turns(monkeypatch) -> None:
     monkeypatch.setattr(
         service,
         "_run_agent_turn",
-        lambda _prompt, _hooks: _turn(""),
+        lambda _prompt, _hooks, **_kwargs: _turn(""),
     )
     incomplete = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
 
     monkeypatch.setattr(
         service,
         "_run_agent_turn",
-        lambda _prompt, _hooks: _turn("stopped", cancelled=True),
+        lambda _prompt, _hooks, **_kwargs: _turn("stopped", cancelled=True),
     )
     cancelled = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
 
@@ -278,7 +331,7 @@ def test_run_ask_maps_incomplete_and_cancelled_turns(monkeypatch) -> None:
     [(signal.SIGINT, AskExitCode.SIGINT), (signal.SIGTERM, AskExitCode.SIGTERM)],
 )
 def test_run_ask_maps_signals(monkeypatch, signum: int, exit_code: AskExitCode) -> None:
-    def raise_signal(_prompt: str, _hooks) -> TurnResult:
+    def raise_signal(_prompt: str, _hooks, **_kwargs: object) -> TurnResult:
         raise AskSignal(signum)
 
     monkeypatch.setattr(service, "_run_agent_turn", raise_signal)

--- a/tests/core/agent_harness/test_headless_build.py
+++ b/tests/core/agent_harness/test_headless_build.py
@@ -147,6 +147,25 @@ def test_default_headless_build_takes_the_hosts_tool_provider_and_forwards_the_l
     assert isinstance(bare._tools, DefaultToolProvider)  # noqa: SLF001
 
 
+def test_default_headless_build_forwards_tool_events_to_the_default_provider() -> None:
+    from core.agent_harness.tools.tool_provider import DefaultToolProvider
+
+    session = SessionCore(store=InMemorySessionStore())
+
+    def observer(_kind: str, _data: dict[str, object]) -> None:
+        """Observe default-provider tool events."""
+
+    tools = DefaultHeadlessBuild(
+        session=session,
+        output=BufferOutputSink(),
+        tool_event_observer=observer,
+    ).tools()
+
+    assert isinstance(tools, DefaultToolProvider)
+    assert tools._observer_factory is not None  # noqa: SLF001
+    assert tools._observer_factory("investigate") is observer  # noqa: SLF001
+
+
 def test_a_stage_override_replaces_the_agent_stage() -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
Fixes #6195

#### Describe the changes you have made in this PR -

- Show a transient, elapsed-time progress spinner for interactive `opensre ask` runs.
- Use the shared terminal spinner frames and semantic colors, with a generic `Thinking…` phase, specific tool activity, and a neutral batch count when several tools are requested. Tool inputs are never displayed.
- Keep final results on stdout and disable progress for redirected or `--json` output.
- Thread the existing tool-event observer through the default headless build and document the behavior.

### Demo/Screenshot for feature changes and bug fixes -

<img width="368" height="96" alt="image" src="https://github.com/user-attachments/assets/e6103599-b29a-4ac3-8c1a-f446492098ad" />

[Screencast from 2026-09-11 21-02-16.webm](https://github.com/user-attachments/assets/fbaea5ca-d4e6-4838-9eef-2acf90857d62)


Interactive terminal example:

```text

⠋ Thinking…                      0:00:00
⠋ Invoking tools… · grafana query 0:00:01
⠋ Thinking…                      0:00:02
```

The display is transient and clears before the final response is rendered.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The CLI owns a terminal-only Rich progress display, while the shared harness exposes its existing action-tool observer through the default build. The display starts before the heavier agent service is imported, uses the shared terminal theme and spinner frames, and leaves a breathing row before the transient status. I chose stderr-only UI instead of streaming intermediate model output so scripts, pipes, and `--json` retain their existing stable contracts.

Validation:

- `uv run python -m pytest tests/cli/test_ask_command.py tests/cli/test_ask_service.py tests/cli/test_ask_progress.py tests/core/agent_harness/test_headless_build.py -q`
- `make lint`
- `make format-check`
- `make typecheck`

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


