### PR TITLE
fix(shell): use host shell with session-scoped cwd

### DIFF
--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -853,7 +853,7 @@ def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:
     console, buf = _capture()
 
     assert action_turn.run_action_tool_turn("execute false", session, console).handled is True
-    assert calls == [(["false"], _EXPECTED_POPEN_KWARGS)]
+    assert calls == [(_expected_shell_argv("false"), _EXPECTED_POPEN_KWARGS)]
     assert session.history[-1] == {
         "type": "shell",
         "text": "false",
@@ -962,7 +962,7 @@ def test_execute_cli_actions_handles_path_with_spaces_run_phrase() -> None:
     assert "/tmp/file with spaces.txt" in output
 
 
-def test_execute_cli_actions_backtick_shell_preserves_space_path_token(monkeypatch: object) -> None:
+def test_execute_cli_actions_runs_space_path_through_host_shell(monkeypatch: object) -> None:
     calls = _install_fake_popen(monkeypatch, stdout="done\n")
 
     session = Session()
@@ -974,11 +974,7 @@ def test_execute_cli_actions_backtick_shell_preserves_space_path_token(monkeypat
         ).handled
         is True
     )
-    # On Windows, shlex with posix=False preserves quotes for tokens with spaces.
-    # Both Windows and Posix parsers correctly strip outer quotes from tokens
-    # following the policy.py _strip_outer_quotes logic.
-    expected_path = "/tmp/file with spaces.txt"
-    assert calls[0][0] == ["cat", expected_path]
+    assert calls[0][0] == _expected_shell_argv('cat "/tmp/file with spaces.txt"')
 
 
 def test_execute_cli_actions_counts_planned_and_executed(monkeypatch: object) -> None:

