### PR TITLE
chore(ci): expand PR size label thresholds

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -37,9 +37,9 @@ jobs:
             // #FBCA04, size:large #D93F0B, size:extra-large #B60205) — recreate
             // manually with `gh label create` if one is ever deleted.
             const SIZES = [
-              { name: "size:small", max: 99 },
-              { name: "size:medium", max: 499 },
-              { name: "size:large", max: 1999 },
+              { name: "size:small", max: 199 },
+              { name: "size:medium", max: 999 },
+              { name: "size:large", max: 2999 },
               { name: "size:extra-large", max: Infinity },
             ];
 


### PR DESCRIPTION
Fixes #

_No linked issue; this is a CI workflow maintenance change._

#### Describe the changes you have made in this PR -

- Expand the PR size-label thresholds to small ≤199 lines, medium ≤999 lines, and large ≤2,999 lines.
- Keep changes of 3,000 lines or more classified as extra-large.

### Demo/Screenshot for feature changes and bug fixes -

N/A — workflow-only change. Local boundary checks confirm the expected labels at every threshold.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Updated the existing ordered threshold table only, preserving label names, exclusion behavior, and the workflow's label-replacement logic. The selected bands make sub-1,000-line changes medium at most and reserve extra-large for 3,000+ changed lines, matching the repository's recent PR-size distribution.

---

## Checklist before requesting a review
- [x] I have added a clear PR title; no issue is associated with this workflow maintenance change
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] N/A — this is not a core feature and does not require product tests
- [x] My code follows the project's style guidelines and conventions

## Validation

- `make lint`
- `make format-check`
- `make typecheck`
- Parsed `.github/workflows/pr-size-label.yml` with PyYAML
- Verified label transitions at 199/200, 999/1,000, and 2,999/3,000 changed lines
