### PR TITLE
fix(cli): keep ask tool output concise

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -110,7 +110,7 @@ repository-wide test result.
 The required automated pull-request execution gate has a p90 target of 90
 seconds. Static checks, cached typechecking, duration-balanced pytest shards,
 and interactive-shell checks run concurrently. Automated and
-human review completion, including Greptile and Codex, remains a separate merge
+human review completion, including Greptile and Codex when available, remains a separate merge
 requirement and is not part of that execution-time SLO.
 
 Pull requests run the complete test selection without coverage instrumentation;
@@ -131,7 +131,7 @@ revert and must not be reported as successful delivery.
 Opening a pull request does not end the validation cycle. Follow it through until
 the repository's merge requirements are satisfied: required GitHub checks are
 green, actionable human or automated review feedback (including Greptile and
-Codex) is
+Codex when available) is
 addressed, and resolved conversations are closed out.
 
 Agents: the always-on rule lives in [AGENTS.md — CI failures and tests](AGENTS.md).
@@ -148,11 +148,10 @@ finding, reply with the rationale and resolve the thread without changing code.
 After each completed PR update, once commits are pushed, the PR description is
 current, and addressed threads are resolved, trigger the required automated
 reviews. Follow [CONTRIBUTING.md](CONTRIBUTING.md#greptile-code-review) to
-request Greptile; repeat until it reports 5/5 with no unresolved comments. Also
-request a Codex review with `@codex review` and wait for its review of the
-current head commit to complete. Address and resolve every actionable Codex
-thread, then request another review of the updated head. Do not re-trigger
-either reviewer while its review is already running.
+request Greptile; repeat until it reports 5/5 with no unresolved comments. If
+Codex review is available for the repository, request it with `@codex review`
+and address its actionable feedback. Do not re-trigger either reviewer while
+its review is already running.
 
 Use relevant built-in capabilities or locally installed skills, when available,
 for PR monitoring, CI diagnosis, and review remediation rather than duplicating

--- a/CI.md
+++ b/CI.md
@@ -110,7 +110,7 @@ repository-wide test result.
 The required automated pull-request execution gate has a p90 target of 90
 seconds. Static checks, cached typechecking, duration-balanced pytest shards,
 and interactive-shell checks run concurrently. Automated and
-human review completion, including Greptile, remains a separate merge
+human review completion, including Greptile and Codex, remains a separate merge
 requirement and is not part of that execution-time SLO.
 
 Pull requests run the complete test selection without coverage instrumentation;
@@ -130,7 +130,8 @@ revert and must not be reported as successful delivery.
 
 Opening a pull request does not end the validation cycle. Follow it through until
 the repository's merge requirements are satisfied: required GitHub checks are
-green, actionable human or automated review feedback (including Greptile) is
+green, actionable human or automated review feedback (including Greptile and
+Codex) is
 addressed, and resolved conversations are closed out.
 
 Agents: the always-on rule lives in [AGENTS.md — CI failures and tests](AGENTS.md).
@@ -145,10 +146,13 @@ fix, reply, and resolve the addressed thread. For an incorrect or non-actionable
 finding, reply with the rationale and resolve the thread without changing code.
 
 After each completed PR update, once commits are pushed, the PR description is
-current, and addressed threads are resolved, trigger a Greptile re-review by
-following [CONTRIBUTING.md](CONTRIBUTING.md#greptile-code-review). Repeat until
-Greptile reports 5/5 with no unresolved comments. Do not re-trigger while a
-review is already running.
+current, and addressed threads are resolved, trigger the required automated
+reviews. Follow [CONTRIBUTING.md](CONTRIBUTING.md#greptile-code-review) to
+request Greptile; repeat until it reports 5/5 with no unresolved comments. Also
+request a Codex review with `@codex review` and wait for its review of the
+current head commit to complete. Address and resolve every actionable Codex
+thread, then request another review of the updated head. Do not re-trigger
+either reviewer while its review is already running.
 
 Use relevant built-in capabilities or locally installed skills, when available,
 for PR monitoring, CI diagnosis, and review remediation rather than duplicating

--- a/docs/headless-cli.mdx
+++ b/docs/headless-cli.mdx
@@ -18,8 +18,9 @@ opensre ask "why did checkout latency increase today?"
 When both output streams are attached to a terminal, `ask` starts with a
 `Thinking…` spinner with elapsed time. It switches to the active diagnostic
 tool (or a neutral tool count for a batch) when tools are invoked. The final
-answer remains on standard output. Piped and `--json` runs do not emit progress,
-so their output remains machine-readable.
+answer remains on standard output without echoing raw tool transcripts. Piped
+and `--json` runs do not emit progress, so their output remains
+machine-readable.
 
 Pass `-` as the prompt to read all of standard input:
 

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import signal
 import threading
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from io import StringIO
@@ -90,7 +92,12 @@ class _CancellableConsole:
 
 
 class _AskOutputSink:
-    """Discard intermediate rendering while preserving streamed answer text."""
+    """Discard intermediate rendering while retaining the terminal-visible answer."""
+
+    def __init__(self) -> None:
+        self._rendered_responses: list[str] = []
+        self._rendered_errors: list[str] = []
+        self._completed_turn = False
 
     def print(self, message: str = "") -> None:
         _ = message
@@ -99,7 +106,8 @@ class _AskOutputSink:
         _ = label
 
     def render_error(self, message: str) -> None:
-        _ = message
+        if message.strip():
+            self._rendered_errors.append(message)
 
     def stream(
         self,
@@ -110,10 +118,49 @@ class _AskOutputSink:
         defer_want_me_to_closer: bool = False,
     ) -> str:
         _ = (label, suppress_if_starts_with, defer_want_me_to_closer)
-        return "".join(str(chunk) for chunk in chunks)
+        response = "".join(str(chunk) for chunk in chunks)
+        if response.strip():
+            self._rendered_responses.append(response)
+        return response
 
     def finish_streamed_response(self, answer: str) -> None:
         _ = answer
+
+    def mark_turn_complete(self) -> None:
+        """Mark that the real agent turn drove this sink."""
+        self._completed_turn = True
+
+    @property
+    def rendered_response(self) -> str:
+        """Return only the response or error the interactive terminal would render."""
+        rendered = self._rendered_responses or self._rendered_errors
+        return "\n\n".join(rendered).strip()
+
+    @property
+    def completed_turn(self) -> bool:
+        """Whether this sink observed a completed real agent turn."""
+        return self._completed_turn
+
+
+@contextmanager
+def _ask_log_scope() -> Iterator[None]:
+    """Keep unrendered internal warnings out of a normal one-shot response."""
+    root = logging.getLogger()
+    if root.handlers:
+        yield
+        return
+
+    # A normal CLI process does not configure root logging. Without a handler,
+    # Python's ``lastResort`` handler writes warnings such as a failed shell
+    # probe directly to stderr, ahead of the answer renderer. The tool result
+    # remains in the agent context; the final response is the user-facing
+    # diagnostic. Do not override an embedding host's configured logging.
+    handler = logging.NullHandler()
+    root.addHandler(handler)
+    try:
+        yield
+    finally:
+        root.removeHandler(handler)
 
 
 def _restrict_ask_capabilities(session: SessionCore) -> None:
@@ -127,14 +174,15 @@ def _run_agent_turn(
     hooks: ToolExecutionHooks,
     *,
     tool_event_observer: ToolEventObserver | None = None,
+    output: _AskOutputSink | None = None,
 ) -> TurnResult:
     manager = SessionManager()
-    output = _AskOutputSink()
+    output = output or _AskOutputSink()
     cancel_event = ensure_turn_cancel(output)
     console = _CancellableConsole(cancel_event)
     session: SessionCore | None = None
     try:
-        with ask_signal_scope(cancel_event):
+        with ask_signal_scope(cancel_event), _ask_log_scope():
             agent_session = AgentSession.start(
                 SessionConfig(
                     load_env=True,
@@ -154,13 +202,15 @@ def _run_agent_turn(
             session = agent_session.bound_session
             # chat_until_goal, not chat: the agent can attach a session goal,
             # which must run to completion rather than stop after one turn.
-            return agent_session.chat_until_goal(prompt).last_result
+            result = agent_session.chat_until_goal(prompt).last_result
+            output.mark_turn_complete()
+            return result
     finally:
         if session is not None:
             manager.close(session, extract_memory=False)
 
 
-def _successful_turn(result: TurnResult) -> bool:
+def _successful_turn(result: TurnResult, response: str) -> bool:
     action = result.action_result
     action_ok = (
         action.handled
@@ -169,10 +219,11 @@ def _successful_turn(result: TurnResult) -> bool:
         and action.accounting_status == "completed"
     )
     return bool(
-        (result.answered or action_ok)
+        action.accounting_status == "completed"
+        and (result.answered or action_ok)
         and not action.hit_iteration_cap
         and not result.cancelled
-        and result.primary_response_text
+        and response
     )
 
 
@@ -226,13 +277,19 @@ def run_ask(
 ) -> AskOutcome:
     """Execute one ask turn with invocation-scoped approval authority."""
     tracker = ApprovalTracker()
+    output = _AskOutputSink()
     hooks = build_approval_hooks(
         allowed_tools=allowed_tools,
         bypass_approvals=bypass_approvals,
         tracker=tracker,
     )
     try:
-        result = _run_agent_turn(prompt, hooks, tool_event_observer=tool_event_observer)
+        result = _run_agent_turn(
+            prompt,
+            hooks,
+            tool_event_observer=tool_event_observer,
+            output=output,
+        )
     except AskSignal as exc:
         return cancelled_outcome(exc.signum)
     except OpenSREError as exc:
@@ -275,20 +332,23 @@ def run_ask(
             exit_code=AskExitCode.ERROR,
         )
 
+    # The shared turn result retains tool history for session persistence. A
+    # one-shot CLI must instead print the same concise response the terminal
+    # surface selected, never raw shell stdout/stderr or command transcripts.
+    response = output.rendered_response if output.completed_turn else result.primary_response_text
     denied = _approval_denied_outcome(
         tracker,
-        response=result.primary_response_text,
+        response=response,
     )
     if denied is not None:
         return denied
     if result.cancelled:
         return AskOutcome(
             status=AskStatus.CANCELLED,
-            response=result.primary_response_text or "Agent execution cancelled.",
+            response=response or "Agent execution cancelled.",
             exit_code=AskExitCode.SIGINT,
         )
-    if not _successful_turn(result):
-        response = result.primary_response_text
+    if not _successful_turn(result, response):
         return AskOutcome(
             status=AskStatus.ERROR,
             response=response,
@@ -297,7 +357,7 @@ def run_ask(
         )
     return AskOutcome(
         status=AskStatus.SUCCESS,
-        response=result.primary_response_text,
+        response=response,
     )
 
 

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -95,8 +95,7 @@ class _AskOutputSink:
     """Discard intermediate rendering while retaining the terminal-visible answer."""
 
     def __init__(self) -> None:
-        self._rendered_responses: list[str] = []
-        self._rendered_errors: list[str] = []
+        self._rendered_event = ""
         self._completed_turn = False
 
     def print(self, message: str = "") -> None:
@@ -107,7 +106,7 @@ class _AskOutputSink:
 
     def render_error(self, message: str) -> None:
         if message.strip():
-            self._rendered_errors.append(message)
+            self._rendered_event = message
 
     def stream(
         self,
@@ -120,7 +119,7 @@ class _AskOutputSink:
         _ = (label, suppress_if_starts_with, defer_want_me_to_closer)
         response = "".join(str(chunk) for chunk in chunks)
         if response.strip():
-            self._rendered_responses.append(response)
+            self._rendered_event = response
         return response
 
     def finish_streamed_response(self, answer: str) -> None:
@@ -133,8 +132,7 @@ class _AskOutputSink:
     @property
     def rendered_response(self) -> str:
         """Return only the response or error the interactive terminal would render."""
-        rendered = self._rendered_responses or self._rendered_errors
-        return "\n\n".join(rendered).strip()
+        return self._rendered_event.strip()
 
     @property
     def completed_turn(self) -> bool:
@@ -351,7 +349,7 @@ def run_ask(
     if not _successful_turn(result, response):
         return AskOutcome(
             status=AskStatus.ERROR,
-            response=response,
+            response="",
             error=AskError(message=response or "The agent did not complete the request."),
             exit_code=AskExitCode.ERROR,
         )

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -22,6 +22,7 @@ from core.agent_harness import (
     TurnResult,
 )
 from core.agent_harness.ports import ToolEventObserver
+from core.agent_harness.session_goal import SessionGoal, SessionGoalReason, SessionGoalStatus
 from core.agent_harness.spi.cancel import ensure_turn_cancel
 from core.tool import ToolExecutionHooks
 from infrastructure.errors import OpenSREError
@@ -129,6 +130,10 @@ class _AskOutputSink:
         """Mark that the real agent turn drove this sink."""
         self._completed_turn = True
 
+    def clear_rendered_event(self) -> None:
+        """Discard a prior outer turn's response before the next one starts."""
+        self._rendered_event = ""
+
     @property
     def rendered_response(self) -> str:
         """Return only the response or error the interactive terminal would render."""
@@ -167,6 +172,12 @@ def _restrict_ask_capabilities(session: SessionCore) -> None:
         session.available_capabilities[capability] = ()
 
 
+def _clear_prior_goal_response(output: _AskOutputSink, goal: SessionGoal) -> None:
+    """Prevent an earlier goal turn from standing in for a silent final turn."""
+    if goal.status == SessionGoalStatus.ACTIVE and SessionGoalReason.is_working(goal.last_reason):
+        output.clear_rendered_event()
+
+
 def _run_agent_turn(
     prompt: str,
     hooks: ToolExecutionHooks,
@@ -200,7 +211,10 @@ def _run_agent_turn(
             session = agent_session.bound_session
             # chat_until_goal, not chat: the agent can attach a session goal,
             # which must run to completion rather than stop after one turn.
-            result = agent_session.chat_until_goal(prompt).last_result
+            result = agent_session.chat_until_goal(
+                prompt,
+                on_progress=lambda goal: _clear_prior_goal_response(output, goal),
+            ).last_result
             output.mark_turn_complete()
             return result
     finally:

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -22,8 +22,8 @@ from core.agent_harness import (
     TurnResult,
 )
 from core.agent_harness.ports import ToolEventObserver
-from core.agent_harness.session_goal import SessionGoal, SessionGoalReason, SessionGoalStatus
 from core.agent_harness.spi.cancel import ensure_turn_cancel
+from core.agent_harness.spi.session_goal import SessionGoal, SessionGoalReason, SessionGoalStatus
 from core.tool import ToolExecutionHooks
 from infrastructure.errors import OpenSREError
 from surfaces.cli.ask.approval import ApprovalTracker, build_approval_hooks

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import signal
 import threading
 
@@ -136,6 +137,95 @@ def test_run_ask_forwards_a_tool_event_observer(monkeypatch) -> None:
 
     assert outcome.status is AskStatus.SUCCESS
     assert recorded["tool_event_observer"] is observer
+
+
+def test_run_ask_returns_the_rendered_answer_not_raw_tool_history(monkeypatch) -> None:
+    """One-shot output must not dump command evidence retained by the harness."""
+
+    def run_turn(_prompt: str, _hooks: ToolExecutionHooks, **kwargs: object) -> TurnResult:
+        output = kwargs["output"]
+        assert isinstance(output, service._AskOutputSink)
+        output.stream(label="OpenSRE", chunks=iter(["The repository is an SRE agent framework."]))
+        output.mark_turn_complete()
+        return _turn("git remote -v\nREADME contents\nThe repository is an SRE agent framework.")
+
+    monkeypatch.setattr(service, "_run_agent_turn", run_turn)
+
+    outcome = service.run_ask("what is this repo doing?", allowed_tools=(), bypass_approvals=False)
+
+    assert outcome.status is AskStatus.SUCCESS
+    assert outcome.response == "The repository is an SRE agent framework."
+    assert "git remote" not in outcome.response
+
+
+def test_run_ask_preserves_a_rendered_agent_error(monkeypatch) -> None:
+    """Suppressing raw tool history must not hide an actionable agent error."""
+
+    def run_turn(_prompt: str, _hooks: ToolExecutionHooks, **kwargs: object) -> TurnResult:
+        output = kwargs["output"]
+        assert isinstance(output, service._AskOutputSink)
+        output.render_error("The configured model is unavailable.")
+        output.mark_turn_complete()
+        return TurnResult(
+            final_intent="agent_completed",
+            action_result=ToolCallingTurnResult(
+                planned_count=0,
+                executed_count=0,
+                executed_success_count=0,
+                has_unhandled_clause=True,
+                handled=False,
+                response_text="raw internal diagnostic",
+                accounting_status="not_run",
+            ),
+            assistant_response_text="raw internal diagnostic",
+        )
+
+    monkeypatch.setattr(service, "_run_agent_turn", run_turn)
+
+    outcome = service.run_ask("why is checkout slow?", allowed_tools=(), bypass_approvals=False)
+
+    assert outcome.status is AskStatus.ERROR
+    assert outcome.response == "The configured model is unavailable."
+    assert "raw internal diagnostic" not in outcome.response
+
+
+def test_ask_log_scope_suppresses_unrendered_fallback_warnings(monkeypatch) -> None:
+    """Internal tool warnings must not bypass the one-shot answer renderer."""
+
+    class _CaptureHandler(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.messages: list[str] = []
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.messages.append(record.getMessage())
+
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    logger = logging.getLogger("tests.cli.ask.fallback_warning")
+    original_logger_handlers = list(logger.handlers)
+    original_logger_propagate = logger.propagate
+    original_logger_level = logger.level
+    capture = _CaptureHandler()
+    for handler in original_handlers:
+        root.removeHandler(handler)
+    logger.handlers.clear()
+    logger.propagate = True
+    logger.setLevel(logging.WARNING)
+    root.setLevel(logging.WARNING)
+    monkeypatch.setattr(logging, "lastResort", capture)
+    try:
+        with service._ask_log_scope():
+            logger.warning("subprocess error: exit 1")
+        assert capture.messages == []
+    finally:
+        root.setLevel(original_level)
+        for handler in original_handlers:
+            root.addHandler(handler)
+        logger.handlers[:] = original_logger_handlers
+        logger.propagate = original_logger_propagate
+        logger.setLevel(original_logger_level)
 
 
 def test_agent_turn_closes_ephemeral_session_after_failure(monkeypatch) -> None:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -6,6 +6,7 @@ import threading
 
 import pytest
 
+from core.agent_harness.session_goal import SessionGoal, SessionGoalReason, SessionGoalStatus
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.domain.types.tools import ToolSurface
 from core.llm.types import ToolCall
@@ -95,7 +96,7 @@ class _FakeAgentSession:
     def bound_session(self) -> _FakeSession:
         return type(self).session
 
-    def chat_until_goal(self, _prompt: str) -> object:
+    def chat_until_goal(self, _prompt: str, **_kwargs: object) -> object:
         raise RuntimeError("turn failed")
 
 
@@ -202,6 +203,33 @@ def test_ask_output_sink_uses_the_latest_rendered_event() -> None:
     assert output.rendered_response == "The final model request failed."
 
 
+def test_ask_output_sink_clears_an_earlier_goal_response_before_the_next_turn() -> None:
+    """A silent final goal turn must not reuse its predecessor's response."""
+    output = service._AskOutputSink()
+    output.stream(label="OpenSRE", chunks=iter(["Investigation update."]))
+    goal = SessionGoal(
+        condition="investigate the alert",
+        status=SessionGoalStatus.ACTIVE,
+    ).with_reason(SessionGoalReason.working_session_turn(2, 3))
+
+    service._clear_prior_goal_response(output, goal)
+
+    assert output.rendered_response == ""
+
+
+def test_ask_output_sink_keeps_a_final_goal_response() -> None:
+    output = service._AskOutputSink()
+    final_goal = SessionGoal(
+        condition="investigate the alert",
+        status=SessionGoalStatus.ACHIEVED,
+    )
+    output.stream(label="OpenSRE", chunks=iter(["Final investigation summary."]))
+
+    service._clear_prior_goal_response(output, final_goal)
+
+    assert output.rendered_response == "Final investigation summary."
+
+
 def test_ask_log_scope_suppresses_unrendered_fallback_warnings(monkeypatch) -> None:
     """Internal tool warnings must not bypass the one-shot answer renderer."""
 
@@ -280,7 +308,7 @@ def test_agent_turn_binds_hooks_and_restricts_capabilities_via_start(monkeypatch
         def bound_session(self) -> _FakeSession:
             return session
 
-        def chat_until_goal(self, prompt: str) -> _GoalRun:
+        def chat_until_goal(self, prompt: str, **_kwargs: object) -> _GoalRun:
             # chat_until_goal, not chat: ask must run the session-goal loop so a
             # multi-step turn completes instead of stopping after the first.
             recorded["prompt"] = prompt
@@ -303,6 +331,42 @@ def test_agent_turn_binds_hooks_and_restricts_capabilities_via_start(monkeypatch
     assert manager.closed == [(session, False)]
 
 
+def test_agent_turn_discards_a_previous_goal_response_before_a_silent_final_turn(
+    monkeypatch,
+) -> None:
+    manager = _FakeSessionManager()
+    session = _FakeSession()
+
+    class _GoalAgentSession:
+        @classmethod
+        def start(cls, _config: object, **_kwargs: object) -> _GoalAgentSession:
+            return cls()
+
+        @property
+        def bound_session(self) -> _FakeSession:
+            return session
+
+        def chat_until_goal(self, _prompt: str, **kwargs: object) -> _GoalRun:
+            on_progress = kwargs["on_progress"]
+            assert callable(on_progress)
+            progress = SessionGoal(
+                condition="investigate the alert",
+                status=SessionGoalStatus.ACTIVE,
+            ).with_reason(SessionGoalReason.working_session_turn(2, 3))
+            on_progress(progress)
+            return _GoalRun(_turn("raw turn history"))
+
+    output = service._AskOutputSink()
+    output.stream(label="OpenSRE", chunks=iter(["Investigation update."]))
+    monkeypatch.setattr(service, "SessionManager", lambda: manager)
+    monkeypatch.setattr(service, "AgentSession", _GoalAgentSession)
+
+    service._run_agent_turn("hello", ToolExecutionHooks(), output=output)
+
+    assert output.rendered_response == ""
+    assert manager.closed == [(session, False)]
+
+
 def test_agent_turn_passes_tool_events_to_the_default_agent_build(monkeypatch) -> None:
     manager = _FakeSessionManager()
     session = _FakeSession()
@@ -318,7 +382,7 @@ def test_agent_turn_passes_tool_events_to_the_default_agent_build(monkeypatch) -
         def bound_session(self) -> _FakeSession:
             return session
 
-        def chat_until_goal(self, _prompt: str) -> _GoalRun:
+        def chat_until_goal(self, _prompt: str, **_kwargs: object) -> _GoalRun:
             return _GoalRun(_turn())
 
     def observer(_kind: str, _data: dict[str, object]) -> None:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -6,7 +6,7 @@ import threading
 
 import pytest
 
-from core.agent_harness.session_goal import SessionGoal, SessionGoalReason, SessionGoalStatus
+from core.agent_harness.spi.session_goal import SessionGoal, SessionGoalReason, SessionGoalStatus
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.domain.types.tools import ToolSurface
 from core.llm.types import ToolCall

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -185,8 +185,21 @@ def test_run_ask_preserves_a_rendered_agent_error(monkeypatch) -> None:
     outcome = service.run_ask("why is checkout slow?", allowed_tools=(), bypass_approvals=False)
 
     assert outcome.status is AskStatus.ERROR
-    assert outcome.response == "The configured model is unavailable."
-    assert "raw internal diagnostic" not in outcome.response
+    assert outcome.response == ""
+    assert outcome.error is not None
+    assert outcome.error.message == "The configured model is unavailable."
+
+
+def test_ask_output_sink_uses_the_latest_rendered_event() -> None:
+    """A multi-turn goal exposes only its final response or error."""
+    output = service._AskOutputSink()
+
+    output.stream(label="OpenSRE", chunks=iter(["First investigation update."]))
+    output.stream(label="OpenSRE", chunks=iter(["Final investigation summary."]))
+    assert output.rendered_response == "Final investigation summary."
+
+    output.render_error("The final model request failed.")
+    assert output.rendered_response == "The final model request failed."
 
 
 def test_ask_log_scope_suppresses_unrendered_fallback_warnings(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #6204

#### Describe the changes you have made in this PR -

`opensre ask` previously rendered the harness's durable action history as its final output. When an authorized `shell_run` inspected a repository, that meant raw command output and fallback warning logs appeared before the model's synthesized answer.

This change:

- captures the response/error selected by the terminal output sink and uses it for the one-shot result;
- preserves user-facing agent errors while keeping raw tool evidence in the agent context only;
- prevents Python's unconfigured fallback logger from printing internal warnings directly to the terminal during `ask`; and
- treats a non-run action phase as an error instead of a successful answer.
- clears a prior goal-turn response before the next goal turn so a silent final turn cannot replay stale output; and
- records Codex review completion alongside Greptile in `CI.md`.

### Demo/Screenshot for feature changes and bug fixes -

Before, a repository question could emit hundreds of lines such as:

```text
subprocess error: ✗ exit 1
[agent] trimmed low-value tool pair to fit context budget
<raw git / ls / README transcript …>
<eventual agent summary>
```

After, the same invocation keeps its live activity row and prints only the concise answer (or the rendered actionable error):

```text
→ uv run opensre ask "what is this repo doing" --dangerously-bypass-approvals

⠋ Thinking… 0:00:01
The repository is an SRE agent framework.
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The shared harness must retain tool history for agent context and session persistence, so changing that data would affect other surfaces. Instead, the `ask` surface captures the already-curated terminal response from its output sink and renders that. This keeps the fix localized while preserving final answers and actionable agent errors. A temporary null root handler prevents only Python's otherwise-unconfigured fallback logger from bypassing the same renderer; configured embedding hosts are left unchanged.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