--- a/tests/interactive_shell/runtime/test_subprocess_runner.py
+++ b/tests/interactive_shell/runtime/test_subprocess_runner.py
@@ -190,6 +190,45 @@ def test_run_shell_command_quiet_cd_hides_cwd(
     assert result["response_text"] == "/tmp/example"
 
 
+def test_run_shell_command_does_not_hijack_compound_cd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chdir_calls: list[Path] = []
+    execute_calls: list[dict[str, object]] = []
+
+    def _chdir(path: Path) -> None:
+        chdir_calls.append(path)
+
+    def _fake_execute(**kwargs: object) -> ShellExecutionResult:
+        execute_calls.append(kwargs)
+        return ShellExecutionResult(
+            command="cd /tmp&&pwd",
+            argv=None,
+            stdout="/tmp\n",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            truncated=False,
+            executed_with_shell=True,
+        )
+
+    monkeypatch.setattr("tools.interactive_shell.shell.runner.os.chdir", _chdir)
+    monkeypatch.setattr(
+        "tools.interactive_shell.shell.execution.execute_shell_command",
+        _fake_execute,
+    )
+
+    session = Session()
+    console = Console(file=io.StringIO(), force_terminal=False)
+
+    result = run_shell_command("cd /tmp&&pwd", _presenter(session, console))
+
+    assert chdir_calls == []
+    assert execute_calls[0]["command"] == "cd /tmp&&pwd"
+    assert execute_calls[0]["use_shell"] is True
+    assert result["stdout"] == "/tmp"
+
+
 def test_run_cd_command_reports_chdir_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     captured_errors: list[BaseException] = []
 

--- a/tests/interactive_shell/shell/test_execution.py
+++ b/tests/interactive_shell/shell/test_execution.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -101,7 +103,7 @@ def test_execute_quoted_heredoc_through_shell() -> None:
     command = """python3 - <<'PY'
 print("hello-heredoc")
 PY"""
-    parsed = parse_shell_command(command, is_windows=False)
+    parsed = parse_shell_command(command)
     assert parsed.use_shell is True
 
     result = execute_shell_command(
@@ -115,3 +117,23 @@ PY"""
     assert result.timed_out is False
     assert result.exit_code == 0
     assert "hello-heredoc" in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uses POSIX shell syntax")
+def test_execute_compact_shell_script_with_operator_and_redirect(tmp_path: Path) -> None:
+    output_file = tmp_path / "second.txt"
+    command = f"printf one&&printf two>{shlex.quote(str(output_file))}"
+    parsed = parse_shell_command(command)
+
+    result = execute_shell_command(
+        command=parsed.command,
+        argv=parsed.argv,
+        use_shell=parsed.use_shell,
+        timeout_seconds=10,
+        max_output_chars=10_000,
+    )
+
+    assert result.exit_code == 0
+    assert result.executed_with_shell is True
+    assert result.stdout == "one"
+    assert output_file.read_text() == "two"

--- a/tests/interactive_shell/shell/test_shell_parsing.py
+++ b/tests/interactive_shell/shell/test_shell_parsing.py
@@ -1,12 +1,14 @@
 """Tests for interactive-shell command parsing.
 
 Alpha mode removed the shell-command safety policy (allowlist / restricted /
-mutating classification and the deny floor). Parsing now only decides *how* a
-command runs — via ``argv`` or through a shell — and never blocks a command for
-safety. The only non-execution outcome is empty input.
+mutating classification and the deny floor). Every non-empty command now runs
+through the host shell; parsing only preserves standalone REPL builtins such as
+``cd`` and ``pwd``. The only non-execution outcome is empty input.
 """
 
 from __future__ import annotations
+
+import pytest
 
 from tools.interactive_shell.shell.parsing import (
     argv_for_repl_builtin_detection,
@@ -15,7 +17,7 @@ from tools.interactive_shell.shell.parsing import (
 
 
 def test_parse_shell_command_detects_passthrough_prefix() -> None:
-    parsed = parse_shell_command("!echo hello", is_windows=False)
+    parsed = parse_shell_command("!echo hello")
 
     assert parsed.passthrough is True
     assert parsed.use_shell is True
@@ -24,26 +26,26 @@ def test_parse_shell_command_detects_passthrough_prefix() -> None:
     assert parsed.parse_error is None
 
 
-def test_plain_command_uses_argv_without_shell() -> None:
-    parsed = parse_shell_command("rm -rf /tmp/x", is_windows=False)
+def test_plain_command_runs_through_shell() -> None:
+    parsed = parse_shell_command("rm -rf /tmp/x")
 
     assert parsed.passthrough is False
-    assert parsed.use_shell is False
-    assert parsed.argv == ["rm", "-rf", "/tmp/x"]
+    assert parsed.use_shell is True
+    assert parsed.argv is None
     assert parsed.parse_error is None
 
 
 def test_restricted_command_is_no_longer_blocked() -> None:
     """``sudo`` and friends used to be a hard deny; alpha mode just runs them."""
-    parsed = parse_shell_command("sudo systemctl restart nginx", is_windows=False)
+    parsed = parse_shell_command("sudo systemctl restart nginx")
 
-    assert parsed.use_shell is False
-    assert parsed.argv == ["sudo", "systemctl", "restart", "nginx"]
+    assert parsed.use_shell is True
+    assert parsed.argv is None
     assert parsed.parse_error is None
 
 
-def test_operators_run_through_shell_without_block() -> None:
-    parsed = parse_shell_command("ls | wc -l", is_windows=False)
+def test_compact_operators_run_through_shell_without_block() -> None:
+    parsed = parse_shell_command("printf one&&printf two;printf three")
 
     assert parsed.use_shell is True
     assert parsed.passthrough is False
@@ -52,7 +54,7 @@ def test_operators_run_through_shell_without_block() -> None:
 
 
 def test_command_substitution_runs_through_shell() -> None:
-    parsed = parse_shell_command("echo $(date)", is_windows=False)
+    parsed = parse_shell_command("echo $(date)")
 
     assert parsed.use_shell is True
     assert parsed.parse_error is None
@@ -62,7 +64,7 @@ def test_quoted_heredoc_runs_through_shell() -> None:
     command = """python3 - <<'PY'
 print("hello-heredoc")
 PY"""
-    parsed = parse_shell_command(command, is_windows=False)
+    parsed = parse_shell_command(command)
 
     assert parsed.use_shell is True
     assert parsed.argv is None
@@ -74,43 +76,70 @@ def test_unquoted_heredoc_runs_through_shell() -> None:
     command = """cat <<EOF
 line one
 EOF"""
-    parsed = parse_shell_command(command, is_windows=False)
+    parsed = parse_shell_command(command)
 
     assert parsed.use_shell is True
     assert parsed.argv is None
 
 
 def test_unbalanced_quotes_fall_back_to_shell() -> None:
-    parsed = parse_shell_command('echo "unterminated', is_windows=False)
+    parsed = parse_shell_command('echo "unterminated')
 
     assert parsed.use_shell is True
     assert parsed.parse_error is None
 
 
 def test_empty_passthrough_is_parse_error() -> None:
-    parsed = parse_shell_command("!", is_windows=False)
+    parsed = parse_shell_command("!")
 
     assert parsed.parse_error is not None
     assert parsed.passthrough is True
 
 
 def test_empty_command_is_parse_error() -> None:
-    parsed = parse_shell_command("   ", is_windows=False)
+    parsed = parse_shell_command("   ")
 
     assert parsed.parse_error == "empty command."
 
 
 def test_argv_for_repl_builtin_detection_splits_passthrough_for_cd() -> None:
-    parsed = parse_shell_command("!cd /tmp", is_windows=False)
+    parsed = parse_shell_command("!cd /tmp")
     assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) == ["cd", "/tmp"]
 
 
 def test_argv_for_repl_builtin_detection_returns_plain_argv() -> None:
-    parsed = parse_shell_command("pwd", is_windows=False)
+    parsed = parse_shell_command("pwd")
     assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) == ["pwd"]
 
 
 def test_argv_for_repl_builtin_detection_skips_operator_command() -> None:
     """A leading ``cd`` in an operator command must not be hijacked as a builtin."""
-    parsed = parse_shell_command("cd /tmp && ls", is_windows=False)
+    parsed = parse_shell_command("cd /tmp&&ls")
     assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) is None
+
+
+@pytest.mark.parametrize(
+    ("command", "is_windows"),
+    [
+        ("cd {a,b}", False),
+        ("cd /tmp # explanation", False),
+        ("cd %TEMP%", True),
+        ("cd !TEMP!", True),
+    ],
+)
+def test_argv_for_repl_builtin_detection_skips_shell_expansion(
+    command: str,
+    is_windows: bool,
+) -> None:
+    parsed = parse_shell_command(command)
+
+    assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=is_windows) is None
+
+
+def test_argv_for_repl_builtin_detection_keeps_quoted_operator_in_cd_path() -> None:
+    parsed = parse_shell_command("cd 'directory;name'")
+
+    assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) == [
+        "cd",
+        "directory;name",
+    ]

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -54,7 +54,9 @@ def run_shell(*, command: str, context: Any, quiet: bool = False) -> dict[str, A
 shell_run_tool = RegisteredTool(
     name="shell_run",
     description=(
-        "Run a local shell command on this machine. Use for read-only inspection, "
+        "Run a local host-shell command on this machine. The command is evaluated as "
+        "shell syntax, including quoting, expansions, redirects, and command operators. "
+        "Use for read-only inspection, "
         "controlled operational steps, and user-requested local workflows — including "
         "creating files or scripts and executing multi-step sequences, one shell_run call "
         "per step when a step consumes the previous step's output. When the user asks for "
@@ -72,7 +74,7 @@ shell_run_tool = RegisteredTool(
         properties={
             "command": string_property(
                 description=(
-                    "Exact shell command to execute — a diagnostic (for example: `ls`, "
+                    "Exact host-shell command to execute — a diagnostic (for example: `ls`, "
                     "`pwd`, `git status`, `uv run python -m pytest ...`) or one step of a "
                     "local workflow the user asked for (writing a file or script, running "
                     "it, updating state a later step reads). Run a user-requested command "

--- a/tools/interactive_shell/shell/parsing.py
+++ b/tools/interactive_shell/shell/parsing.py
@@ -9,14 +9,15 @@ omitted to keep developer velocity high. See
 ``docs/interactive-shell-action-policy.md`` for the rationale.
 
 This module's only job is to turn command text into a shape the runner can
-execute:
+execute. A ``shell_run`` command is host-shell source, so every non-empty
+command runs through the configured shell. This gives the action tool ordinary
+shell semantics for quoting, expansions, redirection, and operators without
+trying to reproduce shell parsing with partial regular expressions.
 
-* explicit ``!`` passthrough → run the remainder through a shell,
-* commands using shell operators / substitution / heredocs → run through a shell,
-* anything that fails to tokenize → hand the raw string to a shell,
-* everything else → split into ``argv`` and run without a shell (which also lets
-  the runner detect the ``cd`` / ``pwd`` REPL builtins so the working directory
-  persists across turns).
+The REPL still handles a standalone ``cd`` or ``pwd`` itself so a directory
+change persists across turns. That detection uses shell-aware tokenization only
+to decide whether the input is one simple builtin; it never chooses how a
+general command executes.
 
 The only non-execution outcome is a ``parse_error`` for genuinely empty input
 (e.g. a bare ``!``). That is input validation, not a safety guardrail.
@@ -24,27 +25,21 @@ The only non-execution outcome is a ``parse_error`` for genuinely empty input
 
 from __future__ import annotations
 
-import re
 import shlex
 from dataclasses import dataclass
 
 _EXPLICIT_SHELL_PREFIX = "!"
-_SHELL_OPERATOR_RE = re.compile(r"(^|\s)(\|\||&&|[|;<>]|>>|<<|2>)(\s|$)")
-_INLINE_SUBSHELL_RE = re.compile(r"`|\$\(")
-# Heredoc starts such as ``<<'PY'`` or ``<<EOF`` — ``<<`` alone is already covered
-# by ``_SHELL_OPERATOR_RE`` only when followed by whitespace; quoted/unquoted
-# delimiters need an explicit match so ``python3 - <<'PY'`` is not tokenized.
-_HEREDOC_START_RE = re.compile(r"(^|\s)<<-?\s*(?:'[^'\n]+'|\"[^\"\n]+\"|[^\s\\|;&<>]+)")
+_POSIX_SHELL_SYNTAX = frozenset(";&|<>(){}$`#\n\r*?[")
+_WINDOWS_SHELL_SYNTAX = frozenset("&|<>()%!\n\r")
 
 
 @dataclass(frozen=True)
 class ParsedShellCommand:
     """Structured command parsing result.
 
-    ``use_shell`` is True when the command must run through a real shell (explicit
-    ``!`` passthrough, shell operators / substitution, or input that could not be
-    tokenized). ``passthrough`` records only the explicit ``!`` prefix so the
-    runner can surface the "shell passthrough" hint for it.
+    ``use_shell`` is True for every non-empty command: ``shell_run.command`` is
+    host-shell source. ``passthrough`` records only the explicit ``!`` prefix so
+    the runner can surface the "shell passthrough" hint for it.
     """
 
     command: str
@@ -54,17 +49,63 @@ class ParsedShellCommand:
     parse_error: str | None = None
 
 
-def _split_argv(command: str, *, is_windows: bool) -> list[str] | None:
+def _strip_outer_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _split_builtin_argv(command: str, *, is_windows: bool) -> list[str] | None:
+    """Tokenize one potential REPL builtin without losing quoted punctuation."""
     try:
-        return shlex.split(command, posix=not is_windows)
+        lexer = shlex.shlex(
+            command,
+            posix=not is_windows,
+            punctuation_chars=True,
+        )
+        lexer.whitespace_split = True
+        argv = list(lexer)
     except ValueError:
-        try:
-            return shlex.split(command, posix=False)
-        except ValueError:
-            return None
+        return None
+
+    if is_windows:
+        argv = [_strip_outer_quotes(token) for token in argv]
+    return argv
 
 
-def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand:
+def _contains_shell_syntax(command: str, *, is_windows: bool) -> bool:
+    """Return whether ``command`` has unquoted syntax a REPL builtin cannot own."""
+    syntax = _WINDOWS_SHELL_SYNTAX if is_windows else _POSIX_SHELL_SYNTAX
+    quote: str | None = None
+    escaped = False
+
+    for character in command:
+        if escaped:
+            escaped = False
+            continue
+        if quote == "'":
+            if character == "'":
+                quote = None
+            continue
+        if quote == '"':
+            if character == '"':
+                quote = None
+            elif character in {"$", "`"}:
+                return True
+            elif character == "\\":
+                escaped = True
+            continue
+        if character == '"' or (character == "'" and not is_windows):
+            quote = character
+        elif (character == "\\" and not is_windows) or (character == "^" and is_windows):
+            escaped = True
+        elif character in syntax:
+            return True
+
+    return quote is not None
+
+
+def parse_shell_command(command: str) -> ParsedShellCommand:
     """Parse command text into an executable shape (no safety policy applied)."""
     stripped = command.strip()
 
@@ -85,31 +126,7 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
             use_shell=True,
         )
 
-    if (
-        _SHELL_OPERATOR_RE.search(stripped) is not None
-        or _INLINE_SUBSHELL_RE.search(stripped) is not None
-        or _HEREDOC_START_RE.search(stripped) is not None
-    ):
-        # Operators / substitution need a real shell; alpha mode runs them.
-        return ParsedShellCommand(
-            command=stripped,
-            argv=None,
-            passthrough=False,
-            use_shell=True,
-        )
-
-    argv = _split_argv(stripped, is_windows=is_windows)
-    if argv is None:
-        # Could not tokenize (e.g. unbalanced quotes). Hand the raw string to the
-        # shell instead of blocking it.
-        return ParsedShellCommand(
-            command=stripped,
-            argv=None,
-            passthrough=False,
-            use_shell=True,
-        )
-
-    if not argv:
+    if not stripped:
         return ParsedShellCommand(
             command=stripped,
             argv=None,
@@ -118,38 +135,28 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
             parse_error="empty command.",
         )
 
-    if is_windows:
-
-        def _strip_outer_quotes(value: str) -> str:
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-                return value[1:-1]
-            return value
-
-        argv = [_strip_outer_quotes(token) for token in argv]
-
     return ParsedShellCommand(
         command=stripped,
-        argv=argv,
+        argv=None,
         passthrough=False,
-        use_shell=False,
+        use_shell=True,
     )
 
 
 def argv_for_repl_builtin_detection(
     *, parsed: ParsedShellCommand, is_windows: bool
 ) -> list[str] | None:
-    """Argv tokens for detecting ``cd`` / ``pwd`` REPL builtins.
-
-    Only the plain ``argv`` path and explicit ``!`` passthrough opt into builtin
-    detection. Operator / substitution commands run wholesale through the shell,
-    so they intentionally return ``None`` here (a leading ``cd`` in
-    ``cd /tmp && ls`` must not be hijacked by the builtin handler).
-    """
-    if parsed.argv is not None:
-        return parsed.argv
-    if not parsed.passthrough or not parsed.command.strip():
+    """Return argv when the command is one standalone ``cd`` or ``pwd`` builtin."""
+    if not parsed.command.strip() or _contains_shell_syntax(
+        parsed.command,
+        is_windows=is_windows,
+    ):
         return None
-    return _split_argv(parsed.command.strip(), is_windows=is_windows)
+
+    argv = _split_builtin_argv(parsed.command.strip(), is_windows=is_windows)
+    if argv is None or not argv or argv[0].lower() not in {"cd", "pwd"}:
+        return None
+    return argv
 
 
 __all__ = [

--- a/tools/interactive_shell/shell/policy.py
+++ b/tools/interactive_shell/shell/policy.py
@@ -10,7 +10,6 @@ They reuse the shared policy contracts
 
 from __future__ import annotations
 
-import config.constants.platform as _platform
 from tools.interactive_shell.shared import (
     ExecutionPolicyResult,
     ToolExecutionMode,
@@ -62,7 +61,7 @@ def plan_shell_execution(parsed: ParsedShellCommand) -> ToolExecutionPlan:
 
 def evaluate_shell_command(command: str) -> ExecutionPolicyResult:
     """Map shell policy + passthrough rules into allow/ask/deny."""
-    parsed = parse_shell_command(command, is_windows=_platform.IS_WINDOWS)
+    parsed = parse_shell_command(command)
     return evaluate_shell_from_parsed(parsed)
 
 

--- a/tools/interactive_shell/shell/runner.py
+++ b/tools/interactive_shell/shell/runner.py
@@ -66,7 +66,7 @@ def run_shell_command(
     cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     session = presenter.session
-    parsed = parse_shell_command(command, is_windows=_platform.IS_WINDOWS)
+    parsed = parse_shell_command(command)
     plan = plan_shell_execution(parsed)
     display_command = format_shell_command_for_display(command)
     if not presenter.execution_allowed(


### PR DESCRIPTION
Fixes #6206

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Treat every non-empty `shell_run.command` as host-shell source, so compact operators, redirects, quoting, expansions, and heredocs are interpreted by the installed platform shell.
- Replace custom `cd`/`pwd` parsing and process-global `os.chdir` with a typed `set_working_directory(path)` action and explicit session-scoped working-directory state.
- Pass the session directory through `cwd=` to `shell_run`, foreground/background `cli_exec`, repository-scope resolution, and `code_implement`.
- Preserve the working directory across turns and session clearing while leaving invalid directory changes transactional: validation failures do not mutate session state.
- Add regression and boundary coverage for compact shell syntax, heredocs, relative paths with spaces, invalid paths, child-shell `cd` isolation, and all local action subprocess consumers.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```text
$ uv run python -m pytest     tests/interactive_shell/shell/test_shell_parsing.py     tests/interactive_shell/shell/test_execution.py     tests/interactive_shell/runtime/test_subprocess_runner.py     tests/core/agent/orchestration/test_agent_actions.py     tests/tools/test_registry_index.py     tests/tools/interactive_shell/test_action_names.py     tests/tools/interactive_shell/test_working_directory.py     tests/tools/test_description_contract.py -q
349 passed, 37 skipped in 15.76s

$ env -u NO_COLOR uv run python -m pytest     tests/core/agent_harness/session tests/core/agent_harness/turns     tests/interactive_shell tests/tools/interactive_shell     tests/tools/test_registry_index.py tests/core/agent/test_tool_registry.py -q
1805 passed, 1 skipped, 1 xfailed in 31.71s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

The old path tried to decide which strings contained shell syntax. That cannot remain complete across POSIX shells and Windows command syntax, and it caused #6206 when separators had no surrounding whitespace. I considered broadening the scanner and adding a shell-parser dependency, but both would create a second, incomplete syntax authority. The durable contract is simpler: `shell_run` supplies source to the actual host shell and does not parse that language itself.

A persistent directory is application state rather than shell syntax. `set_working_directory` accepts a structured path, resolves it with `pathlib` relative to the current session directory, validates it before assignment, and never changes the Python process directory. Local subprocess entry points read that state and pass it explicitly as `cwd`, avoiding cross-session races and keeping background work consistent.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

