### PR TITLE
fix(shell): use host shell with session-scoped cwd

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -935,6 +935,9 @@ if TYPE_CHECKING:
     from config.constants.session_store import (
         OPENSRE_SESSION_FILE_LOCK_ENV as OPENSRE_SESSION_FILE_LOCK_ENV,
     )
+    from config.constants.session_store import (
+        WORKING_DIRECTORY_STATE_CUSTOM_TYPE as WORKING_DIRECTORY_STATE_CUSTOM_TYPE,
+    )
     from config.constants.signoz import (
         SIGNOZ_API_KEY_ENV as SIGNOZ_API_KEY_ENV,
     )

--- a/config/constants/exports.py
+++ b/config/constants/exports.py
@@ -375,6 +375,7 @@ EXPORTS: dict[str, str] = {
     "SERVICENOW_USERNAME_ENV": "servicenow",
     # session_store
     "OPENSRE_SESSION_FILE_LOCK_ENV": "session_store",
+    "WORKING_DIRECTORY_STATE_CUSTOM_TYPE": "session_store",
     # signoz
     "SIGNOZ_API_KEY_ENV": "signoz",
     "SIGNOZ_URL_ENV": "signoz",

--- a/config/constants/session_store.py
+++ b/config/constants/session_store.py
@@ -1,4 +1,4 @@
-"""Session-store environment variable names."""
+"""Session-store constants."""
 
 from __future__ import annotations
 
@@ -7,5 +7,6 @@ from __future__ import annotations
 # without corrupting it. Off by default: a single-task deployment cannot hit the
 # hazard and should not pay the per-write lock cost. Turn on when running N tasks.
 OPENSRE_SESSION_FILE_LOCK_ENV = "OPENSRE_SESSION_FILE_LOCK"
+WORKING_DIRECTORY_STATE_CUSTOM_TYPE = "working_directory_state"
 
-__all__ = ["OPENSRE_SESSION_FILE_LOCK_ENV"]
+__all__ = ["OPENSRE_SESSION_FILE_LOCK_ENV", "WORKING_DIRECTORY_STATE_CUSTOM_TYPE"]

--- a/core/agent_harness/accounting/self_recording_tools.py
+++ b/core/agent_harness/accounting/self_recording_tools.py
@@ -14,6 +14,7 @@ SELF_RECORDING_ACTION_TOOL_NAMES: frozenset[str] = frozenset(
         "code_implement",
         "llm_set_provider",
         "shell_run",
+        "set_working_directory",
         "slash_invoke",
         "task_cancel",
     }

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -72,6 +72,7 @@ class SessionState(Protocol):
     # --- turn-context snapshot fields ---
     cli_agent_messages: list[tuple[str, str]]
     configured_integrations_known: bool
+    working_directory: str
 
     # Read-only here; ``Session`` stores a tuple. A property matches
     # covariantly, so any concrete ``Sequence[str]`` implementation satisfies it.
@@ -94,6 +95,9 @@ class SessionState(Protocol):
 
     def record(self, kind: str, text: str, *, ok: bool = True) -> None:
         """Append a record of an executed action/turn to the session log."""
+
+    def set_working_directory(self, working_directory: str) -> None:
+        """Persist and apply the default directory for local session tools."""
 
 
 @runtime_checkable

--- a/core/agent_harness/session/lifecycle.py
+++ b/core/agent_harness/session/lifecycle.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Any, TypeVar
 
 from core.agent_harness.session.persistence.contracts import (
@@ -288,6 +289,12 @@ class SessionManager:
         history = data.get(RestoreContextKey.HISTORY)
         if isinstance(history, list):
             session.history = [dict(item) for item in history if isinstance(item, dict)]
+        working_directory = data.get(RestoreContextKey.WORKING_DIRECTORY)
+        if isinstance(working_directory, str) and working_directory.strip():
+            with contextlib.suppress(OSError, RuntimeError):
+                restored_directory = Path(working_directory).expanduser().resolve(strict=True)
+                if restored_directory.is_dir():
+                    session.working_directory = str(restored_directory)
         return session
 
     def close(

--- a/core/agent_harness/session/persistence/contracts.py
+++ b/core/agent_harness/session/persistence/contracts.py
@@ -31,6 +31,7 @@ class RestoreContextKey(StrEnum):
     SESSION_GOAL_STATE = "session_goal_state"
     TASK_PLAN_STATE = "task_plan_state"
     HISTORY = "history"
+    WORKING_DIRECTORY = "working_directory"
 
 
 # Turn kinds that represent user-initiated chat messages. Session.record()
@@ -44,6 +45,7 @@ class SessionPersistenceSource(Protocol):
 
     session_id: str
     started_at: float
+    working_directory: str
     agent: MutableAgentState
     accumulated_context: dict[str, Any]
 
@@ -121,6 +123,9 @@ class SessionStore(Protocol):
         after_tokens: int | None = None,
     ) -> str:
         raise NotImplementedError
+
+    def append_working_directory(self, session_id: str, working_directory: str) -> None:
+        """Persist the session's current working directory on its active branch."""
 
     def flush(self, session: SessionPersistenceSource) -> None:
         raise NotImplementedError

--- a/core/agent_harness/session/persistence/jsonl_repo.py
+++ b/core/agent_harness/session/persistence/jsonl_repo.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from typing import Any
 
 import core.agent_harness.session.persistence.paths as storage_paths
-from core.agent_harness.session.persistence.contracts import CHAT_KINDS, RestoreContextKey
+from config.constants.session_store import WORKING_DIRECTORY_STATE_CUSTOM_TYPE
+from core.agent_harness.session.persistence.contracts import (
+    CHAT_KINDS,
+    RestoreContextKey,
+)
 from core.agent_harness.session.persistence.wal_recovery import dangling_tool_intents
 from core.state.transcript_window import SESSION_SUMMARY_PREFIX
 
@@ -90,6 +94,10 @@ class JsonlSessionRepo:
                 RestoreContextKey.SESSION_GOAL_STATE: goal_state,
                 RestoreContextKey.TASK_PLAN_STATE: plan_state,
                 RestoreContextKey.HISTORY: history,
+                RestoreContextKey.WORKING_DIRECTORY: _working_directory_for_branch(
+                    header,
+                    branch,
+                ),
                 "turn_details": turn_details,
                 "has_snapshot": False,
                 # WAL sidecars are off-branch, so scan the full entry list:
@@ -235,6 +243,20 @@ def _history_for_branch(branch: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 }
             )
     return history
+
+
+def _working_directory_for_branch(
+    header: dict[str, Any],
+    branch: list[dict[str, Any]],
+) -> str | None:
+    value = header.get("cwd")
+    for record in branch:
+        if (
+            record.get("type") == "custom_message"
+            and record.get("custom_type") == WORKING_DIRECTORY_STATE_CUSTOM_TYPE
+        ):
+            value = record.get("content")
+    return value if isinstance(value, str) and value.strip() else None
 
 
 def _turn_details_for_branch(branch: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/core/agent_harness/session/persistence/jsonl_store.py
+++ b/core/agent_harness/session/persistence/jsonl_store.py
@@ -16,9 +16,15 @@ from typing import Any
 
 from filelock import FileLock, Timeout
 
-from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
+from config.constants.session_store import (
+    OPENSRE_SESSION_FILE_LOCK_ENV,
+    WORKING_DIRECTORY_STATE_CUSTOM_TYPE,
+)
 from config.version import get_opensre_version
-from core.agent_harness.session.persistence.contracts import CHAT_KINDS, SessionPersistenceSource
+from core.agent_harness.session.persistence.contracts import (
+    CHAT_KINDS,
+    SessionPersistenceSource,
+)
 from core.agent_harness.session.persistence.paths import session_path
 from infrastructure.observability.operations_log import record_operation
 
@@ -154,7 +160,7 @@ class JsonlSessionStore:
                     "version": 2,
                     "id": session.session_id,
                     "created_at": datetime.fromtimestamp(session.started_at, tz=UTC).isoformat(),
-                    "cwd": str(Path.cwd()),
+                    "cwd": getattr(session, "working_directory", str(Path.cwd())),
                     "opensre_version": get_opensre_version(),
                 }
                 with path.open("w", encoding="utf-8") as fh:
@@ -173,6 +179,18 @@ class JsonlSessionStore:
                 "text": text,
                 "display": False,
             },
+        )
+
+    def append_working_directory(self, session_id: str, working_directory: str) -> None:
+        self._append_entry(
+            session_id,
+            "custom_message",
+            {
+                "custom_type": WORKING_DIRECTORY_STATE_CUSTOM_TYPE,
+                "content": working_directory,
+                "display": False,
+            },
+            durable=True,
         )
 
     def append_turn_detail(

--- a/core/agent_harness/session/persistence/memory.py
+++ b/core/agent_harness/session/persistence/memory.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
+from config.constants.session_store import WORKING_DIRECTORY_STATE_CUSTOM_TYPE
 from core.agent_harness.session.persistence.contracts import SessionPersistenceSource
 
 
@@ -29,7 +30,7 @@ class InMemorySessionStore:
                 "version": 2,
                 "id": session.session_id,
                 "created_at": datetime.fromtimestamp(session.started_at, tz=UTC).isoformat(),
-                "cwd": "",
+                "cwd": session.working_directory,
             }
         ]
 
@@ -38,6 +39,17 @@ class InMemorySessionStore:
             session.session_id,
             "custom_message",
             {"custom_type": "turn_stub", "kind": kind, "text": text, "display": False},
+        )
+
+    def append_working_directory(self, session_id: str, working_directory: str) -> None:
+        self._append(
+            session_id,
+            "custom_message",
+            {
+                "custom_type": WORKING_DIRECTORY_STATE_CUSTOM_TYPE,
+                "content": working_directory,
+                "display": False,
+            },
         )
 
     def append_turn_detail(

--- a/core/agent_harness/session/session_core.py
+++ b/core/agent_harness/session/session_core.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import time
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from core.agent_harness.session.history_entry import build_history_entry
@@ -108,6 +109,13 @@ class SessionCore:
 
     runtime_metadata: dict[str, Any] = field(default_factory=dict)
     """Read-only process facts (version, build, env) exposed to prompts and sandboxed tools."""
+
+    working_directory: str = field(default_factory=lambda: str(Path.cwd()))
+    """Default directory for local subprocess tools in this session.
+
+    Kept as explicit session state instead of changing the process-wide current
+    directory, which would race with concurrent sessions and background work.
+    """
 
     reasoning_effort: ReasoningEffortChoice | None = None
     """Session-scoped reasoning effort preference for REPL-driven LLM calls."""
@@ -261,6 +269,11 @@ class SessionCore:
         self._shed_stale_response_text()
 
         self.store.append_turn(self, kind, text)
+
+    def set_working_directory(self, working_directory: str) -> None:
+        """Persist and apply the default directory for local session tools."""
+        self.store.append_working_directory(self.session_id, working_directory)
+        self.working_directory = working_directory
 
     def _shed_stale_response_text(self) -> None:
         """Drop the response body from the entry just aged out of the window.

--- a/core/agent_harness/tools/action_tools.py
+++ b/core/agent_harness/tools/action_tools.py
@@ -60,12 +60,12 @@ def get_action_tools_from_integrations_view(
     tools: list[RegisteredTool] = []
     for candidate in _registered_single_turn_tools().values():
         try:
-            if not candidate.is_available(sources):
+            if not candidate.should_advertise(sources):
                 continue
         except Exception as exc:
             safe_sources = redact_sensitive(sources)
             raise RuntimeError(
-                f"{candidate.name} availability check failed for sources {safe_sources!r}: {exc}"
+                f"{candidate.name} advertisement check failed for sources {safe_sources!r}: {exc}"
             ) from exc
         tools.append(candidate)
     return tools

--- a/core/agent_harness/turns/action_dedup.py
+++ b/core/agent_harness/turns/action_dedup.py
@@ -1,6 +1,6 @@
 """Suppress replayed action-tool calls within one turn.
 
-A guarded tool (``slash_invoke`` / ``shell_run`` / ``cli_exec``) that the model
+A guarded local action tool that the model
 re-emits with identical arguments after it already succeeded this turn is
 blocked, so a stuttering model cannot run the same side-effecting command
 twice. Kept apart from the turn driver: this is a self-contained hook policy,
@@ -9,7 +9,8 @@ not part of driving the loop.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import Any
 
 from core.llm.types import ToolCall
@@ -23,8 +24,15 @@ from core.tool.execution import (
 )
 
 # Local REPL tools covered by consecutive identical-batch suppress (oracle 202 /
-# 203): slash_invoke, shell_run, cli_exec. One rule — no per-tool carve-outs.
-_DEDUPE_ACTION_TOOL_NAMES: frozenset[str] = frozenset({"slash_invoke", "shell_run", "cli_exec"})
+# 203). Directory changes are guarded across provider batches but intentionally
+# remain repeatable inside one ordered batch: the same relative path can resolve
+# to a different destination after the preceding change.
+_DEDUPE_ACTION_TOOL_NAMES: frozenset[str] = frozenset(
+    {"slash_invoke", "shell_run", "cli_exec", "set_working_directory"}
+)
+_SAME_BATCH_DEDUPE_ACTION_TOOL_NAMES: frozenset[str] = frozenset(
+    {"slash_invoke", "shell_run", "cli_exec"}
+)
 
 # Hashable identity for one guarded call (no hot-path json.dumps).
 _ActionCallFingerprint = tuple[Any, ...]
@@ -39,8 +47,20 @@ def coerce_fingerprint_quiet(value: Any) -> bool:
     return bool(value)
 
 
-def _action_call_fingerprint(name: str, args: Any) -> _ActionCallFingerprint:
-    """Stable identity for one guarded action call (schema fields only)."""
+def _tool_result_succeeded(result: ToolExecutionResult) -> bool:
+    """Treat explicit action-level ``ok: false`` payloads as failures."""
+    if result.is_error:
+        return False
+    return not (isinstance(result.details, dict) and result.details.get("ok") is False)
+
+
+def _action_call_fingerprint(
+    name: str,
+    args: Any,
+    *,
+    working_directory: str | None = None,
+) -> _ActionCallFingerprint:
+    """Stable identity for one guarded action call and its stateful destination."""
     if not isinstance(args, dict):
         args = {}
 
@@ -53,6 +73,16 @@ def _action_call_fingerprint(name: str, args: Any) -> _ActionCallFingerprint:
     if name == "cli_exec":
         return (name, str(args.get("payload", "")).strip())
 
+    if name == "set_working_directory":
+        path = Path(str(args.get("path", "")).strip()).expanduser()
+        if working_directory is not None and not path.is_absolute():
+            path = Path(working_directory) / path
+        try:
+            resolved_path = str(path.resolve())
+        except OSError:
+            resolved_path = str(path.absolute())
+        return (name, resolved_path)
+
     # shell_run
     return (
         name,
@@ -63,14 +93,16 @@ def _action_call_fingerprint(name: str, args: Any) -> _ActionCallFingerprint:
 
 def with_duplicate_action_call_guard(
     base: ToolExecutionHooks | None = None,
+    *,
+    working_directory: Callable[[], str] | None = None,
 ) -> ToolExecutionHooks:
     """Block replaying guarded action calls already covered by the success snapshot.
 
-    Suppress ``slash_invoke`` / ``shell_run`` / ``cli_exec`` when the call's
-    fingerprint is in ``last_fully_succeeded_batch`` *or* already succeeded
-    earlier in the current provider batch (same-batch duplicates). Guarded
-    tools are sequential, so ``batch_succeeded`` is visible to the next
-    ``before()`` in the batch.
+    Suppress guarded local action tools when the call's fingerprint is in
+    ``last_fully_succeeded_batch`` *or* already succeeded earlier in the
+    current provider batch (same-batch duplicates). Guarded tools are
+    sequential, so ``batch_succeeded`` is visible to the next ``before()`` in
+    the batch.
 
     Snapshot updates at the next batch boundary:
 
@@ -83,13 +115,16 @@ def with_duplicate_action_call_guard(
     - Pure suppress or total failure → leave the snapshot alone (a third
       identical replay stays blocked; failed calls may still retry).
 
-    Limitation (intentional): the same batch twice in one turn — lone or
-    multi — is also suppressed; accidental replay and “run that again” are
-    indistinguishable without parsing the user message. Ask again next turn.
+    Limitation (intentional): the same destination batch twice in one turn —
+    lone or multi — is also suppressed; accidental replay and “run that again”
+    are indistinguishable without parsing the user message. Relative directory
+    changes use the live base directory, so different destinations do not
+    collide. Ask again next turn to intentionally replay an identical action.
     """
     last_fully_succeeded_batch: frozenset[_ActionCallFingerprint] = frozenset()
-    current_batch: frozenset[_ActionCallFingerprint] = frozenset()
+    current_batch: set[_ActionCallFingerprint] = set()
     batch_succeeded: set[_ActionCallFingerprint] = set()
+    request_fingerprints: dict[str, _ActionCallFingerprint] = {}
     has_open_batch = False
     base_before = base.before_tool_call if base is not None else None
     base_after = base.after_tool_call if base is not None else None
@@ -102,23 +137,18 @@ def with_duplicate_action_call_guard(
             base_batch(tool_calls)
         if has_open_batch and current_batch:
             succeeded = frozenset(batch_succeeded)
-            if succeeded == current_batch:
-                last_fully_succeeded_batch = current_batch
+            requested = frozenset(current_batch)
+            if succeeded == requested:
+                last_fully_succeeded_batch = requested
             elif succeeded:
                 # Mixed suppress/success: snapshot is only what newly ran.
                 # Do not retain suppressed members — that would block a later
                 # intentional standalone A after {A suppressed, C succeeded}.
                 last_fully_succeeded_batch = succeeded
             # else: pure suppress or all-error — leave snapshot intact.
-        keys: list[_ActionCallFingerprint] = []
-        for tool_call in tool_calls:
-            if tool_call.name not in _DEDUPE_ACTION_TOOL_NAMES:
-                continue
-            keys.append(
-                _action_call_fingerprint(tool_call.name, public_tool_input(tool_call.input))
-            )
-        current_batch = frozenset(keys)
+        current_batch = set()
         batch_succeeded = set()
+        request_fingerprints.clear()
         has_open_batch = True
 
     def before(request: ToolExecutionRequest) -> BeforeToolCallResult | None:
@@ -128,8 +158,18 @@ def with_duplicate_action_call_guard(
         # successful {B} replaces the snapshot. Same-batch duplicates (two
         # identical cli_exec in one provider response) hit batch_succeeded.
         if name in _DEDUPE_ACTION_TOOL_NAMES:
-            key = _action_call_fingerprint(name, public_tool_input(request.arguments))
-            if key in last_fully_succeeded_batch or key in batch_succeeded:
+            current_directory = working_directory() if working_directory is not None else None
+            key = _action_call_fingerprint(
+                name,
+                public_tool_input(request.arguments),
+                working_directory=current_directory,
+            )
+            current_batch.add(key)
+            request_fingerprints[request.tool_call.id] = key
+            repeated_in_batch = (
+                name in _SAME_BATCH_DEDUPE_ACTION_TOOL_NAMES and key in batch_succeeded
+            )
+            if key in last_fully_succeeded_batch or repeated_in_batch:
                 return BeforeToolCallResult(
                     blocked=True,
                     reason=(
@@ -146,12 +186,14 @@ def with_duplicate_action_call_guard(
         request: ToolExecutionRequest,
         result: ToolExecutionResult,
     ) -> ToolExecutionPatch | None:
-        if request.tool_call.name in _DEDUPE_ACTION_TOOL_NAMES and not result.is_error:
-            batch_succeeded.add(
-                _action_call_fingerprint(
-                    request.tool_call.name, public_tool_input(request.arguments)
-                )
+        if request.tool_call.name in _DEDUPE_ACTION_TOOL_NAMES and _tool_result_succeeded(result):
+            current_directory = working_directory() if working_directory is not None else None
+            fallback = _action_call_fingerprint(
+                request.tool_call.name,
+                public_tool_input(request.arguments),
+                working_directory=current_directory,
             )
+            batch_succeeded.add(request_fingerprints.pop(request.tool_call.id, fallback))
         if base_after is not None:
             return base_after(request, result)
         return None

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -64,13 +64,20 @@ from core.agent_harness.turns.goal_review import (
 )
 from core.agent_harness.turns.skill_after_tool import with_skill_after_tool
 from core.agent_harness.turns.skill_scope import scope_tools_to_active_skill
-from core.agent_harness.turns.turn_plan import TurnPlan
+from core.agent_harness.turns.turn_plan import (
+    TurnPlan,
+    working_directory_scope_refresh_hooks,
+)
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from core.agent_harness.turns.wal_recorder import with_wal_recording
 from core.events import runtime_event_callback_from_observer
 from core.llm.types import AgentLLMResponse, SchemaDescribedTool, ToolCall
-from core.tool.execution import ToolExecutionHooks, public_tool_input
+from core.tool.execution import (
+    ToolExecutionHooks,
+    compose_tool_execution_hooks,
+    public_tool_input,
+)
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from infrastructure.analytics.react_turn import run_react_agent_with_telemetry
 from infrastructure.observability.trace.prompts import persist_turn_system_prompt
@@ -977,7 +984,19 @@ def _run_action_turn(
             resolved_integrations=resolved_integrations,
             llm_factory=args.llm_factory,
             tool_hooks=with_menu_turn_end(
-                with_skill_after_tool(with_duplicate_action_call_guard(args.tool_hooks), session),
+                with_skill_after_tool(
+                    with_duplicate_action_call_guard(
+                        compose_tool_execution_hooks(
+                            args.tool_hooks,
+                            working_directory_scope_refresh_hooks(
+                                session=session,
+                                message=message,
+                            ),
+                        ),
+                        working_directory=lambda: session.working_directory,
+                    ),
+                    session,
+                ),
                 session,
             ),
             tool_resources=tool_resources,

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from core.agent_harness.ports import (
@@ -31,6 +32,7 @@ class InMemorySessionState:
     cli_agent_messages: list[tuple[str, str]] = field(default_factory=list)
     configured_integrations: list[str] = field(default_factory=list)
     configured_integrations_known: bool = False
+    working_directory: str = field(default_factory=lambda: str(Path.cwd()))
     pending_schedule_offer: PendingScheduleOffer | None = None
     reasoning_effort: Any | None = None
     history: list[dict[str, Any]] = field(default_factory=list)
@@ -63,6 +65,10 @@ class InMemorySessionState:
             slash_outcome=slash_outcome,
         )
         self.history.append(entry)
+
+    def set_working_directory(self, working_directory: str) -> None:
+        """Apply the default directory for this in-memory session."""
+        self.working_directory = working_directory
 
 
 @dataclass

--- a/core/agent_harness/turns/turn_plan.py
+++ b/core/agent_harness/turns/turn_plan.py
@@ -15,6 +15,7 @@ here so there is one source.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -24,6 +25,11 @@ from core.agent_harness.session.integration_resolution import (
     resolve_and_cache_integrations,
 )
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
+from core.tool.execution import (
+    ToolExecutionHooks,
+    ToolExecutionRequest,
+    ToolExecutionResult,
+)
 from infrastructure.harness_providers import enrich_resolved_with_repo_scopes
 
 _MAX_KNOWN_REPOSITORIES_PER_VENDOR = 20
@@ -46,24 +52,16 @@ class TurnPlan:
         return self.snapshot.resolved_integrations
 
 
-def build_turn_plan(snapshot: TurnSnapshot, session: SessionState) -> TurnPlan:
-    """Assemble the turn plan: resolve integrations once, then compose the snapshot.
-
-    Resolution runs only when the snapshot has not already been populated (a
-    runtime-request source can pre-fill it), so the plan is the single place that
-    decides what this turn knows about connected integrations.
-
-    An empty result (``{}`` — no integrations configured) is a valid resolved
-    view; downstream phases read it from the plan rather than re-checking, so the
-    resolve-once contract holds even in that case (``resolve_and_cache`` also
-    caches, so a repeat call would be a no-op regardless).
-
-    Metadata-only maps (underscore keys such as ``_gateway_chat_id``) are not a
-    resolved view — they must still trigger a real resolve.
-    """
-    if not has_resolved_integrations(snapshot.resolved_integrations):
-        snapshot = replace(snapshot, resolved_integrations=resolve_and_cache_integrations(session))
-
+def _enrich_repository_scopes(
+    *,
+    resolved: dict[str, Any],
+    session: SessionState,
+    message: str,
+    conversation_messages: Sequence[tuple[str, str]] | None,
+    cwd: str | None,
+    cached_scopes: dict[str, tuple[str, ...]],
+) -> dict[str, Any]:
+    """Enrich one resolved-integration view and update session scope caches."""
     repository_keys: dict[tuple[str, tuple[str, ...]], str] = {}
 
     def _set_active_scope(vendor: str, scope: tuple[str, ...] | None) -> None:
@@ -88,23 +86,107 @@ def build_turn_plan(snapshot: TurnSnapshot, session: SessionState) -> TurnPlan:
             name: dict(scopes) for name, scopes in session.known_vcs_repo_scopes.items()
         }
         known = known_by_vendor.setdefault(vendor, {})
-        # Re-inserting moves a reused repository to the recent end without
-        # creating a duplicate. Bound the collection for long-running gateways.
         known.pop(repository, None)
         known[repository] = scope
         while len(known) > _MAX_KNOWN_REPOSITORIES_PER_VENDOR:
             known.pop(next(iter(known)))
         session.known_vcs_repo_scopes = known_by_vendor
 
-    enriched = enrich_resolved_with_repo_scopes(
-        resolved=snapshot.resolved_integrations,
-        message=snapshot.text,
-        conversation_messages=snapshot.conversation_messages,
+    return enrich_resolved_with_repo_scopes(
+        resolved=resolved,
+        message=message,
+        conversation_messages=conversation_messages,
         env=None,
-        cwd=snapshot.working_directory,
-        cached_scopes=session.vcs_repo_scopes,
+        cwd=cwd,
+        cached_scopes=cached_scopes,
         set_cached_scope=_set_active_scope,
         remember_scope=_remember_scope,
+    )
+
+
+def refresh_repository_scopes_after_directory_change(
+    *,
+    resolved: dict[str, Any],
+    session: SessionState,
+    message: str,
+    cwd: str,
+) -> dict[str, Any]:
+    """Rebuild repository scope after an explicit workspace change.
+
+    The new workspace replaces stale conversation/cache inference unless the
+    current request explicitly names a repository. Metadata keys carried by
+    the turn are preserved alongside the session's unscoped integration view.
+    """
+    metadata = {key: value for key, value in resolved.items() if key.startswith("_")}
+    base = {**resolve_and_cache_integrations(session), **metadata}
+    session.vcs_repo_scopes = {}
+    session.active_vcs_repositories = {}
+    return _enrich_repository_scopes(
+        resolved=base,
+        session=session,
+        message=message,
+        conversation_messages=None,
+        cwd=cwd,
+        cached_scopes={},
+    )
+
+
+def working_directory_scope_refresh_hooks(
+    *,
+    session: SessionState,
+    message: str,
+) -> ToolExecutionHooks:
+    """Refresh the running tool-execution view after a directory change."""
+
+    def after(
+        request: ToolExecutionRequest,
+        result: ToolExecutionResult,
+    ) -> None:
+        if request.tool_call.name != "set_working_directory" or result.is_error:
+            return
+        details = result.details
+        if not isinstance(details, dict) or details.get("ok") is not True:
+            return
+        cwd = details.get("working_directory")
+        if not isinstance(cwd, str) or not cwd:
+            return
+        refreshed = refresh_repository_scopes_after_directory_change(
+            resolved=request.resolved_integrations,
+            session=session,
+            message=message,
+            cwd=cwd,
+        )
+        request.resolved_integrations.clear()
+        request.resolved_integrations.update(refreshed)
+
+    return ToolExecutionHooks(after_tool_call=after)
+
+
+def build_turn_plan(snapshot: TurnSnapshot, session: SessionState) -> TurnPlan:
+    """Assemble the turn plan: resolve integrations once, then compose the snapshot.
+
+    Resolution runs only when the snapshot has not already been populated (a
+    runtime-request source can pre-fill it), so the plan is the single place that
+    decides what this turn knows about connected integrations.
+
+    An empty result (``{}`` — no integrations configured) is a valid resolved
+    view; downstream phases read it from the plan rather than re-checking, so the
+    resolve-once contract holds even in that case (``resolve_and_cache`` also
+    caches, so a repeat call would be a no-op regardless).
+
+    Metadata-only maps (underscore keys such as ``_gateway_chat_id``) are not a
+    resolved view — they must still trigger a real resolve.
+    """
+    if not has_resolved_integrations(snapshot.resolved_integrations):
+        snapshot = replace(snapshot, resolved_integrations=resolve_and_cache_integrations(session))
+
+    enriched = _enrich_repository_scopes(
+        resolved=snapshot.resolved_integrations,
+        session=session,
+        message=snapshot.text,
+        conversation_messages=snapshot.conversation_messages,
+        cwd=snapshot.working_directory,
+        cached_scopes=session.vcs_repo_scopes,
     )
     snapshot = replace(
         snapshot,
@@ -117,4 +199,9 @@ def build_turn_plan(snapshot: TurnSnapshot, session: SessionState) -> TurnPlan:
     return TurnPlan(snapshot=snapshot)
 
 
-__all__ = ["TurnPlan", "build_turn_plan"]
+__all__ = [
+    "TurnPlan",
+    "build_turn_plan",
+    "refresh_repository_scopes_after_directory_change",
+    "working_directory_scope_refresh_hooks",
+]

--- a/core/agent_harness/turns/turn_plan.py
+++ b/core/agent_harness/turns/turn_plan.py
@@ -60,6 +60,7 @@ def _enrich_repository_scopes(
     conversation_messages: Sequence[tuple[str, str]] | None,
     cwd: str | None,
     cached_scopes: dict[str, tuple[str, ...]],
+    prefer_cwd_over_environment: bool = False,
 ) -> dict[str, Any]:
     """Enrich one resolved-integration view and update session scope caches."""
     repository_keys: dict[tuple[str, tuple[str, ...]], str] = {}
@@ -99,6 +100,7 @@ def _enrich_repository_scopes(
         env=None,
         cwd=cwd,
         cached_scopes=cached_scopes,
+        prefer_cwd_over_environment=prefer_cwd_over_environment,
         set_cached_scope=_set_active_scope,
         remember_scope=_remember_scope,
     )
@@ -128,6 +130,7 @@ def refresh_repository_scopes_after_directory_change(
         conversation_messages=None,
         cwd=cwd,
         cached_scopes={},
+        prefer_cwd_over_environment=True,
     )
 
 

--- a/core/agent_harness/turns/turn_snapshot.py
+++ b/core/agent_harness/turns/turn_snapshot.py
@@ -269,6 +269,7 @@ class TurnSnapshot:
             tool_resources=dict(getattr(runtime_input, "tool_resources", {}) or {}),
             max_iterations=int(getattr(runtime_input, "max_iterations", 1)),
             model=getattr(runtime_input, "model", None),
+            working_directory=getattr(session, "working_directory", None),
             last_observation=last_observation,
             recovery_note=recovery_note,
             task_plan=_read_task_plan(session),

--- a/core/tool/contracts.py
+++ b/core/tool/contracts.py
@@ -225,6 +225,7 @@ class ToolMetadata(StrictConfigModel):
     outputs: dict[str, str] = Field(default_factory=dict)
     output_schema: dict[str, Any] | None = None
     injected_params: list[str] = Field(default_factory=list)
+    context_params: list[str] = Field(default_factory=list)
     retrieval_controls: RetrievalControls = Field(
         default_factory=RetrievalControls,
         description="Declares which structured retrieval controls this tool supports",
@@ -283,6 +284,8 @@ class BaseTool(ABC):
     #: Optional per-tool output→evidence mapper; assign a module-level function.
     evidence_mapper: ClassVar[EvidenceMapper | None] = None
     injected_params: ClassVar[Sequence[str]] = ()
+    #: Public parameters whose non-empty runtime context values are authoritative.
+    context_params: ClassVar[Sequence[str]] = ()
     retrieval_controls: ClassVar[RetrievalControls] = (
         RetrievalControls()
     )  # Declares supported controls
@@ -312,6 +315,7 @@ class BaseTool(ABC):
         cls.outputs = metadata.outputs
         cls.output_schema = metadata.output_schema
         cls.injected_params = tuple(metadata.injected_params)
+        cls.context_params = tuple(metadata.context_params)
         cls.retrieval_controls = metadata.retrieval_controls
         registry = cls.registry_metadata()
         cls.surfaces = registry.surfaces
@@ -338,6 +342,7 @@ class BaseTool(ABC):
                 "outputs": dict(getattr(cls, "outputs", {})),
                 "output_schema": getattr(cls, "output_schema", None),
                 "injected_params": list(getattr(cls, "injected_params", [])),
+                "context_params": list(getattr(cls, "context_params", [])),
                 "retrieval_controls": getattr(cls, "retrieval_controls", RetrievalControls()),
             }
         )
@@ -419,6 +424,8 @@ class RegisteredTool:
     output_schema: dict[str, Any] | None = None
     evidence_mapper: EvidenceMapper | None = field(default=None, repr=False)
     injected_params: tuple[str, ...] = ()
+    #: Public parameters whose non-empty ``extract_params`` values beat model input.
+    context_params: tuple[str, ...] = ()
     retrieval_controls: RetrievalControls = field(
         default_factory=RetrievalControls,
     )
@@ -462,6 +469,7 @@ class RegisteredTool:
                 "outputs": self.outputs,
                 "output_schema": self.output_schema,
                 "injected_params": list(self.injected_params),
+                "context_params": list(self.context_params),
                 "retrieval_controls": self.retrieval_controls,
             }
         )
@@ -480,6 +488,7 @@ class RegisteredTool:
         self.outputs = metadata.outputs
         self.output_schema = metadata.output_schema
         self.injected_params = tuple(metadata.injected_params)
+        self.context_params = tuple(metadata.context_params)
         self.retrieval_controls = metadata.retrieval_controls
         self.surfaces = _normalize_surfaces(self.surfaces)
 
@@ -581,6 +590,7 @@ class RegisteredTool:
         accepts_runtime_context: bool | None = None,
         evidence_mapper: EvidenceMapper | None = None,
         is_advertised: Callable[[dict[str, dict]], bool] | None = None,
+        context_params: tuple[str, ...] | None = None,
     ) -> RegisteredTool:
         metadata = tool.metadata()
         input_model = cast(type[BaseModel] | None, getattr(tool, "input_model", None))
@@ -612,6 +622,11 @@ class RegisteredTool:
             outputs=metadata.outputs,
             output_schema=resolved_output_schema,
             injected_params=tuple(metadata.injected_params),
+            context_params=(
+                tuple(context_params)
+                if context_params is not None
+                else tuple(metadata.context_params)
+            ),
             retrieval_controls=retrieval_controls or metadata.retrieval_controls,
             surfaces=resolved_surfaces,
             run=tool.run,  # type: ignore[attr-defined]
@@ -673,6 +688,7 @@ class RegisteredTool:
         output_model: type[BaseModel] | None = None,
         evidence_mapper: EvidenceMapper | None = None,
         injected_params: tuple[str, ...] | None = None,
+        context_params: tuple[str, ...] | None = None,
         retrieval_controls: RetrievalControls | None = None,
         is_available: Callable[[dict[str, dict]], bool] | None = None,
         is_advertised: Callable[[dict[str, dict]], bool] | None = None,
@@ -714,6 +730,7 @@ class RegisteredTool:
             output_schema=resolved_output_schema,
             evidence_mapper=evidence_mapper,
             injected_params=tuple(injected_params or ()),
+            context_params=tuple(context_params or ()),
             retrieval_controls=retrieval_controls or RetrievalControls(),
             run=func,
             is_available=is_available or _always_available,

--- a/core/tool/contracts.py
+++ b/core/tool/contracts.py
@@ -424,7 +424,7 @@ class RegisteredTool:
     output_schema: dict[str, Any] | None = None
     evidence_mapper: EvidenceMapper | None = field(default=None, repr=False)
     injected_params: tuple[str, ...] = ()
-    #: Public parameters whose non-empty ``extract_params`` values beat model input.
+    #: Public defaults refreshed when model input still matches the prior context.
     context_params: tuple[str, ...] = ()
     retrieval_controls: RetrievalControls = field(
         default_factory=RetrievalControls,

--- a/core/tool/contracts.py
+++ b/core/tool/contracts.py
@@ -256,9 +256,10 @@ class BaseTool(ABC):
       ``telemetry.invoke_tool`` so exceptions are always captured and
       converted to a structured ``{"error": ..., "exception_type": ...}``
       dict rather than propagating to the agent loop.
-    * Override ``is_available`` and ``extract_params`` when the tool
-      requires specific data-source checks or needs to pull kwargs from the
-      resolved-integration sources dict.
+    * Override ``is_available`` and ``extract_params`` when the tool requires
+      specific data-source checks or needs to pull kwargs from the resolved
+      integration sources. Override ``is_advertised`` only when the schema can
+      be useful before all runtime scope defaults are known.
     * Do **not** declare ``run`` with positional arguments — the call site
       always uses keyword arguments: ``tool_instance.run(**kwargs)``.
     """
@@ -362,6 +363,14 @@ class BaseTool(ABC):
         """
         return True
 
+    def is_advertised(self, sources: dict[str, dict]) -> bool:
+        """Return True when the agent should receive this tool's schema.
+
+        Override when a tool can accept model-supplied scope that is not yet
+        present in ``sources``. By default advertisement follows availability.
+        """
+        return self.is_available(sources)
+
     def extract_params(self, _sources: dict[str, dict]) -> dict[str, Any]:
         """Extract the kwargs to pass to ``run()`` from the available sources.
 
@@ -415,6 +424,10 @@ class RegisteredTool:
     )
     is_available: Callable[[dict[str, dict]], bool] = field(
         default=_always_available,
+        repr=False,
+    )
+    is_advertised: Callable[[dict[str, dict]], bool] | None = field(
+        default=None,
         repr=False,
     )
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] = field(
@@ -474,8 +487,15 @@ class RegisteredTool:
             raise TypeError("run must be callable")
         if not callable(self.is_available):
             raise TypeError("is_available must be callable")
+        if self.is_advertised is not None and not callable(self.is_advertised):
+            raise TypeError("is_advertised must be callable")
         if not callable(self.extract_params):
             raise TypeError("extract_params must be callable")
+
+    def should_advertise(self, sources: dict[str, dict]) -> bool:
+        """Return whether this tool's schema belongs in the agent request."""
+        predicate = self.is_advertised or self.is_available
+        return predicate(sources)
 
     @property
     def inputs(self) -> dict[str, str]:
@@ -560,6 +580,7 @@ class RegisteredTool:
         parallel_safe: bool | None = None,
         accepts_runtime_context: bool | None = None,
         evidence_mapper: EvidenceMapper | None = None,
+        is_advertised: Callable[[dict[str, dict]], bool] | None = None,
     ) -> RegisteredTool:
         metadata = tool.metadata()
         input_model = cast(type[BaseModel] | None, getattr(tool, "input_model", None))
@@ -600,6 +621,7 @@ class RegisteredTool:
                 else getattr(tool.__class__, "evidence_mapper", None)
             ),
             is_available=tool.is_available,
+            is_advertised=is_advertised or tool.is_advertised,
             extract_params=tool.extract_params,
             tags=resolved_tags,
             requires_approval=bool(
@@ -653,6 +675,7 @@ class RegisteredTool:
         injected_params: tuple[str, ...] | None = None,
         retrieval_controls: RetrievalControls | None = None,
         is_available: Callable[[dict[str, dict]], bool] | None = None,
+        is_advertised: Callable[[dict[str, dict]], bool] | None = None,
         extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
         tags: tuple[str, ...] | None = None,
         requires_approval: bool | None = None,
@@ -694,6 +717,7 @@ class RegisteredTool:
             retrieval_controls=retrieval_controls or RetrievalControls(),
             run=func,
             is_available=is_available or _always_available,
+            is_advertised=is_advertised,
             extract_params=extract_params or _extract_no_params,
             tags=tags or (),
             requires_approval=bool(requires_approval),

--- a/core/tool/execution.py
+++ b/core/tool/execution.py
@@ -241,7 +241,6 @@ def execute_tool_calls(
     hooks = hooks or ToolExecutionHooks()
     if hooks.before_tool_batch is not None:
         hooks.before_tool_batch(tool_calls)
-    tool_sources = availability_view(resolved_integrations)
     tool_map = {t.name: t for t in tools}
     runtime_resources = dict(tool_resources or {})
 
@@ -250,7 +249,9 @@ def execute_tool_calls(
             return _execute_one_tool_call(
                 tc,
                 tool_map=tool_map,
-                tool_sources=tool_sources,
+                # A prior sequential action may have refreshed this live view
+                # (for example after changing the session workspace).
+                tool_sources=availability_view(resolved_integrations),
                 resolved_integrations=resolved_integrations,
                 runtime_resources=runtime_resources,
                 hooks=hooks,

--- a/core/tool/execution.py
+++ b/core/tool/execution.py
@@ -243,6 +243,7 @@ def execute_tool_calls(
         hooks.before_tool_batch(tool_calls)
     tool_map = {t.name: t for t in tools}
     runtime_resources = dict(tool_resources or {})
+    initial_tool_sources = availability_view(resolved_integrations)
 
     def _call(tc: ToolCall) -> ToolExecutionResult:
         with tool_span(tc.name, tool_call_id=tc.id) as span_attrs:
@@ -252,6 +253,7 @@ def execute_tool_calls(
                 # A prior sequential action may have refreshed this live view
                 # (for example after changing the session workspace).
                 tool_sources=availability_view(resolved_integrations),
+                initial_tool_sources=initial_tool_sources,
                 resolved_integrations=resolved_integrations,
                 runtime_resources=runtime_resources,
                 hooks=hooks,
@@ -341,6 +343,7 @@ def _execute_one_tool_call(
     *,
     tool_map: dict[str, RuntimeTool],
     tool_sources: dict[str, Any],
+    initial_tool_sources: dict[str, Any],
     resolved_integrations: dict[str, Any],
     runtime_resources: dict[str, Any],
     hooks: ToolExecutionHooks,
@@ -390,6 +393,7 @@ def _execute_one_tool_call(
             tc,
             request=request,
             tool_sources=tool_sources,
+            initial_tool_sources=initial_tool_sources,
             resolved_integrations=resolved_integrations,
             runtime_resources=runtime_resources,
             hooks=hooks,
@@ -432,6 +436,7 @@ def _invoke_runtime_tool(
     *,
     request: ToolExecutionRequest,
     tool_sources: dict[str, Any],
+    initial_tool_sources: dict[str, Any],
     resolved_integrations: dict[str, Any],
     runtime_resources: dict[str, Any],
     hooks: ToolExecutionHooks,
@@ -447,14 +452,30 @@ def _invoke_runtime_tool(
 
     injected = tool.extract_params(tool_sources)
     kwargs = {**injected, **tc.input}
-    # Vendor-agnostic: hidden injected values and public authoritative context
-    # values must win over potentially stale model input when present.
-    protected = frozenset(
-        (*getattr(tool, "injected_params", ()), *getattr(tool, "context_params", ()))
-    )
+    # Hidden values always come from runtime integration state, never the model.
+    protected = frozenset(getattr(tool, "injected_params", ()))
     for key, value in injected.items():
         if key in protected and value not in (None, "", []):
             kwargs[key] = value
+
+    # Public context fields are defaults rather than secrets. Preserve an
+    # explicitly different target, but replace values copied from the batch's
+    # original context when an earlier sequential action refreshed that scope.
+    context_params = tuple(getattr(tool, "context_params", ()))
+    model_context = {
+        key: tc.input[key]
+        for key in context_params
+        if key in tc.input and tc.input[key] not in (None, "", [])
+    }
+    initial_context = tool.extract_params(initial_tool_sources) if context_params else {}
+    uses_initial_context = bool(model_context) and all(
+        initial_context.get(key) == value for key, value in model_context.items()
+    )
+    if not model_context or uses_initial_context:
+        for key in context_params:
+            value = injected.get(key)
+            if value not in (None, "", []):
+                kwargs[key] = value
     if getattr(tool, "accepts_runtime_context", False):
         context = AgentToolContext(
             resolved_integrations=resolved_integrations,

--- a/core/tool/execution.py
+++ b/core/tool/execution.py
@@ -447,9 +447,11 @@ def _invoke_runtime_tool(
 
     injected = tool.extract_params(tool_sources)
     kwargs = {**injected, **tc.input}
-    # Vendor-agnostic: each tool declares which extract_params keys must win
-    # over model input (secrets / connection fields). See ``injected_params``.
-    protected = frozenset(getattr(tool, "injected_params", ()) or ())
+    # Vendor-agnostic: hidden injected values and public authoritative context
+    # values must win over potentially stale model input when present.
+    protected = frozenset(
+        (*getattr(tool, "injected_params", ()), *getattr(tool, "context_params", ()))
+    )
     for key, value in injected.items():
         if key in protected and value not in (None, "", []):
             kwargs[key] = value

--- a/core/tool_framework/tool_decorator.py
+++ b/core/tool_framework/tool_decorator.py
@@ -44,6 +44,7 @@ def tool(
     injected_params: tuple[str, ...] | None = None,
     retrieval_controls: RetrievalControls | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
+    is_advertised: Callable[[dict[str, dict]], bool] | None = None,
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
     tags: tuple[str, ...] | None = None,
     requires_approval: bool | None = None,
@@ -80,6 +81,7 @@ def tool[F: Callable[..., Any]](
     injected_params: tuple[str, ...] | None = None,
     retrieval_controls: RetrievalControls | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
+    is_advertised: Callable[[dict[str, dict]], bool] | None = None,
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
     tags: tuple[str, ...] | None = None,
     requires_approval: bool | None = None,
@@ -116,6 +118,7 @@ def tool[F: Callable[..., Any]](
     injected_params: tuple[str, ...] | None = None,
     retrieval_controls: RetrievalControls | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
+    is_advertised: Callable[[dict[str, dict]], bool] | None = None,
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
     tags: tuple[str, ...] | None = None,
     requires_approval: bool | None = None,
@@ -151,6 +154,7 @@ def tool[F: Callable[..., Any]](
     injected_params: tuple[str, ...] | None = None,
     retrieval_controls: RetrievalControls | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
+    is_advertised: Callable[[dict[str, dict]], bool] | None = None,
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
     tags: tuple[str, ...] | None = None,
     requires_approval: bool | None = None,
@@ -190,6 +194,7 @@ def tool[F: Callable[..., Any]](
                 bool(injected_params),
                 retrieval_controls is not None,
                 is_available is not None,
+                is_advertised is not None,
                 extract_params is not None,
                 bool(tags),
                 requires_approval is not None,
@@ -212,6 +217,7 @@ def tool[F: Callable[..., Any]](
                 or parallel_safe is not None
                 or accepts_runtime_context is not None
                 or evidence_mapper is not None
+                or is_advertised is not None
             ):
                 setattr(
                     target,
@@ -227,6 +233,7 @@ def tool[F: Callable[..., Any]](
                         parallel_safe=parallel_safe,
                         accepts_runtime_context=accepts_runtime_context,
                         evidence_mapper=evidence_mapper,
+                        is_advertised=is_advertised,
                     ),
                 )
             return target
@@ -258,6 +265,7 @@ def tool[F: Callable[..., Any]](
                     injected_params=injected_params,
                     retrieval_controls=retrieval_controls,
                     is_available=is_available,
+                    is_advertised=is_advertised,
                     extract_params=extract_params,
                     tags=tags,
                     requires_approval=requires_approval,

--- a/core/tool_framework/tool_decorator.py
+++ b/core/tool_framework/tool_decorator.py
@@ -42,6 +42,7 @@ def tool(
     output_model: type[BaseModel] | None = None,
     evidence_mapper: EvidenceMapper | None = None,
     injected_params: tuple[str, ...] | None = None,
+    context_params: tuple[str, ...] | None = None,
     retrieval_controls: RetrievalControls | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
     is_advertised: Callable[[dict[str, dict]], bool] | None = None,
@@ -79,6 +80,7 @@ def tool[F: Callable[..., Any]](
     output_model: type[BaseModel] | None = None,
     evidence_mapper: EvidenceMapper | None = None,
     injected_params: tuple[str, ...] | None = None,
+    context_params: tuple[str, ...] | None = None,
     retrieval_controls: RetrievalControls | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
     is_advertised: Callable[[dict[str, dict]], bool] | None = None,
@@ -116,6 +118,7 @@ def tool[F: Callable[..., Any]](
     output_model: type[BaseModel] | None = None,
     evidence_mapper: EvidenceMapper | None = None,
     injected_params: tuple[str, ...] | None = None,
+    context_params: tuple[str, ...] | None = None,
     retrieval_controls: RetrievalControls | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
     is_advertised: Callable[[dict[str, dict]], bool] | None = None,
@@ -152,6 +155,7 @@ def tool[F: Callable[..., Any]](
     output_model: type[BaseModel] | None = None,
     evidence_mapper: EvidenceMapper | None = None,
     injected_params: tuple[str, ...] | None = None,
+    context_params: tuple[str, ...] | None = None,
     retrieval_controls: RetrievalControls | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
     is_advertised: Callable[[dict[str, dict]], bool] | None = None,
@@ -192,6 +196,7 @@ def tool[F: Callable[..., Any]](
                 output_model is not None,
                 evidence_mapper is not None,
                 bool(injected_params),
+                bool(context_params),
                 retrieval_controls is not None,
                 is_available is not None,
                 is_advertised is not None,
@@ -218,6 +223,7 @@ def tool[F: Callable[..., Any]](
                 or accepts_runtime_context is not None
                 or evidence_mapper is not None
                 or is_advertised is not None
+                or context_params is not None
             ):
                 setattr(
                     target,
@@ -234,6 +240,7 @@ def tool[F: Callable[..., Any]](
                         accepts_runtime_context=accepts_runtime_context,
                         evidence_mapper=evidence_mapper,
                         is_advertised=is_advertised,
+                        context_params=context_params,
                     ),
                 )
             return target
@@ -263,6 +270,7 @@ def tool[F: Callable[..., Any]](
                     output_model=output_model,
                     evidence_mapper=evidence_mapper,
                     injected_params=injected_params,
+                    context_params=context_params,
                     retrieval_controls=retrieval_controls,
                     is_available=is_available,
                     is_advertised=is_advertised,

--- a/infrastructure/harness_providers/repo_scope.py
+++ b/infrastructure/harness_providers/repo_scope.py
@@ -32,9 +32,9 @@ class VcsRepoScopeProvider(Protocol):
         env: Mapping[str, str] | None,
         cwd: str | Path | None,
         cached: tuple[str, ...] | None,
+        prefer_cwd_over_environment: bool = False,
     ) -> tuple[str, ...] | None:
-        """Resolve this vendor's repo scope from message/history/env/git/cache."""
-        raise NotImplementedError
+        """Resolve scope, optionally preferring the cwd over ambient repo identity."""
 
     def apply(self, resolved: dict[str, Any], scope: tuple[str, ...]) -> dict[str, Any]:
         """Return a copy of *resolved* enriched with this vendor's scope."""
@@ -71,6 +71,7 @@ def enrich_resolved_with_repo_scopes(
     env: Mapping[str, str] | None,
     cwd: str | Path | None,
     cached_scopes: Mapping[str, tuple[str, ...]],
+    prefer_cwd_over_environment: bool = False,
     set_cached_scope: Callable[[str, tuple[str, ...] | None], None] | None = None,
     remember_scope: Callable[[str, str, tuple[str, ...]], None] | None = None,
 ) -> dict[str, Any]:
@@ -98,6 +99,7 @@ def enrich_resolved_with_repo_scopes(
             env=env,
             cwd=cwd,
             cached=cached_scopes.get(provider.vendor),
+            prefer_cwd_over_environment=prefer_cwd_over_environment,
         )
         if not scope:
             continue

--- a/infrastructure/process/termination.py
+++ b/infrastructure/process/termination.py
@@ -1,0 +1,41 @@
+"""Cross-platform process-tree termination primitives."""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+
+def terminate_process_tree(
+    pid: int,
+    *,
+    grace_seconds: float,
+    force_wait_seconds: float,
+) -> None:
+    """Terminate a process tree through the project's psutil boundary."""
+    import psutil
+
+    if pid <= 0:
+        return
+    try:
+        root = psutil.Process(pid)
+        processes: list[Any] = [*reversed(root.children(recursive=True)), root]
+    except (psutil.Error, OSError):
+        return
+
+    # Stop descendants before their parent so they cannot be orphaned.
+    for process in processes:
+        with contextlib.suppress(psutil.Error, OSError):
+            process.terminate()
+    alive = processes
+    with contextlib.suppress(psutil.Error, OSError):
+        _, alive = psutil.wait_procs(processes, timeout=grace_seconds)
+    for process in alive:
+        with contextlib.suppress(psutil.Error, OSError):
+            process.kill()
+    if alive:
+        with contextlib.suppress(psutil.Error, OSError):
+            psutil.wait_procs(alive, timeout=force_wait_seconds)
+
+
+__all__ = ["terminate_process_tree"]

--- a/integrations/github/helpers.py
+++ b/integrations/github/helpers.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from integrations.github.client import resolve_github_token
 from integrations.github.mcp import (
     DEFAULT_GITHUB_MCP_MODE,
     GitHubMCPConfig,
@@ -46,6 +47,16 @@ def github_source_available(sources: dict[str, dict]) -> bool:
     ``github`` entry or a falsy/missing ``connection_verified`` returns False.
     """
     return bool(sources.get("github", {}).get("connection_verified"))
+
+
+def github_credentials_available(sources: dict[str, dict]) -> bool:
+    """Return True when a verified source or fallback REST token is available."""
+    gh = sources.get("github", {})
+    return bool(
+        github_source_available(sources)
+        or github_creds(gh).get("github_token")
+        or resolve_github_token(None)
+    )
 
 
 def github_creds(gh: dict) -> dict[str, Any]:

--- a/integrations/github/helpers.py
+++ b/integrations/github/helpers.py
@@ -10,6 +10,8 @@ Exports:
 
 - ``GITHUB_INJECTED_PARAMS``: kwargs ``extract_params`` may inject that must
   win over model-supplied values at call time.
+- ``GITHUB_REPOSITORY_CONTEXT_PARAMS``: public repository identifiers whose
+  refreshed runtime values must win over stale model-supplied scope.
 - ``github_source_available``: predicate on the integration store entry.
 - ``github_creds``: maps classified integration fields to tool kwargs.
 - ``resolve_github_mcp_config``: merges env defaults with explicit overrides.
@@ -35,6 +37,7 @@ GITHUB_INJECTED_PARAMS: tuple[str, ...] = (
     "github_command",
     "github_args",
 )
+GITHUB_REPOSITORY_CONTEXT_PARAMS: tuple[str, ...] = ("owner", "repo")
 
 
 def github_source_available(sources: dict[str, dict]) -> bool:

--- a/integrations/github/repo_scope.py
+++ b/integrations/github/repo_scope.py
@@ -130,9 +130,14 @@ def _infer_workspace_repo_scope(
     *,
     env: Mapping[str, str] | None,
     cwd: str | Path | None,
+    prefer_cwd_over_environment: bool = False,
 ) -> tuple[str, str] | None:
     """Resolve only the process workspace repository, not prompt-provided scope."""
     env_map = env if env is not None else os.environ
+    if prefer_cwd_over_environment:
+        cwd_scope = detect_git_remote_repo_scope(cwd)
+        if cwd_scope is not None:
+            return cwd_scope
     for key in WORKSPACE_REPO_ENV_KEYS:
         source = workspace_public_repository_source({"workspace_repo": str(env_map.get(key, ""))})
         github = source.get("github", {})
@@ -180,6 +185,7 @@ class _GithubVcsRepoScopeProvider:
         env: Mapping[str, str] | None,
         cwd: str | Path | None,
         cached: tuple[str, ...] | None,
+        prefer_cwd_over_environment: bool = False,
     ) -> tuple[str, ...] | None:
         from_message = parse_github_repository_reference(message)
         if from_message:
@@ -191,7 +197,11 @@ class _GithubVcsRepoScopeProvider:
                     return from_history
         if cached:
             return cached
-        workspace_scope = _infer_workspace_repo_scope(env=env, cwd=cwd)
+        workspace_scope = _infer_workspace_repo_scope(
+            env=env,
+            cwd=cwd,
+            prefer_cwd_over_environment=prefer_cwd_over_environment,
+        )
         if workspace_scope is None:
             return None
         return (*workspace_scope, _PUBLIC_WORKSPACE_SCOPE_MARKER)

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -16,6 +16,7 @@ from integrations.github.client import GitHubApiError, GitHubRestClient
 from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
     resolve_github_mcp_config,
@@ -718,6 +719,7 @@ def _map_list_github_actions_workflow_runs(
     is_advertised=github_source_available,
     extract_params=_github_actions_repo_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_list_github_actions_workflow_runs,
 )
 def list_github_actions_workflow_runs(
@@ -871,6 +873,7 @@ def _map_list_github_actions_active_runs(
     is_advertised=github_source_available,
     extract_params=_github_actions_repo_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_list_github_actions_active_runs,
 )
 def list_github_actions_active_runs(
@@ -1001,6 +1004,7 @@ def _map_list_github_actions_run_jobs(
     is_advertised=github_source_available,
     extract_params=_github_actions_run_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_list_github_actions_run_jobs,
 )
 def list_github_actions_run_jobs(
@@ -1140,6 +1144,7 @@ def _map_get_github_actions_step_log(
     is_advertised=github_source_available,
     extract_params=_github_actions_run_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_get_github_actions_step_log,
 )
 def get_github_actions_step_log(

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -618,10 +618,10 @@ def _github_actions_is_available(sources: dict[str, dict]) -> bool:
 
 def _github_actions_repo_params(sources: dict[str, dict]) -> dict[str, Any]:
     """Extract repo parameters for GitHub Actions tools."""
-    github = sources["github"]
+    github = sources.get("github", {})
     params: dict[str, Any] = {
-        "owner": github["owner"],
-        "repo": github["repo"],
+        "owner": github.get("owner"),
+        "repo": github.get("repo"),
         **github_creds(github),
     }
     return params
@@ -715,6 +715,7 @@ def _map_list_github_actions_workflow_runs(
         "required": ["owner", "repo"],
     },
     is_available=_github_actions_is_available,
+    is_advertised=github_source_available,
     extract_params=_github_actions_repo_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_list_github_actions_workflow_runs,
@@ -867,6 +868,7 @@ def _map_list_github_actions_active_runs(
         "required": ["owner", "repo"],
     },
     is_available=_github_actions_is_available,
+    is_advertised=github_source_available,
     extract_params=_github_actions_repo_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_list_github_actions_active_runs,
@@ -996,6 +998,7 @@ def _map_list_github_actions_run_jobs(
         "required": ["owner", "repo", "run_id"],
     },
     is_available=_github_actions_is_available,
+    is_advertised=github_source_available,
     extract_params=_github_actions_run_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_list_github_actions_run_jobs,
@@ -1134,6 +1137,7 @@ def _map_get_github_actions_step_log(
         "required": ["owner", "repo", "run_id", "job_id"],
     },
     is_available=_github_actions_is_available,
+    is_advertised=github_source_available,
     extract_params=_github_actions_run_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_get_github_actions_step_log,

--- a/integrations/github/tools/architecture_issue_tool/tool.py
+++ b/integrations/github/tools/architecture_issue_tool/tool.py
@@ -8,6 +8,7 @@ from core.agent_harness.tools import action_context_from_agent_context
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
 from core.tool_framework import tool
+from integrations.github.helpers import GITHUB_REPOSITORY_CONTEXT_PARAMS
 from integrations.github.tools.architecture_issue_tool.repo_workspace import (
     WorkspaceError,
     architecture_workspace_dir,
@@ -107,6 +108,7 @@ def _session_id_from_runtime(context: Any, explicit: str = "") -> str:
     is_available=_github_clone_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_CLI_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def architecture_clone_repo(
     owner: str,

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -19,6 +19,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
 )
@@ -359,6 +360,7 @@ def _result(
     is_available=_available,
     extract_params=_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_evidence,
 )
 def analyze_github_ci_reliability(

--- a/integrations/github/tools/ci_fix/tool.py
+++ b/integrations/github/tools/ci_fix/tool.py
@@ -11,6 +11,7 @@ from core.tool_framework import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
 )
@@ -131,6 +132,7 @@ def _confirm_fn(context: Any) -> Any:
     is_available=_github_ci_fix_available,
     extract_params=_github_ci_fix_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def fix_github_pr_ci(
     owner: str | None = None,

--- a/integrations/github/tools/commits.py
+++ b/integrations/github/tools/commits.py
@@ -11,6 +11,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
     resolve_github_mcp_config,
@@ -93,6 +94,7 @@ def _map_list_github_commits(
     is_advertised=github_source_available,
     extract_params=_list_github_commits_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_list_github_commits,
 )
 def list_github_commits(

--- a/integrations/github/tools/commits.py
+++ b/integrations/github/tools/commits.py
@@ -33,10 +33,10 @@ def _unwrap_exception_message(exc: BaseException) -> str:
 
 
 def _list_github_commits_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gh = sources["github"]
+    gh = sources.get("github", {})
     return {
-        "owner": gh["owner"],
-        "repo": gh["repo"],
+        "owner": gh.get("owner"),
+        "repo": gh.get("repo"),
         "path": gh.get("path", ""),
         "sha": gh.get("sha") or gh.get("ref", ""),
         "per_page": 10,
@@ -90,6 +90,7 @@ def _map_list_github_commits(
         "required": ["owner", "repo"],
     },
     is_available=_list_github_commits_available,
+    is_advertised=github_source_available,
     extract_params=_list_github_commits_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_list_github_commits,

--- a/integrations/github/tools/community_followup_tool/__init__.py
+++ b/integrations/github/tools/community_followup_tool/__init__.py
@@ -12,6 +12,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    github_credentials_available,
     github_creds,
     github_source_available,
 )
@@ -68,6 +69,7 @@ def _community_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "required": [],
     },
     is_available=_community_available,
+    is_advertised=github_credentials_available,
     extract_params=_community_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
 )

--- a/integrations/github/tools/community_followup_tool/__init__.py
+++ b/integrations/github/tools/community_followup_tool/__init__.py
@@ -12,6 +12,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_credentials_available,
     github_creds,
     github_source_available,
@@ -72,6 +73,7 @@ def _community_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     is_advertised=github_credentials_available,
     extract_params=_community_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def summarize_community_followups(
     owner: str = "",

--- a/integrations/github/tools/file_contents.py
+++ b/integrations/github/tools/file_contents.py
@@ -31,11 +31,11 @@ def _file_from_resource_text(content: list[dict[str, Any]]) -> dict[str, Any] | 
 
 
 def _get_github_file_contents_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gh = sources["github"]
+    gh = sources.get("github", {})
     return {
-        "owner": gh["owner"],
-        "repo": gh["repo"],
-        "path": gh["path"],
+        "owner": gh.get("owner"),
+        "repo": gh.get("repo"),
+        "path": gh.get("path", ""),
         "ref": gh.get("ref", ""),
         "sha": gh.get("sha", ""),
         **github_creds(gh),
@@ -89,6 +89,7 @@ def _map_get_github_file_contents(
         "required": ["owner", "repo", "path"],
     },
     is_available=_get_github_file_contents_available,
+    is_advertised=github_source_available,
     extract_params=_get_github_file_contents_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_get_github_file_contents,

--- a/integrations/github/tools/file_contents.py
+++ b/integrations/github/tools/file_contents.py
@@ -11,6 +11,7 @@ from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
     resolve_github_mcp_config,
@@ -92,6 +93,7 @@ def _map_get_github_file_contents(
     is_advertised=github_source_available,
     extract_params=_get_github_file_contents_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_get_github_file_contents,
 )
 def get_github_file_contents(

--- a/integrations/github/tools/git_deploy_timeline_tool/__init__.py
+++ b/integrations/github/tools/git_deploy_timeline_tool/__init__.py
@@ -131,7 +131,7 @@ def _summarize_commit(raw: dict[str, Any]) -> dict[str, Any]:
 
 
 def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gh = sources["github"]
+    gh = sources.get("github", {})
     # ``_meta`` carries investigation-level context shared across tools
     # (today: incident_window). Tools that don't care about it ignore the
     # key. See the investigation agent tool context for where this is set.
@@ -142,8 +142,8 @@ def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     meta = raw_meta if isinstance(raw_meta, dict) else {}
     incident_window = meta.get("incident_window")
     return {
-        "owner": gh["owner"],
-        "repo": gh["repo"],
+        "owner": gh.get("owner"),
+        "repo": gh.get("repo"),
         "branch": gh.get("branch") or gh.get("default_branch") or "main",
         "shared_incident_window": incident_window if isinstance(incident_window, dict) else None,
         **github_creds(gh),
@@ -221,6 +221,7 @@ def _map_get_git_deploy_timeline(
         "required": ["owner", "repo"],
     },
     is_available=_is_available,
+    is_advertised=github_source_available,
     extract_params=_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_get_git_deploy_timeline,

--- a/integrations/github/tools/git_deploy_timeline_tool/__init__.py
+++ b/integrations/github/tools/git_deploy_timeline_tool/__init__.py
@@ -30,6 +30,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
     resolve_github_mcp_config,
@@ -224,6 +225,7 @@ def _map_get_git_deploy_timeline(
     is_advertised=github_source_available,
     extract_params=_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_get_git_deploy_timeline,
 )
 def get_git_deploy_timeline(

--- a/integrations/github/tools/github_cli/tool.py
+++ b/integrations/github/tools/github_cli/tool.py
@@ -16,6 +16,8 @@ from integrations.github.tools.github_cli.credentials import (
 from integrations.github.tools.github_cli.runner import run_gh
 from integrations.github.tools.github_cli.summary import attach_summary
 
+_REPOSITORY_CONTEXT_PARAMS = ("repo",)
+
 _ARGS_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -106,6 +108,7 @@ def _normalize_args(args: list[str] | None) -> list[str]:
     is_available=_github_cli_available,
     extract_params=_github_cli_extract_params,
     injected_params=GITHUB_CLI_INJECTED_PARAMS,
+    context_params=_REPOSITORY_CONTEXT_PARAMS,
 )
 def github_cli(
     args: list[str],

--- a/integrations/github/tools/issues.py
+++ b/integrations/github/tools/issues.py
@@ -11,6 +11,7 @@ from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
     resolve_github_mcp_config,
@@ -81,6 +82,7 @@ def _map_search_github_issues(
     is_advertised=github_source_available,
     extract_params=_search_github_issues_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def search_github_issues(
     owner: str,

--- a/integrations/github/tools/issues.py
+++ b/integrations/github/tools/issues.py
@@ -22,10 +22,10 @@ from integrations.github.mcp import (
 
 
 def _search_github_issues_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gh = sources["github"]
+    gh = sources.get("github", {})
     return {
-        "owner": gh["owner"],
-        "repo": gh["repo"],
+        "owner": gh.get("owner"),
+        "repo": gh.get("repo"),
         "query": gh.get("query") or "crash OR error OR exception",
         "state": gh.get("state", "open"),
         **github_creds(gh),
@@ -78,6 +78,7 @@ def _map_search_github_issues(
         "required": ["owner", "repo", "query"],
     },
     is_available=_search_github_issues_available,
+    is_advertised=github_source_available,
     extract_params=_search_github_issues_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
 )

--- a/integrations/github/tools/repository.py
+++ b/integrations/github/tools/repository.py
@@ -12,6 +12,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_credentials_available,
     github_creds,
     github_source_available,
@@ -107,6 +108,7 @@ def _map_get_github_repository(
     is_advertised=github_credentials_available,
     extract_params=_github_repository_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_get_github_repository,
 )
 def get_github_repository(

--- a/integrations/github/tools/repository.py
+++ b/integrations/github/tools/repository.py
@@ -12,6 +12,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    github_credentials_available,
     github_creds,
     github_source_available,
 )
@@ -103,6 +104,7 @@ def _map_get_github_repository(
         "required": ["owner", "repo"],
     },
     is_available=_github_repository_available,
+    is_advertised=github_credentials_available,
     extract_params=_github_repository_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_get_github_repository,

--- a/integrations/github/tools/repository_tree.py
+++ b/integrations/github/tools/repository_tree.py
@@ -11,6 +11,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
     resolve_github_mcp_config,
@@ -79,6 +80,7 @@ def _map_get_github_repository_tree(
     is_advertised=github_source_available,
     extract_params=_get_github_repository_tree_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_get_github_repository_tree,
 )
 def get_github_repository_tree(

--- a/integrations/github/tools/repository_tree.py
+++ b/integrations/github/tools/repository_tree.py
@@ -19,10 +19,10 @@ from integrations.github.mcp import call_github_mcp_tool
 
 
 def _get_github_repository_tree_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gh = sources["github"]
+    gh = sources.get("github", {})
     return {
-        "owner": gh["owner"],
-        "repo": gh["repo"],
+        "owner": gh.get("owner"),
+        "repo": gh.get("repo"),
         "path_filter": gh.get("path", ""),
         "tree_sha": gh.get("sha") or gh.get("ref", ""),
         "recursive": True,
@@ -76,6 +76,7 @@ def _map_get_github_repository_tree(
         "required": ["owner", "repo"],
     },
     is_available=_get_github_repository_tree_available,
+    is_advertised=github_source_available,
     extract_params=_get_github_repository_tree_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_get_github_repository_tree,

--- a/integrations/github/tools/search_code.py
+++ b/integrations/github/tools/search_code.py
@@ -11,6 +11,7 @@ from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
     resolve_github_mcp_config,
@@ -79,6 +80,7 @@ def _map_search_github_code(
     is_advertised=github_source_available,
     extract_params=_search_github_code_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def search_github_code(
     owner: str,

--- a/integrations/github/tools/search_code.py
+++ b/integrations/github/tools/search_code.py
@@ -22,10 +22,10 @@ from integrations.github.mcp import (
 
 
 def _search_github_code_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gh = sources["github"]
+    gh = sources.get("github", {})
     return {
-        "owner": gh["owner"],
-        "repo": gh["repo"],
+        "owner": gh.get("owner"),
+        "repo": gh.get("repo"),
         "query": gh.get("query") or "exception OR error",
         **github_creds(gh),
     }
@@ -76,6 +76,7 @@ def _map_search_github_code(
         "required": ["owner", "repo", "query"],
     },
     is_available=_search_github_code_available,
+    is_advertised=github_source_available,
     extract_params=_search_github_code_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
 )

--- a/integrations/github/tools/security_fix/tool.py
+++ b/integrations/github/tools/security_fix/tool.py
@@ -11,6 +11,7 @@ from core.tool_framework import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_creds,
     github_source_available,
 )
@@ -135,6 +136,7 @@ def _confirm_fn(context: Any) -> Any:
     is_available=_github_security_fix_available,
     extract_params=_github_security_fix_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def fix_github_security_alert(
     owner: str | None = None,

--- a/integrations/github/tools/stargazers.py
+++ b/integrations/github/tools/stargazers.py
@@ -16,6 +16,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    github_credentials_available,
     github_creds,
     github_source_available,
 )
@@ -160,6 +161,7 @@ def _map_get_github_star_history(
         "required": ["owner", "repo"],
     },
     is_available=_github_star_history_available,
+    is_advertised=github_credentials_available,
     extract_params=_github_star_history_extract_params,
     injected_params=(
         *GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -13,6 +13,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_credentials_available,
     github_creds,
     github_source_available,
@@ -172,6 +173,7 @@ def _map_summarize_github_pr_status(
     is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def list_github_work_items(
     owner: str,
@@ -313,6 +315,7 @@ def _count_prs(prs: list[dict[str, Any]]) -> dict[str, int]:
     is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def summarize_github_pr_status(
     owner: str,
@@ -438,6 +441,7 @@ _ISSUE_MUTATION_OPERATIONS = {"create", "update", "close"}
     is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_list_github_security_alerts,
 )
 def list_github_security_alerts(
@@ -511,6 +515,7 @@ def list_github_security_alerts(
     is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def propose_github_issue_mutation_from_slack(
     owner: str,
@@ -711,6 +716,7 @@ def _marker_exists_on_issue(
     is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
 )
 def execute_github_issue_mutation(
     owner: str,

--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -13,6 +13,7 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    github_credentials_available,
     github_creds,
     github_source_available,
 )
@@ -168,6 +169,7 @@ def _map_summarize_github_pr_status(
         "required": ["owner", "repo"],
     },
     is_available=_github_available,
+    is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
 )
@@ -308,6 +310,7 @@ def _count_prs(prs: list[dict[str, Any]]) -> dict[str, int]:
         "required": ["owner", "repo"],
     },
     is_available=_github_available,
+    is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
 )
@@ -432,6 +435,7 @@ _ISSUE_MUTATION_OPERATIONS = {"create", "update", "close"}
         "required": ["owner", "repo"],
     },
     is_available=_github_available,
+    is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_list_github_security_alerts,
@@ -504,6 +508,7 @@ def list_github_security_alerts(
         "required": ["owner", "repo", "operation", "slack_text"],
     },
     is_available=_github_available,
+    is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
 )
@@ -703,6 +708,7 @@ def _marker_exists_on_issue(
         "required": ["owner", "repo", "proposal"],
     },
     is_available=_github_available,
+    is_advertised=github_credentials_available,
     extract_params=_github_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
 )

--- a/integrations/github/tools/work_status_report_tool/__init__.py
+++ b/integrations/github/tools/work_status_report_tool/__init__.py
@@ -11,6 +11,7 @@ from core.tool_framework import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    GITHUB_REPOSITORY_CONTEXT_PARAMS,
     github_credentials_available,
     github_creds,
     github_source_available,
@@ -75,6 +76,7 @@ def _map_generate_work_status_report(
     is_advertised=github_credentials_available,
     extract_params=_report_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
+    context_params=GITHUB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_generate_work_status_report,
 )
 def generate_work_status_report(

--- a/integrations/github/tools/work_status_report_tool/__init__.py
+++ b/integrations/github/tools/work_status_report_tool/__init__.py
@@ -11,6 +11,7 @@ from core.tool_framework import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
+    github_credentials_available,
     github_creds,
     github_source_available,
 )
@@ -71,6 +72,7 @@ def _map_generate_work_status_report(
         "required": [],
     },
     is_available=_report_available,
+    is_advertised=github_credentials_available,
     extract_params=_report_extract_params,
     injected_params=GITHUB_INJECTED_PARAMS,
     evidence_mapper=_map_generate_work_status_report,

--- a/integrations/gitlab/repo_scope.py
+++ b/integrations/gitlab/repo_scope.py
@@ -140,6 +140,7 @@ def infer_gitlab_repo_scope(
     env: Mapping[str, str] | None = None,
     cwd: str | Path | None = None,
     cached: tuple[str, str, str] | None = None,
+    prefer_cwd_over_environment: bool = False,
 ) -> GitlabRepoScope | None:
     """Resolve GitLab scope from message, history, cache, environment, or git."""
     env_map = env if env is not None else os.environ
@@ -157,6 +158,11 @@ def infer_gitlab_repo_scope(
 
     if cached:
         return GitlabRepoScope(*cached)
+
+    if prefer_cwd_over_environment:
+        cwd_scope = detect_git_remote_repo_scope(cwd, allowed_hosts=allowed_hosts)
+        if cwd_scope is not None:
+            return cwd_scope
 
     project = _clean_project_path(str(env_map.get("GITLAB_PROJECT_ID", "")))
     if project:
@@ -211,6 +217,7 @@ class _GitlabVcsRepoScopeProvider:
         env: Mapping[str, str] | None,
         cwd: str | Path | None,
         cached: tuple[str, ...] | None,
+        prefer_cwd_over_environment: bool = False,
     ) -> tuple[str, ...] | None:
         cached_scope = GitlabRepoScope(*cached) if cached else None
         scope = infer_gitlab_repo_scope(
@@ -219,6 +226,7 @@ class _GitlabVcsRepoScopeProvider:
             env=env,
             cwd=cwd,
             cached=cached_scope,
+            prefer_cwd_over_environment=prefer_cwd_over_environment,
         )
         return tuple(scope) if scope else None
 

--- a/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
@@ -15,6 +15,8 @@ from integrations.gitlab import (
     gitlab_config_from_env,
 )
 
+_GITLAB_REPOSITORY_CONTEXT_PARAMS = ("project_id",)
+
 
 #: Every GitLab list tool (commits/pipelines/MRs) sends ``per_page`` straight
 #: to the GitLab API as its own page-size param and returns the raw page with
@@ -127,6 +129,7 @@ def _map_list_gitlab_commits(
     is_available=_list_gitlab_commits_available,
     is_advertised=_gitlab_available,
     extract_params=_list_gitlab_commits_extract_params,
+    context_params=_GITLAB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_list_gitlab_commits,
 )
 def list_gitlab_commits(

--- a/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
@@ -71,9 +71,9 @@ def _resolve_config(gitlab_url: str | None, gitlab_token: str | None) -> GitlabC
 
 
 def _list_gitlab_commits_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gl = sources["gitlab"]
+    gl = sources.get("gitlab", {})
     return {
-        "project_id": gl["project_id"],
+        "project_id": gl.get("project_id"),
         "since": gl.get("since", ""),
         "ref_name": gl.get("ref_name", "main"),
         "per_page": 10,
@@ -125,6 +125,7 @@ def _map_list_gitlab_commits(
         "required": ["project_id"],
     },
     is_available=_list_gitlab_commits_available,
+    is_advertised=_gitlab_available,
     extract_params=_list_gitlab_commits_extract_params,
     evidence_mapper=_map_list_gitlab_commits,
 )

--- a/integrations/gitlab/tools/gitlab_file_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_file_tool/__init__.py
@@ -13,6 +13,7 @@ from integrations.gitlab import (
     get_gitlab_file,
 )
 from integrations.gitlab.tools.gitlab_commits_tool import (
+    _GITLAB_REPOSITORY_CONTEXT_PARAMS,
     _gitlab_available,
     _gl_creds,
     _resolve_config,
@@ -76,6 +77,7 @@ def _get_gitlab_file_available(sources: dict[str, dict]) -> bool:
     is_available=_get_gitlab_file_available,
     is_advertised=_gitlab_available,
     extract_params=_get_gitlab_file_extract_params,
+    context_params=_GITLAB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_get_gitlab_file_contents,
 )
 def get_gitlab_file_contents(

--- a/integrations/gitlab/tools/gitlab_file_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_file_tool/__init__.py
@@ -39,9 +39,9 @@ def _map_get_gitlab_file_contents(
 
 
 def _get_gitlab_file_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gl = sources["gitlab"]
+    gl = sources.get("gitlab", {})
     return {
-        "project_id": gl["project_id"],
+        "project_id": gl.get("project_id"),
         "file_path": gl.get("file_path", ""),
         "ref": gl.get("ref_name", "main"),
         **_gl_creds(gl),
@@ -74,6 +74,7 @@ def _get_gitlab_file_available(sources: dict[str, dict]) -> bool:
         "required": ["project_id", "file_path"],
     },
     is_available=_get_gitlab_file_available,
+    is_advertised=_gitlab_available,
     extract_params=_get_gitlab_file_extract_params,
     evidence_mapper=_map_get_gitlab_file_contents,
 )

--- a/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
@@ -39,9 +39,9 @@ def _map_list_gitlab_mrs(
 
 
 def _list_gitlab_mrs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gl = sources["gitlab"]
+    gl = sources.get("gitlab", {})
     return {
-        "project_id": gl["project_id"],
+        "project_id": gl.get("project_id"),
         "updated_after": gl.get("updated_after", ""),
         "target_branch": gl.get("target_branch", "main"),
         "per_page": 10,
@@ -76,6 +76,7 @@ def _list_gitlab_mrs_available(sources: dict[str, dict]) -> bool:
         "required": ["project_id"],
     },
     is_available=_list_gitlab_mrs_available,
+    is_advertised=_gitlab_available,
     extract_params=_list_gitlab_mrs_extract_params,
     evidence_mapper=_map_list_gitlab_mrs,
 )

--- a/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
@@ -12,6 +12,7 @@ from integrations.gitlab import (
     get_gitlab_mrs,
 )
 from integrations.gitlab.tools.gitlab_commits_tool import (
+    _GITLAB_REPOSITORY_CONTEXT_PARAMS,
     _gitlab_available,
     _gitlab_count_label,
     _gl_creds,
@@ -78,6 +79,7 @@ def _list_gitlab_mrs_available(sources: dict[str, dict]) -> bool:
     is_available=_list_gitlab_mrs_available,
     is_advertised=_gitlab_available,
     extract_params=_list_gitlab_mrs_extract_params,
+    context_params=_GITLAB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_list_gitlab_mrs,
 )
 def list_gitlab_mrs(

--- a/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
@@ -12,6 +12,7 @@ from integrations.gitlab import (
     get_gitlab_pipelines,
 )
 from integrations.gitlab.tools.gitlab_commits_tool import (
+    _GITLAB_REPOSITORY_CONTEXT_PARAMS,
     _gitlab_available,
     _gitlab_count_label,
     _gl_creds,
@@ -80,6 +81,7 @@ def _list_gitlab_pipelines_available(sources: dict[str, dict]) -> bool:
     is_available=_list_gitlab_pipelines_available,
     is_advertised=_gitlab_available,
     extract_params=_list_gitlab_pipelines_extract_params,
+    context_params=_GITLAB_REPOSITORY_CONTEXT_PARAMS,
     evidence_mapper=_map_list_gitlab_pipelines,
 )
 def list_gitlab_pipelines(

--- a/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
@@ -39,9 +39,9 @@ def _map_list_gitlab_pipelines(
 
 
 def _list_gitlab_pipelines_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
-    gl = sources["gitlab"]
+    gl = sources.get("gitlab", {})
     return {
-        "project_id": gl["project_id"],
+        "project_id": gl.get("project_id"),
         "updated_after": gl.get("updated_after", ""),
         "ref": gl.get("ref_name", "main"),
         "status": "failed",
@@ -78,6 +78,7 @@ def _list_gitlab_pipelines_available(sources: dict[str, dict]) -> bool:
         "required": ["project_id"],
     },
     is_available=_list_gitlab_pipelines_available,
+    is_advertised=_gitlab_available,
     extract_params=_list_gitlab_pipelines_extract_params,
     evidence_mapper=_map_list_gitlab_pipelines,
 )

--- a/surfaces/interactive_shell/AGENTS.md
+++ b/surfaces/interactive_shell/AGENTS.md
@@ -22,7 +22,7 @@ should be predictable, interruptible, explainable, and safe by default.
 | `runtime/core/turn_accounting.py` | shell turn accounting (`ShellTurnAccounting`) for analytics, telemetry, recorder flush, turn persistence, and intent stamps | turn-flow control (owned by `core.agent_harness`) or tool-calling turn execution |
 | `command_registry/` | slash-command definitions, argument validation, command dispatch | long-running implementation details better placed in services/runtime modules |
 | `runtime/` | background task workers, lifecycle/`ReplState`, runtime context assembly, semantic shell-turn execution, and core harness adapters | prompt text, reusable session persistence, or compatibility shims |
-| `tools/interactive_shell/shell/` | shell command parsing, shell execution policy, subprocess execution, and the `run_shell_command`/`run_cd`/`run_pwd` runner (next to the `shell_run` tool in `tools/interactive_shell/actions/shell.py`) | slash-command execution |
+| `tools/interactive_shell/shell/` | shell input normalization, shell execution policy, subprocess execution, and the `run_shell_command` runner (next to `shell_run` and `set_working_directory` in `tools/interactive_shell/actions/shell.py`) | slash-command execution |
 | `references/` | CLI/docs/source/AGENTS reference loading and caching | generated model prose |
 | `config/` | interactive-shell config loading and tool catalog metadata | global app config unrelated to the REPL |
 | `ui/` | Rich/prompt-toolkit rendering, theme, menus, streaming output, and domain views such as `incoming_alerts.py` (receiver/queue/listener lifecycle lives in `core.domain.alerts.inbox`) | business logic or network calls |

--- a/surfaces/interactive_shell/runtime/subprocess_runner/__init__.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/__init__.py
@@ -9,8 +9,8 @@ parity. Tests and callers import canonical names from
 ``tools.interactive_shell.cli`` rather than underscore aliases here.
 
 Shell command execution lives in ``tools.interactive_shell.shell`` (parsing,
-policy, ``execute_shell_command``, and the ``run_shell_command`` / ``run_cd`` /
-``run_pwd`` runner); it is intentionally not re-exported here. Claude Code
+policy, ``execute_shell_command``, and the ``run_shell_command`` runner); it is
+intentionally not re-exported here. Claude Code
 implementation execution lives in ``tools.interactive_shell.implementation.claude_code_executor``
 (``run_claude_code_implementation``); it is not re-exported here. Shared stdlib
 subprocess primitives live in ``tools.interactive_shell.subprocess``; Rich
@@ -29,7 +29,7 @@ inside the submodules.
 from __future__ import annotations
 
 # Stdlib singletons — imported so that monkeypatch paths resolve correctly in tests:
-# ``"…subprocess_runner.os.chdir"``, ``"…subprocess_runner.subprocess.Popen"``,
+# ``"…subprocess_runner.os.openpty"``, ``"…subprocess_runner.subprocess.Popen"``,
 # ``"…subprocess_runner.threading.Thread"``, ``"…subprocess_runner.time.sleep"``,
 # ``"…subprocess_runner.Path.cwd"``.
 import os

--- a/surfaces/interactive_shell/runtime/subprocess_runner/background_task_executor.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/background_task_executor.py
@@ -17,6 +17,7 @@ from surfaces.interactive_shell.runtime import Session, TaskKind, TaskRecord
 from surfaces.interactive_shell.telemetry import PromptRecorder
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
 from surfaces.shared.error_handling.exception_reporting import report_exception
+from tools.interactive_shell.working_directory import session_working_directory
 
 from .task_streaming import (
     _MAX_COMMAND_OUTPUT_CHARS,
@@ -102,6 +103,7 @@ def start_background_cli_task(
                 text=True,
                 encoding="utf-8",
                 errors="replace",
+                cwd=session_working_directory(session),
                 start_new_session=True,
                 env=subprocess_env,
             )
@@ -113,6 +115,7 @@ def start_background_cli_task(
                 stdout=slave_fd,
                 stderr=slave_fd,
                 close_fds=True,
+                cwd=session_working_directory(session),
                 start_new_session=True,
                 env=subprocess_env,
             )

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -73,6 +73,7 @@ _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
     ActionToolName.CLI_EXEC: ("opensre", "payload"),
     ActionToolName.CODE_IMPLEMENT: ("implementation", "task"),
     ActionToolName.SHELL_RUN: ("Execute", "command"),
+    ActionToolName.SET_WORKING_DIRECTORY: ("Working directory", "path"),
 }
 
 #: Tools that must not appear in the post-execution plan work log (plan/UI plumbing).

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -4,16 +4,14 @@ from __future__ import annotations
 
 import io
 import subprocess
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 import pytest
 from rich.console import Console
 
-import config.constants.platform as platform_module
 import surfaces.interactive_shell.runtime.action_turn as action_turn
 import surfaces.interactive_shell.runtime.llm_provider_adapter as llm_provider_adapter
 import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
-import surfaces.interactive_shell.runtime.subprocess_runner as subprocess_runner
 import tests.shared.harness_turn_driver as harness_turn_driver
 import tools.interactive_shell.shell.execution as shell_execution
 from core.llm.types import AgentLLMResponse, ToolCall
@@ -90,6 +88,8 @@ def _tool_args_for_action(action: PlannedAction) -> dict[str, object]:
         return {"target": content}
     if action.kind == "shell":
         return {"command": content}
+    if action.kind == "working_directory":
+        return {"path": content}
     if action.kind == "task_cancel":
         return {"target": content}
     if action.kind == "cli_command":
@@ -142,6 +142,7 @@ _EXPECTED_POPEN_KWARGS: dict[str, object] = {
     "text": True,
     "encoding": "utf-8",
     "errors": "replace",
+    "cwd": str(Path.cwd()),
     "start_new_session": True,
 }
 
@@ -211,8 +212,10 @@ def _expected_shell_argv(command: str) -> list[str]:
     if shell_execution.os.name == "nt":
         shell = shell_execution.os.environ.get("COMSPEC") or "cmd.exe"
         return [shell, "/d", "/s", "/c", command]
-    shell = shell_execution.os.environ.get("SHELL") or "/bin/sh"
-    return [shell, "-lc", command]
+    shell = shell_execution.os.environ.get("SHELL")
+    if shell:
+        return [shell, "-lc", command]
+    return ["/bin/sh", "-c", command]
 
 
 class _MessageMappedActionLLM(FakeActionLLM):
@@ -286,10 +289,6 @@ _FAKE_PLANS: dict[str, tuple[list[PlannedAction], bool]] = {
     ),
     # Shell phrases — the planner emits the exact command body for the shell tool.
     "run `pwd`": ([_action("shell", "pwd")], False),
-    r"run `cd C:\Users\Alice`": ([_action("shell", r"cd C:\Users\Alice")], False),
-    r"run `CD C:\Users\Alice`": ([_action("shell", r"CD C:\Users\Alice")], False),
-    r"run `cd C:\`": ([_action("shell", "cd C:\\")], False),
-    r'run `cd "C:\Users\Alice"`': ([_action("shell", r'cd "C:\Users\Alice"')], False),
     "execute false": ([_action("shell", "false")], False),
     "run `true`": ([_action("shell", "true")], False),
     "run `!echo hello`": ([_action("shell", "!echo hello")], False),
@@ -741,109 +740,53 @@ def test_execute_cli_actions_falls_through_for_chat() -> None:
 
 
 def test_execute_cli_actions_runs_shell_command(monkeypatch: object) -> None:
-    def _fake_cwd(_: type[Path]) -> PurePosixPath:
-        return PurePosixPath("/tmp/project")
-
-    def _fail_run(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
-        raise AssertionError("subprocess.run should not be used for pwd")
-
-    monkeypatch.setattr(subprocess_runner.Path, "cwd", classmethod(_fake_cwd))
-    monkeypatch.setattr(shell_execution.subprocess, "run", _fail_run)
-
     session = Session()
+    calls = _install_fake_popen(monkeypatch, stdout=f"{session.working_directory}\n")
     console, buf = _capture()
 
     assert action_turn.run_action_tool_turn("run `pwd`", session, console).handled is True
+    assert calls == [(_expected_shell_argv("pwd"), _EXPECTED_POPEN_KWARGS)]
     assert session.history == [
-        {"type": "shell", "text": "pwd", "ok": True},
+        {
+            "type": "shell",
+            "text": "pwd",
+            "ok": True,
+            "response_text": session.working_directory,
+        },
     ]
     output = buf.getvalue()
     assert "$ pwd" in output
-    assert "/tmp/project" in output
+    assert session.working_directory in output
 
 
-def test_execute_cli_actions_cd_preserves_windows_paths(monkeypatch: object) -> None:
-    changed_directories: list[Path] = []
-
-    def _fake_chdir(target: Path) -> None:
-        changed_directories.append(target)
-
-    monkeypatch.setattr(platform_module, "IS_WINDOWS", True)
-    monkeypatch.setattr(subprocess_runner.os, "chdir", _fake_chdir)
-
+def test_execute_cli_actions_sets_session_working_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_action_llm_factory(
+        monkeypatch,
+        lambda: FakeActionLLM(
+            [
+                _llm_response(
+                    [_action("working_directory", str(tmp_path))],
+                )
+            ]
+        ),
+    )
     session = Session()
-    console, _ = _capture()
+    original = session.working_directory
+    console, buf = _capture()
 
-    message = r"run `cd C:\Users\Alice`"
-    assert action_turn.run_action_tool_turn(message, session, console).handled is True
-    assert changed_directories == [Path(r"C:\Users\Alice")]
-    assert session.history == [
-        {"type": "shell", "text": r"cd C:\Users\Alice", "ok": True},
-    ]
-
-
-def test_execute_cli_actions_cd_dispatches_case_insensitively(monkeypatch: object) -> None:
-    changed_directories: list[Path] = []
-
-    def _fake_chdir(target: Path) -> None:
-        changed_directories.append(target)
-
-    def _fail_run(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
-        raise AssertionError("subprocess.run should not be used for CD")
-
-    monkeypatch.setattr(platform_module, "IS_WINDOWS", True)
-    monkeypatch.setattr(subprocess_runner.os, "chdir", _fake_chdir)
-    monkeypatch.setattr(shell_execution.subprocess, "run", _fail_run)
-
-    session = Session()
-    console, _ = _capture()
-
-    message = r"run `CD C:\Users\Alice`"
-    assert action_turn.run_action_tool_turn(message, session, console).handled is True
-    assert changed_directories == [Path(r"C:\Users\Alice")]
-    assert session.history == [
-        {"type": "shell", "text": r"CD C:\Users\Alice", "ok": True},
-    ]
-
-
-def test_execute_cli_actions_cd_handles_trailing_backslash_on_windows(monkeypatch: object) -> None:
-    changed_directories: list[Path] = []
-
-    def _fake_chdir(target: Path) -> None:
-        changed_directories.append(target)
-
-    monkeypatch.setattr(platform_module, "IS_WINDOWS", True)
-    monkeypatch.setattr(subprocess_runner.os, "chdir", _fake_chdir)
-
-    session = Session()
-    console, _ = _capture()
-
-    message = r"run `cd C:\`"
-    assert action_turn.run_action_tool_turn(message, session, console).handled is True
-    assert changed_directories == [Path("C:\\")]
-    assert session.history == [
-        {"type": "shell", "text": "cd C:\\", "ok": True},
-    ]
-
-
-def test_execute_cli_actions_cd_strips_quotes_on_windows(monkeypatch: object) -> None:
-    changed_directories: list[Path] = []
-
-    def _fake_chdir(target: Path) -> None:
-        changed_directories.append(target)
-
-    monkeypatch.setattr(platform_module, "IS_WINDOWS", True)
-    monkeypatch.setattr(subprocess_runner.os, "chdir", _fake_chdir)
-
-    session = Session()
-    console, _ = _capture()
-
-    message = r'run `cd "C:\Users\Alice"`'
-    assert action_turn.run_action_tool_turn(message, session, console).handled is True
-    assert changed_directories == [Path(r"C:\Users\Alice")]
-    assert session.history == [
-        {"type": "shell", "text": r'cd "C:\Users\Alice"', "ok": True},
-    ]
+    assert action_turn.run_action_tool_turn("change directory", session, console).handled is True
+    assert session.working_directory == str(tmp_path.resolve())
+    assert session.working_directory != original
+    assert session.history[-1] == {
+        "type": "shell",
+        "text": f"cd {tmp_path}",
+        "ok": True,
+        "response_text": str(tmp_path.resolve()),
+    }
+    assert str(tmp_path.resolve()) in buf.getvalue()
 
 
 def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:
@@ -853,7 +796,7 @@ def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:
     console, buf = _capture()
 
     assert action_turn.run_action_tool_turn("execute false", session, console).handled is True
-    assert calls == [(["false"], _EXPECTED_POPEN_KWARGS)]
+    assert calls == [(_expected_shell_argv("false"), _EXPECTED_POPEN_KWARGS)]
     assert session.history[-1] == {
         "type": "shell",
         "text": "false",
@@ -907,47 +850,32 @@ def test_execute_cli_actions_runs_passthrough_with_shell_true(monkeypatch: objec
     assert "ok" in output
 
 
-def test_execute_cli_actions_dispatches_bang_cd_through_builtin(monkeypatch: object) -> None:
-    dirs: list[Path] = []
-
-    def _fake_chdir(target: Path) -> None:
-        dirs.append(target)
-
-    def _boom(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
-        raise AssertionError("subprocess.run should not be used for !cd builtin execution")
-
-    monkeypatch.setattr(subprocess_runner.os, "chdir", _fake_chdir)
-    monkeypatch.setattr(shell_execution.subprocess, "run", _boom)
-
+def test_execute_cli_actions_runs_bang_cd_in_child_shell(monkeypatch: object) -> None:
+    calls = _install_fake_popen(monkeypatch)
     session = Session()
+    original = session.working_directory
     console, buf = _capture()
 
     message = "run `!cd /tmp`"
     assert action_turn.run_action_tool_turn(message, session, console).handled is True
-    assert dirs == [Path("/tmp")]
-    assert session.history[-1] == {"type": "shell", "text": "cd /tmp", "ok": True}
+    assert calls == [(_expected_shell_argv("cd /tmp"), _EXPECTED_POPEN_KWARGS)]
+    assert session.working_directory == original
+    assert session.history[-1] == {"type": "shell", "text": "!cd /tmp", "ok": True}
     captured = buf.getvalue()
-    assert "explicit shell passthrough enabled" not in captured
+    assert "explicit shell passthrough enabled" in captured
 
 
-def test_execute_cli_actions_dispatches_bang_pwd_through_builtin(monkeypatch: object) -> None:
-    def _fake_cwd(_: type[Path]) -> PurePosixPath:
-        return PurePosixPath("/shown")
-
-    def _boom(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
-        raise AssertionError("subprocess.run should not be used for !pwd builtin execution")
-
-    monkeypatch.setattr(subprocess_runner.Path, "cwd", classmethod(_fake_cwd))
-    monkeypatch.setattr(shell_execution.subprocess, "run", _boom)
-
+def test_execute_cli_actions_runs_bang_pwd_through_shell(monkeypatch: object) -> None:
     session = Session()
+    calls = _install_fake_popen(monkeypatch, stdout=f"{session.working_directory}\n")
     console, buf = _capture()
 
     assert action_turn.run_action_tool_turn("run `!pwd`", session, console).handled is True
-    assert session.history[-1] == {"type": "shell", "text": "pwd", "ok": True}
+    assert calls == [(_expected_shell_argv("pwd"), _EXPECTED_POPEN_KWARGS)]
+    assert session.history[-1]["text"] == "!pwd"
     captured = buf.getvalue()
-    assert "/shown" in captured
-    assert "explicit shell passthrough enabled" not in captured
+    assert session.working_directory in captured
+    assert "explicit shell passthrough enabled" in captured
 
 
 def test_execute_cli_actions_handles_path_with_spaces_run_phrase() -> None:
@@ -962,7 +890,7 @@ def test_execute_cli_actions_handles_path_with_spaces_run_phrase() -> None:
     assert "/tmp/file with spaces.txt" in output
 
 
-def test_execute_cli_actions_backtick_shell_preserves_space_path_token(monkeypatch: object) -> None:
+def test_execute_cli_actions_runs_space_path_through_host_shell(monkeypatch: object) -> None:
     calls = _install_fake_popen(monkeypatch, stdout="done\n")
 
     session = Session()
@@ -974,11 +902,7 @@ def test_execute_cli_actions_backtick_shell_preserves_space_path_token(monkeypat
         ).handled
         is True
     )
-    # On Windows, shlex with posix=False preserves quotes for tokens with spaces.
-    # Both Windows and Posix parsers correctly strip outer quotes from tokens
-    # following the policy.py _strip_outer_quotes logic.
-    expected_path = "/tmp/file with spaces.txt"
-    assert calls[0][0] == ["cat", expected_path]
+    assert calls[0][0] == _expected_shell_argv('cat "/tmp/file with spaces.txt"')
 
 
 def test_execute_cli_actions_counts_planned_and_executed(monkeypatch: object) -> None:

--- a/tests/core/agent/orchestration/test_duplicate_action_guard.py
+++ b/tests/core/agent/orchestration/test_duplicate_action_guard.py
@@ -9,6 +9,7 @@ decides whether two calls count as identical.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from core.agent_harness.turns.action_dedup import with_duplicate_action_call_guard
@@ -25,7 +26,7 @@ def _request(name: str, payload: dict[str, Any]) -> Any:
 
 
 def _label(payload: dict[str, Any]) -> str:
-    return str(payload.get("command", payload.get("payload", "")))
+    return str(payload.get("command", payload.get("payload", payload.get("path", ""))))
 
 
 def _drive(batches: list[list[_Call]]) -> list[str]:
@@ -104,3 +105,56 @@ def test_identical_cli_exec_twice_in_one_batch_runs_once() -> None:
     executed = _drive([[first, second]])
 
     assert executed == ["integrations verify --dry-run"]
+
+
+def test_replayed_absolute_working_directory_change_is_suppressed() -> None:
+    change: _Call = ("set_working_directory", {"path": "/workspace/child"}, True)
+
+    executed = _drive([[change], [change]])
+
+    assert executed == ["/workspace/child"]
+
+
+def test_relative_working_directory_fingerprint_uses_live_base(tmp_path: Path) -> None:
+    current = [tmp_path]
+    hooks = with_duplicate_action_call_guard(
+        working_directory=lambda: str(current[0]),
+    )
+    payload = {"path": "child"}
+
+    hooks.before_tool_batch([ToolCall(id="first", name="set_working_directory", input=payload)])
+    first = _request("set_working_directory", payload)
+    assert hooks.before_tool_call(first) is None
+    current[0] /= "child"
+    hooks.after_tool_call(first, ToolExecutionResult(content="out"))
+
+    hooks.before_tool_batch([ToolCall(id="second", name="set_working_directory", input=payload)])
+    second = _request("set_working_directory", payload)
+
+    assert hooks.before_tool_call(second) is None
+
+
+def test_failed_working_directory_change_may_retry() -> None:
+    change = {"path": "/workspace/missing"}
+    hooks = with_duplicate_action_call_guard()
+
+    hooks.before_tool_batch([ToolCall(id="first", name="set_working_directory", input=change)])
+    first = _request("set_working_directory", change)
+    assert hooks.before_tool_call(first) is None
+    hooks.after_tool_call(
+        first,
+        ToolExecutionResult(content="unchanged", details={"ok": False}),
+    )
+
+    hooks.before_tool_batch([ToolCall(id="second", name="set_working_directory", input=change)])
+    second = _request("set_working_directory", change)
+
+    assert hooks.before_tool_call(second) is None
+
+
+def test_relative_working_directory_changes_remain_ordered_inside_one_batch() -> None:
+    change: _Call = ("set_working_directory", {"path": "child"}, True)
+
+    executed = _drive([[change, change]])
+
+    assert executed == ["child", "child"]

--- a/tests/core/agent/test_tool_registry.py
+++ b/tests/core/agent/test_tool_registry.py
@@ -25,7 +25,7 @@ def _action_tools(
     session: Session,
     *,
     resolved_integrations: dict[str, dict[str, str]] | None = None,
-) -> list[object]:
+) -> list[RegisteredTool]:
     ctx = ActionToolScope(session=session, console=Console(force_terminal=False))
     return get_action_tools_from_integrations_view(ctx, resolved_integrations=resolved_integrations)
 
@@ -218,9 +218,9 @@ def test_repository_tools_are_advertised_before_a_workspace_scope_is_known() -> 
     session.configured_integrations = ("github", "gitlab")
     session.configured_integrations_known = True
 
-    names = {
-        spec["name"]
-        for spec in _tool_specs(
+    tools = {
+        tool.name: tool
+        for tool in _action_tools(
             session,
             resolved_integrations={
                 "github": {"connection_verified": True, "github_token": "github-token"},
@@ -229,8 +229,8 @@ def test_repository_tools_are_advertised_before_a_workspace_scope_is_known() -> 
         )
     }
 
-    assert "search_github_issues" in names
-    assert "list_gitlab_commits" in names
+    assert tools["search_github_issues"].context_params == ("owner", "repo")
+    assert tools["list_gitlab_commits"].context_params == ("project_id",)
 
 
 def test_llm_set_provider_offered_by_default() -> None:

--- a/tests/core/agent/test_tool_registry.py
+++ b/tests/core/agent/test_tool_registry.py
@@ -213,6 +213,26 @@ def test_rocketchat_send_message_hidden_when_rocketchat_is_not_configured() -> N
     assert "rocketchat_send_message" not in names
 
 
+def test_repository_tools_are_advertised_before_a_workspace_scope_is_known() -> None:
+    session = Session()
+    session.configured_integrations = ("github", "gitlab")
+    session.configured_integrations_known = True
+
+    names = {
+        spec["name"]
+        for spec in _tool_specs(
+            session,
+            resolved_integrations={
+                "github": {"connection_verified": True, "github_token": "github-token"},
+                "gitlab": {"connection_verified": True, "auth_token": "gitlab-token"},
+            },
+        )
+    }
+
+    assert "search_github_issues" in names
+    assert "list_gitlab_commits" in names
+
+
 def test_llm_set_provider_offered_by_default() -> None:
     """With no capability constraints (the production default), the planner is
     still offered the provider-switch tool."""

--- a/tests/core/agent_harness/session/test_session_characterization.py
+++ b/tests/core/agent_harness/session/test_session_characterization.py
@@ -53,6 +53,7 @@ _CORE_FIELDS = (
     "agent",
     "grounding",
     "runtime_metadata",
+    "working_directory",
 )
 
 

--- a/tests/core/agent_harness/test_turn_plan.py
+++ b/tests/core/agent_harness/test_turn_plan.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
+import subprocess
 from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+import core.agent_harness.turns.turn_plan as turn_plan_module
 from core.agent_harness.session.pending_choice import AskUserQuestion, format_ask_user_answers
-from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
+from core.agent_harness.turns.turn_plan import (
+    TurnPlan,
+    build_turn_plan,
+    refresh_repository_scopes_after_directory_change,
+    working_directory_scope_refresh_hooks,
+)
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
+from core.tool.execution import ToolExecutionResult
 from surfaces.interactive_shell.session import Session
 
 
@@ -219,3 +229,78 @@ def test_repo_scope_uses_workspace_only_without_explicit_or_sticky_scope(
     assert plan.resolved_integrations["github"]["owner"] == "Tracer-Cloud"
     assert plan.resolved_integrations["github"]["repo"] == "opensre"
     assert session.vcs_repo_scopes["github"][:2] == ("Tracer-Cloud", "opensre")
+
+
+def test_directory_change_refreshes_same_turn_repository_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    for path, remote in (
+        (repo_a, "https://github.com/example/repo-a.git"),
+        (repo_b, "https://github.com/example/repo-b.git"),
+    ):
+        path.mkdir()
+        subprocess.run(["git", "init", "-q", str(path)], check=True)
+        subprocess.run(
+            ["git", "-C", str(path), "remote", "add", "origin", remote],
+            check=True,
+        )
+
+    session = Session(working_directory=str(repo_a))
+    session.resolved_integrations_cache = {"github": {"connection_verified": True}}
+    initial = build_turn_plan(
+        TurnSnapshot.from_session("check this repository", session, surface="interactive_shell"),
+        session,
+    )
+    assert initial.resolved_integrations["github"]["repo"] == "repo-a"
+
+    refreshed = refresh_repository_scopes_after_directory_change(
+        resolved=initial.resolved_integrations,
+        session=session,
+        message="change directory and check this repository",
+        cwd=str(repo_b),
+    )
+
+    assert refreshed["github"]["owner"] == "example"
+    assert refreshed["github"]["repo"] == "repo-b"
+    assert session.active_vcs_repositories == {"github": "example/repo-b"}
+
+
+def test_directory_change_hook_updates_running_execution_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = Session()
+    running = {"github": {"configured": True, "repo": "repo-a"}}
+
+    def _refresh(**kwargs: object) -> dict[str, object]:
+        assert kwargs["resolved"] is running
+        assert kwargs["cwd"] == "/workspace/repo-b"
+        return {"github": {"configured": True, "repo": "repo-b"}}
+
+    monkeypatch.setattr(
+        turn_plan_module,
+        "refresh_repository_scopes_after_directory_change",
+        _refresh,
+    )
+    hooks = working_directory_scope_refresh_hooks(
+        session=session,
+        message="change directory and inspect this repository",
+    )
+    request = SimpleNamespace(
+        tool_call=SimpleNamespace(name="set_working_directory"),
+        resolved_integrations=running,
+    )
+    assert hooks.after_tool_call is not None
+
+    hooks.after_tool_call(
+        request,
+        ToolExecutionResult(
+            content="ok",
+            details={"ok": True, "working_directory": "/workspace/repo-b"},
+        ),
+    )
+
+    assert running["github"]["repo"] == "repo-b"

--- a/tests/core/agent_harness/test_turn_plan.py
+++ b/tests/core/agent_harness/test_turn_plan.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 import core.agent_harness.turns.turn_plan as turn_plan_module
+from config.constants import WORKSPACE_REPO_ENV_KEYS
 from core.agent_harness.session.pending_choice import AskUserQuestion, format_ask_user_answers
 from core.agent_harness.turns.turn_plan import (
     TurnPlan,
@@ -235,7 +236,8 @@ def test_directory_change_refreshes_same_turn_repository_scope(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    for key in WORKSPACE_REPO_ENV_KEYS:
+        monkeypatch.setenv(key, "ambient/repo-a")
     repo_a = tmp_path / "repo-a"
     repo_b = tmp_path / "repo-b"
     for path, remote in (
@@ -255,6 +257,7 @@ def test_directory_change_refreshes_same_turn_repository_scope(
         TurnSnapshot.from_session("check this repository", session, surface="interactive_shell"),
         session,
     )
+    assert initial.resolved_integrations["github"]["owner"] == "ambient"
     assert initial.resolved_integrations["github"]["repo"] == "repo-a"
 
     refreshed = refresh_repository_scopes_after_directory_change(

--- a/tests/core/tool/test_execution.py
+++ b/tests/core/tool/test_execution.py
@@ -445,6 +445,43 @@ def test_non_parallel_safe_registered_tool_serializes_mixed_batch(
     ]
 
 
+def test_sequential_batch_uses_integration_scope_refreshed_by_prior_tool() -> None:
+    resolved = {"github": {"owner": "old-owner"}}
+
+    def refresh(value: str, context: AgentToolContext) -> dict[str, str]:
+        context.resolved_integrations["github"] = {"owner": value}
+        return {"value": value}
+
+    def read_scope(owner: str, value: str) -> dict[str, str]:
+        return {"owner": owner, "value": value}
+
+    refresh_tool = RegisteredTool(
+        name="refresh_scope",
+        description="refresh integration scope",
+        input_schema=_schema(["value"]),
+        source="knowledge",
+        run=refresh,
+        accepts_runtime_context=True,
+        parallel_safe=False,
+    )
+    scoped_tool = RegisteredTool(
+        name="read_scope",
+        description="read integration scope",
+        input_schema=_schema(["value"]),
+        source="github",
+        run=read_scope,
+        extract_params=lambda sources: {"owner": sources["github"]["owner"]},
+    )
+
+    results = execute_tool_calls(
+        [_call("refresh_scope", "new-owner"), _call("read_scope", "observed")],
+        [refresh_tool, scoped_tool],
+        resolved,
+    )
+
+    assert results[1].details == {"owner": "new-owner", "value": "observed"}
+
+
 def test_agent_tool_sequential_execution_mode_serializes_mixed_batch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/tool/test_execution.py
+++ b/tests/core/tool/test_execution.py
@@ -498,6 +498,59 @@ def test_sequential_batch_uses_integration_scope_refreshed_by_prior_tool() -> No
     assert results[1].details == {"owner": "new-owner", "value": "observed"}
 
 
+def test_sequential_batch_preserves_explicit_context_after_scope_refresh() -> None:
+    resolved = {"github": {"owner": "old-owner"}}
+
+    def refresh(value: str, context: AgentToolContext) -> dict[str, str]:
+        context.resolved_integrations["github"] = {"owner": value}
+        return {"value": value}
+
+    def read_scope(owner: str, value: str) -> dict[str, str]:
+        return {"owner": owner, "value": value}
+
+    refresh_tool = RegisteredTool(
+        name="refresh_scope",
+        description="refresh integration scope",
+        input_schema=_schema(["value"]),
+        source="knowledge",
+        run=refresh,
+        accepts_runtime_context=True,
+        parallel_safe=False,
+    )
+    scoped_tool = RegisteredTool(
+        name="read_scope",
+        description="read integration scope",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "owner": {"type": "string"},
+                "value": {"type": "string"},
+            },
+            "required": ["owner", "value"],
+            "additionalProperties": False,
+        },
+        source="github",
+        run=read_scope,
+        extract_params=lambda sources: {"owner": sources["github"]["owner"]},
+        context_params=("owner",),
+    )
+
+    results = execute_tool_calls(
+        [
+            _call("refresh_scope", "new-owner"),
+            ToolCall(
+                id="read-scope-1",
+                name="read_scope",
+                input={"owner": "explicit-owner", "value": "observed"},
+            ),
+        ],
+        [refresh_tool, scoped_tool],
+        resolved,
+    )
+
+    assert results[1].details == {"owner": "explicit-owner", "value": "observed"}
+
+
 def test_agent_tool_sequential_execution_mode_serializes_mixed_batch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/tool/test_execution.py
+++ b/tests/core/tool/test_execution.py
@@ -467,14 +467,30 @@ def test_sequential_batch_uses_integration_scope_refreshed_by_prior_tool() -> No
     scoped_tool = RegisteredTool(
         name="read_scope",
         description="read integration scope",
-        input_schema=_schema(["value"]),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "owner": {"type": "string"},
+                "value": {"type": "string"},
+            },
+            "required": ["owner", "value"],
+            "additionalProperties": False,
+        },
         source="github",
         run=read_scope,
         extract_params=lambda sources: {"owner": sources["github"]["owner"]},
+        context_params=("owner",),
     )
 
     results = execute_tool_calls(
-        [_call("refresh_scope", "new-owner"), _call("read_scope", "observed")],
+        [
+            _call("refresh_scope", "new-owner"),
+            ToolCall(
+                id="read-scope-1",
+                name="read_scope",
+                input={"owner": "old-owner", "value": "observed"},
+            ),
+        ],
         [refresh_tool, scoped_tool],
         resolved,
     )

--- a/tests/core/tool/test_registered_tool.py
+++ b/tests/core/tool/test_registered_tool.py
@@ -185,6 +185,37 @@ def test_public_input_schema_is_cached_and_isolated_from_source() -> None:
     assert "token" not in second["properties"]
 
 
+def test_advertisement_can_outlive_current_scope_availability() -> None:
+    rt = RegisteredTool(
+        name="repository_tool",
+        description="Repository-scoped tool",
+        input_schema={"type": "object", "properties": {}},
+        source="github",
+        run=lambda: {},
+        is_available=lambda sources: bool(sources.get("github", {}).get("repo")),
+        is_advertised=lambda sources: bool(sources.get("github", {}).get("connection_verified")),
+    )
+
+    sources = {"github": {"connection_verified": True}}
+
+    assert rt.is_available(sources) is False
+    assert rt.should_advertise(sources) is True
+
+
+def test_advertisement_defaults_to_current_availability() -> None:
+    rt = RegisteredTool(
+        name="ordinary_tool",
+        description="Ordinary tool",
+        input_schema={"type": "object", "properties": {}},
+        source="github",
+        run=lambda: {},
+        is_available=lambda sources: bool(sources.get("github")),
+    )
+
+    assert rt.should_advertise({}) is False
+    assert rt.should_advertise({"github": {"connection_verified": True}}) is True
+
+
 # ---------------------------------------------------------------------------
 # validate_public_input
 # ---------------------------------------------------------------------------

--- a/tests/core/tool/test_registered_tool.py
+++ b/tests/core/tool/test_registered_tool.py
@@ -155,6 +155,23 @@ def test_public_input_schema_empty_injected_unchanged() -> None:
     assert rt.public_input_schema == rt.input_schema
 
 
+def test_public_input_schema_keeps_authoritative_context_params() -> None:
+    rt = RegisteredTool(
+        name="scoped_tool",
+        description="Tool with a runtime repository default",
+        input_schema={
+            "type": "object",
+            "properties": {"owner": {"type": "string"}},
+            "required": ["owner"],
+        },
+        source="github",
+        run=lambda owner: {"owner": owner},
+        context_params=("owner",),
+    )
+
+    assert rt.public_input_schema == rt.input_schema
+
+
 def test_public_input_schema_is_cached_and_isolated_from_source() -> None:
     def run(query: str, token: str) -> dict[str, Any]:
         return {}

--- a/tests/core/tool/test_registered_tool.py
+++ b/tests/core/tool/test_registered_tool.py
@@ -155,7 +155,7 @@ def test_public_input_schema_empty_injected_unchanged() -> None:
     assert rt.public_input_schema == rt.input_schema
 
 
-def test_public_input_schema_keeps_authoritative_context_params() -> None:
+def test_public_input_schema_keeps_runtime_context_params() -> None:
     rt = RegisteredTool(
         name="scoped_tool",
         description="Tool with a runtime repository default",

--- a/tests/fleet_monitoring/test_probe.py
+++ b/tests/fleet_monitoring/test_probe.py
@@ -31,6 +31,7 @@ _PROBE_MODULE = _REPO_ROOT / "tools" / "system" / "fleet_monitoring" / "probe.py
 _PSUTIL_SANCTIONED = (
     _PROBE_MODULE,
     _REPO_ROOT / "config" / "runtime_metadata" / "probes.py",
+    _REPO_ROOT / "infrastructure" / "process" / "termination.py",
 )
 _SOURCE_ROOTS = (
     "cli",

--- a/tests/infrastructure/process/test_termination.py
+++ b/tests/infrastructure/process/test_termination.py
@@ -1,0 +1,52 @@
+"""Process-tree termination boundary tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
+from infrastructure.process.termination import terminate_process_tree
+
+
+def test_terminate_process_tree_stops_descendants_before_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    def _process(name: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            terminate=lambda: events.append(f"terminate:{name}"),
+            kill=lambda: events.append(f"kill:{name}"),
+        )
+
+    child = _process("child")
+    grandchild = _process("grandchild")
+    root = _process("root")
+
+    def _children(*, recursive: bool) -> list[SimpleNamespace]:
+        assert recursive
+        return [child, grandchild]
+
+    root.children = _children
+    wait_results = iter([([child, grandchild], [root]), ([root], [])])
+    monkeypatch.setattr(psutil, "Process", lambda _pid: root)
+
+    def _wait_procs(
+        _processes: list[SimpleNamespace],
+        timeout: float,
+    ) -> tuple[list[SimpleNamespace], list[SimpleNamespace]]:
+        assert timeout > 0
+        return next(wait_results)
+
+    monkeypatch.setattr(psutil, "wait_procs", _wait_procs)
+
+    terminate_process_tree(123, grace_seconds=10, force_wait_seconds=5)
+
+    assert events == [
+        "terminate:grandchild",
+        "terminate:child",
+        "terminate:root",
+        "kill:root",
+    ]

--- a/tests/interactive_shell/runtime/test_subprocess_runner.py
+++ b/tests/interactive_shell/runtime/test_subprocess_runner.py
@@ -7,12 +7,13 @@ import io
 import subprocess
 import tempfile
 import threading
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from rich.console import Console
 
+import surfaces.interactive_shell.runtime.subprocess_runner as subprocess_runner
 from infrastructure.scheduling.task_types import TaskKind, TaskStatus
 from infrastructure.terminal.theme import GLYPH_ERROR, GLYPH_SUCCESS
 from integrations.llm_cli.base import CLIInvocation, CLIProbe
@@ -36,15 +37,16 @@ from tools.interactive_shell.implementation.claude_code_executor import (
 from tools.interactive_shell.shell.execution import (
     ShellExecutionResult,
 )
-from tools.interactive_shell.shell.runner import (
-    run_cd_command,
-    run_pwd_command,
-    run_shell_command,
-)
+from tools.interactive_shell.shell.runner import run_shell_command
 
 _BACKGROUND_TASK_POPEN = "surfaces.interactive_shell.runtime.subprocess_runner.subprocess.Popen"
 _CLI_POPEN = "tools.interactive_shell.cli.subprocess.Popen"
 _CLI_RUN = "tools.interactive_shell.cli.subprocess.run"
+
+
+def test_subprocess_runner_exports_every_declared_name() -> None:
+    missing = [name for name in subprocess_runner.__all__ if not hasattr(subprocess_runner, name)]
+    assert missing == []
 
 
 def _presenter(
@@ -121,105 +123,39 @@ def test_read_task_output_returns_empty_for_closed_buffer() -> None:
     assert read_task_output(buf, limit=100) == ""
 
 
-def test_run_pwd_command_prints_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_cwd(_: type[Path]) -> PurePosixPath:
-        return PurePosixPath("/shown/pwd")
-
-    monkeypatch.setattr(Path, "cwd", classmethod(_fake_cwd))
-
-    session = Session()
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False)
-
-    run_pwd_command("pwd", _presenter(session, console))
-    assert "/shown/pwd" in buf.getvalue()
-    assert session.history[-1]["type"] == "shell"
-
-
-def test_run_pwd_command_rejects_multiple_tokens() -> None:
-    session = Session()
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False)
-
-    run_pwd_command("pwd extra", _presenter(session, console))
-    assert "too many arguments" in buf.getvalue().lower()
-    assert session.history[-1]["ok"] is False
-
-
-def test_run_cd_command_chdirs_to_target(monkeypatch: pytest.MonkeyPatch) -> None:
-    directories: list[Path] = []
-
-    def _chdir(target: Path) -> None:
-        directories.append(target)
-
-    monkeypatch.setattr(
-        "tools.interactive_shell.shell.runner.os.chdir",
-        _chdir,
-    )
-
-    session = Session()
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False)
-
-    run_cd_command("cd /tmp/example", _presenter(session, console))
-    assert directories == [Path("/tmp/example")]
-    assert session.history[-1]["type"] == "shell"
-
-
-def test_run_shell_command_quiet_cd_hides_cwd(
+def test_run_shell_command_uses_session_directory_without_interpreting_cd(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(
-        "tools.interactive_shell.shell.runner.os.chdir",
-        lambda _target: None,
-    )
-    monkeypatch.setattr(
-        "tools.interactive_shell.shell.runner.Path.cwd",
-        classmethod(lambda _cls: Path("/tmp/example")),
-    )
+    execute_calls: list[dict[str, object]] = []
 
-    session = Session()
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False)
-
-    result = run_shell_command("cd /tmp/example", _presenter(session, console), quiet=True)
-
-    # The dim command line shows what ran; the new cwd stays hidden.
-    assert buf.getvalue().strip() == "$ cd /tmp/example"
-    assert result["ok"] is True
-    assert result["response_text"] == "/tmp/example"
-
-
-def test_run_cd_command_reports_chdir_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured_errors: list[BaseException] = []
-
-    def _chdir(_target: Path) -> None:
-        raise OSError("permission denied")
+    def _fake_execute(**kwargs: object) -> ShellExecutionResult:
+        execute_calls.append(kwargs)
+        return ShellExecutionResult(
+            command="cd /tmp&&pwd",
+            stdout="/tmp\n",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            truncated=False,
+            executed_with_shell=True,
+        )
 
     monkeypatch.setattr(
-        "tools.interactive_shell.shell.runner.os.chdir",
-        _chdir,
-    )
-    monkeypatch.setattr(
-        "surfaces.shared.error_handling.exception_reporting.capture_exception",
-        lambda exc, **_kwargs: captured_errors.append(exc),
+        "tools.interactive_shell.shell.execution.execute_shell_command",
+        _fake_execute,
     )
 
     session = Session()
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False)
+    session.working_directory = str(tmp_path)
+    console = Console(file=io.StringIO(), force_terminal=False)
 
-    run_cd_command("cd /root/blocked", _presenter(session, console))
+    result = run_shell_command("cd /tmp&&pwd", _presenter(session, console))
 
-    assert "cd failed" in buf.getvalue()
-    assert len(captured_errors) == 1
-    assert isinstance(captured_errors[0], OSError)
-    assert session.history[-1] == {
-        "type": "shell",
-        "text": "cd /root/blocked",
-        "ok": False,
-        "response_text": "cd failed: permission denied",
-    }
+    assert execute_calls[0]["command"] == "cd /tmp&&pwd"
+    assert execute_calls[0]["cwd"] == str(tmp_path)
+    assert session.working_directory == str(tmp_path)
+    assert result["stdout"] == "/tmp"
 
 
 def test_run_shell_command_records_when_input_is_empty() -> None:
@@ -247,6 +183,7 @@ def test_run_shell_command_records_when_input_is_empty() -> None:
 
 def test_run_claude_code_implementation_starts_tracked_task(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     popen_calls: list[tuple[list[str], dict[str, object]]] = []
     stdin_seen: list[str | None] = []
@@ -318,6 +255,7 @@ def test_run_claude_code_implementation_starts_tracked_task(
     )
 
     session = Session()
+    session.working_directory = str(tmp_path)
     session.agent.messages.append(
         ("assistant", "Process auto-discovery should scan local agent processes.")
     )
@@ -339,7 +277,7 @@ def test_run_claude_code_implementation_starts_tracked_task(
         "--permission-mode",
         "acceptEdits",
     ]
-    assert kwargs["cwd"]
+    assert kwargs["cwd"] == str(tmp_path)
     assert stdin_seen and "Process auto-discovery" in stdin_seen[0]
     assert session.history[-1] == {"type": "implementation", "text": "implement", "ok": True}
     task = session.task_registry.list_recent(1)[0]
@@ -371,13 +309,12 @@ def test_run_shell_command_outputless_success_omits_marker(
     def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
         return ShellExecutionResult(
             command="true",
-            argv=["true"],
             stdout="",
             stderr="",
             exit_code=0,
             timed_out=False,
             truncated=False,
-            executed_with_shell=False,
+            executed_with_shell=True,
         )
 
     monkeypatch.setattr(
@@ -402,13 +339,12 @@ def test_run_shell_command_quiet_prints_a_dim_command_line_and_no_stdout(
     def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
         return ShellExecutionResult(
             command="echo hi",
-            argv=["echo", "hi"],
             stdout="hi\n",
             stderr="",
             exit_code=0,
             timed_out=False,
             truncated=False,
-            executed_with_shell=False,
+            executed_with_shell=True,
         )
 
     monkeypatch.setattr(
@@ -442,13 +378,12 @@ def test_run_shell_command_quiet_outputless_success_prints_only_the_command_line
     def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
         return ShellExecutionResult(
             command="touch file",
-            argv=["touch", "file"],
             stdout="",
             stderr="",
             exit_code=0,
             timed_out=False,
             truncated=False,
-            executed_with_shell=False,
+            executed_with_shell=True,
         )
 
     monkeypatch.setattr(
@@ -480,13 +415,12 @@ def test_run_shell_command_success_records_stdout_without_stderr_noise(
     def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
         return ShellExecutionResult(
             command="curl wttr.in/Hawaii?format=3",
-            argv=["curl", "wttr.in/Hawaii?format=3"],
             stdout="Hawaii: +25C\n",
             stderr="curl progress\n",
             exit_code=0,
             timed_out=False,
             truncated=False,
-            executed_with_shell=False,
+            executed_with_shell=True,
         )
 
     monkeypatch.setattr(
@@ -516,13 +450,12 @@ def test_run_shell_command_failure_prints_exit_line(monkeypatch: pytest.MonkeyPa
     def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
         return ShellExecutionResult(
             command="false",
-            argv=["false"],
             stdout="",
             stderr="",
             exit_code=7,
             timed_out=False,
             truncated=False,
-            executed_with_shell=False,
+            executed_with_shell=True,
         )
 
     monkeypatch.setattr(
@@ -554,13 +487,12 @@ def test_run_shell_command_reports_cancelled(monkeypatch: pytest.MonkeyPatch) ->
         seen.update(kwargs)
         return ShellExecutionResult(
             command="sleep 30",
-            argv=["sleep", "30"],
             stdout="",
             stderr="",
             exit_code=-15,
             timed_out=False,
             truncated=False,
-            executed_with_shell=False,
+            executed_with_shell=True,
             cancelled=True,
         )
 
@@ -695,6 +627,7 @@ def test_run_opensre_agents_scan_register_explains_confirmation(
 
 def test_run_opensre_agents_watch_runs_in_foreground(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     popen_kwargs: list[dict[str, object]] = []
 
@@ -715,6 +648,7 @@ def test_run_opensre_agents_watch_runs_in_foreground(
     )
 
     session = Session()
+    session.working_directory = str(tmp_path)
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False)
 
@@ -736,6 +670,7 @@ def test_run_opensre_agents_watch_runs_in_foreground(
     assert "started" not in out
     assert "timeout" not in popen_kwargs[0]
     assert popen_kwargs[0]["stderr"] is subprocess.STDOUT
+    assert popen_kwargs[0]["cwd"] == str(tmp_path)
     assert session.task_registry.list_recent() == []
     assert session.history[-1] == {
         "type": "cli_command",
@@ -746,6 +681,7 @@ def test_run_opensre_agents_watch_runs_in_foreground(
 
 def test_start_background_cli_task_uses_pty_for_live_terminal_output(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     popen_kwargs: list[dict[str, object]] = []
     closed_fds: list[int] = []
@@ -796,6 +732,7 @@ def test_start_background_cli_task_uses_pty_for_live_terminal_output(
     )
 
     session = Session()
+    session.working_directory = str(tmp_path)
     buf = _TtyBuffer()
     console = Console(file=buf, force_terminal=True)
 
@@ -813,6 +750,7 @@ def test_start_background_cli_task_uses_pty_for_live_terminal_output(
     assert popen_kwargs[0]["stdout"] == 11
     assert popen_kwargs[0]["stderr"] == 11
     assert "text" not in popen_kwargs[0]
+    assert popen_kwargs[0]["cwd"] == str(tmp_path)
     assert "live progress" in buf.getvalue()
     assert 10 in closed_fds
     assert 11 in closed_fds
@@ -1394,6 +1332,7 @@ def test_run_opensre_cli_command_refuses_integrations_setup_with_helpful_message
 
 def test_run_opensre_cli_command_runs_integrations_list_in_foreground(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """``integrations list`` is read-only: it runs foreground so the action turn
     observes the result, and is not caught by the interactive-wizard block (only
@@ -1405,7 +1344,10 @@ def test_run_opensre_cli_command_runs_integrations_list_in_foreground(
     def _fake_start_background_cli_task(*, argv_list: list[str], **_kw: object) -> None:
         start_calls.append(argv_list)
 
-    def _fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    run_kwargs: list[dict[str, object]] = []
+
+    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        run_kwargs.append(kwargs)
         return subprocess.CompletedProcess(
             args=command,
             returncode=0,
@@ -1423,6 +1365,7 @@ def test_run_opensre_cli_command_runs_integrations_list_in_foreground(
     )
 
     session = Session()
+    session.working_directory = str(tmp_path)
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False)
 
@@ -1444,6 +1387,7 @@ def test_run_opensre_cli_command_runs_integrations_list_in_foreground(
     # Read-only integrations runs foreground, not as a background task, so the
     # turn observes pass/fail instead of ending on a task id.
     assert start_calls == []
+    assert run_kwargs[0]["cwd"] == str(tmp_path)
 
 
 def test_start_background_cli_task_echoes_command_markup_literally(

--- a/tests/interactive_shell/session/test_session_facets.py
+++ b/tests/interactive_shell/session/test_session_facets.py
@@ -24,7 +24,7 @@ from surfaces.interactive_shell.session.session import Session
 # (task_plan_work, task_plan_work_step_texts, task_plan_breakdown_emitted),
 # and the two 'do not ask twice' sets (questions_already_answered,
 # skills_already_prompted).
-_CORE_FIELD_COUNT = 34
+_CORE_FIELD_COUNT = 35
 _FACET_FIELDS = ("alerts", "terminal")
 
 

--- a/tests/interactive_shell/sessions/test_store.py
+++ b/tests/interactive_shell/sessions/test_store.py
@@ -13,6 +13,7 @@ import pytest
 from core.agent_harness.session import (
     JsonlSessionRepo,
     JsonlSessionStore,
+    SessionManager,
 )
 from core.agent_harness.session.persistence.paths import sessions_dir as _sessions_dir
 from surfaces.interactive_shell.session import (
@@ -107,6 +108,65 @@ def test_open_session_creates_file_with_session_start(tmp_path: Path) -> None:
     assert records[0]["type"] == "session"
     assert records[0]["version"] == 2
     assert records[0]["id"] == session.session_id
+
+
+def test_working_directory_round_trips_through_session_resume(tmp_path: Path) -> None:
+    target = tmp_path / "repository"
+    target.mkdir()
+    session = Session(store=SessionStore, working_directory=str(tmp_path))
+
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "work in the repository")
+        session.set_working_directory(str(target.resolve()))
+        loaded = SessionStore.load_session(session.session_id)
+
+    assert loaded is not None
+    restored = Session(working_directory=str(tmp_path))
+    SessionManager(store=SessionStore, repo=SessionStore).restore_context(restored, loaded)
+    assert restored.working_directory == str(target.resolve())
+
+
+def test_working_directory_restore_follows_selected_session_branch(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    session = Session(store=SessionStore, working_directory=str(tmp_path))
+
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        session.set_working_directory(str(first.resolve()))
+        first_entry_id = _read_lines(tmp_path / f"{session.session_id}.jsonl")[-1]["id"]
+        session.set_working_directory(str(second.resolve()))
+        at_first = SessionStore.load_session(f"{session.session_id}:{first_entry_id}")
+        at_tip = SessionStore.load_session(session.session_id)
+
+    assert at_first is not None
+    assert at_first["working_directory"] == str(first.resolve())
+    assert at_tip is not None
+    assert at_tip["working_directory"] == str(second.resolve())
+
+
+def test_resume_keeps_launch_directory_when_persisted_directory_is_gone(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "deleted"
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    session = Session(store=SessionStore, working_directory=str(tmp_path))
+
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        missing.mkdir()
+        session.set_working_directory(str(missing.resolve()))
+        loaded = SessionStore.load_session(session.session_id)
+        missing.rmdir()
+
+    assert loaded is not None
+    restored = Session(working_directory=str(fallback))
+    SessionManager(store=SessionStore, repo=SessionStore).restore_context(restored, loaded)
+    assert restored.working_directory == str(fallback)
 
 
 def test_open_session_uses_session_id_as_filename(tmp_path: Path) -> None:

--- a/tests/interactive_shell/shell/test_execution.py
+++ b/tests/interactive_shell/shell/test_execution.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
+import tools.interactive_shell.shell.execution as shell_execution
 from tools.interactive_shell.shell.execution import (
     execute_shell_command,
 )
@@ -27,26 +30,20 @@ def _assert_pid_gone(pid: int, *, timeout_seconds: float = 2.0) -> None:
     pytest.fail(f"process {pid} still alive after cancel")
 
 
-def test_execute_shell_command_reports_timeout_argv_mode() -> None:
+@pytest.mark.skipif(os.name == "nt", reason="uses the POSIX shell fallback")
+def test_shell_fallback_does_not_load_login_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SHELL", raising=False)
+
+    assert shell_execution._shell_argv("pwd") == ["/bin/sh", "-c", "pwd"]
+
+
+def test_execute_shell_command_reports_timeout() -> None:
     started = time.monotonic()
     result = execute_shell_command(
         command="sleep 30",
-        argv=["sleep", "30"],
-        use_shell=False,
-        timeout_seconds=1,
-        max_output_chars=10_000,
-    )
-    assert result.timed_out is True
-    assert result.cancelled is False
-    assert time.monotonic() - started < 5
-
-
-def test_execute_shell_command_reports_timeout_shell_mode() -> None:
-    started = time.monotonic()
-    result = execute_shell_command(
-        command="sleep 30",
-        argv=None,
-        use_shell=True,
+        cwd=str(Path.cwd()),
         timeout_seconds=1,
         max_output_chars=10_000,
     )
@@ -81,9 +78,8 @@ def test_execute_shell_command_stops_on_cancel_and_reaps_grandchild() -> None:
     threading.Thread(target=_request_cancel, daemon=True).start()
     started = time.monotonic()
     result = execute_shell_command(
-        command="nested-sleep",
-        argv=[sys.executable, "-c", script],
-        use_shell=False,
+        command=shlex.join([sys.executable, "-c", script]),
+        cwd=str(Path.cwd()),
         timeout_seconds=8,
         max_output_chars=10_000,
         cancel_event=cancel,
@@ -101,13 +97,11 @@ def test_execute_quoted_heredoc_through_shell() -> None:
     command = """python3 - <<'PY'
 print("hello-heredoc")
 PY"""
-    parsed = parse_shell_command(command, is_windows=False)
-    assert parsed.use_shell is True
+    parsed = parse_shell_command(command)
 
     result = execute_shell_command(
         command=parsed.command,
-        argv=parsed.argv,
-        use_shell=parsed.use_shell,
+        cwd=str(Path.cwd()),
         timeout_seconds=10,
         max_output_chars=10_000,
     )
@@ -115,3 +109,34 @@ PY"""
     assert result.timed_out is False
     assert result.exit_code == 0
     assert "hello-heredoc" in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uses POSIX shell syntax")
+def test_execute_compact_shell_script_with_operator_and_redirect(tmp_path: Path) -> None:
+    output_file = tmp_path / "second.txt"
+    command = f"printf one&&printf two>{shlex.quote(str(output_file))}"
+    parsed = parse_shell_command(command)
+
+    result = execute_shell_command(
+        command=parsed.command,
+        cwd=str(tmp_path),
+        timeout_seconds=10,
+        max_output_chars=10_000,
+    )
+
+    assert result.exit_code == 0
+    assert result.executed_with_shell is True
+    assert result.stdout == "one"
+    assert output_file.read_text() == "two"
+
+
+def test_execute_shell_command_uses_explicit_working_directory(tmp_path: Path) -> None:
+    result = execute_shell_command(
+        command="pwd",
+        cwd=str(tmp_path),
+        timeout_seconds=10,
+        max_output_chars=10_000,
+    )
+
+    assert result.exit_code == 0
+    assert Path(result.stdout.strip()).resolve() == tmp_path.resolve()

--- a/tests/interactive_shell/shell/test_execution.py
+++ b/tests/interactive_shell/shell/test_execution.py
@@ -54,29 +54,39 @@ def test_execute_shell_command_reports_timeout() -> None:
 
 
 @pytest.mark.skipif(os.name == "nt", reason="process-group cancel is POSIX")
-def test_execute_shell_command_stops_on_cancel_and_reaps_grandchild() -> None:
+def test_execute_shell_command_stops_on_cancel_and_reaps_grandchild(
+    tmp_path: Path,
+) -> None:
     """ESC must stop shell_run immediately and kill nested OpenSRE-style children.
 
     The CI-agent onboarding skill used to ``shell_run`` ``uv run opensre
     integrations setup github``. That second process ignored the parent ESC
     and kept running until the laptop ran out of memory.
     """
+    pid_file = tmp_path / "grandchild.pid"
     script = (
         "import subprocess, sys, time\n"
+        "from pathlib import Path\n"
         "child = subprocess.Popen("
         "[sys.executable, '-c', 'import time; time.sleep(60)']"
         ")\n"
-        "print(f'GRAND:{child.pid}', flush=True)\n"
+        f"marker = Path({str(pid_file)!r})\n"
+        "temporary_marker = marker.with_suffix('.tmp')\n"
+        "temporary_marker.write_text(str(child.pid))\n"
+        "temporary_marker.replace(marker)\n"
         "time.sleep(60)\n"
     )
     cancel = threading.Event()
+    cancel_requested_at: list[float] = []
 
     def _request_cancel() -> None:
-        time.sleep(0.3)
+        deadline = time.monotonic() + 5
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        cancel_requested_at.append(time.monotonic())
         cancel.set()
 
     threading.Thread(target=_request_cancel, daemon=True).start()
-    started = time.monotonic()
     result = execute_shell_command(
         command=shlex.join([sys.executable, "-c", script]),
         cwd=str(Path.cwd()),
@@ -84,12 +94,11 @@ def test_execute_shell_command_stops_on_cancel_and_reaps_grandchild() -> None:
         max_output_chars=10_000,
         cancel_event=cancel,
     )
-    elapsed = time.monotonic() - started
+    finished_at = time.monotonic()
     assert result.cancelled is True
     assert result.timed_out is False
-    assert elapsed < 4
-    assert "GRAND:" in result.stdout
-    grand_pid = int(result.stdout.strip().split("GRAND:", 1)[1].split()[0])
+    assert finished_at - cancel_requested_at[0] < 4
+    grand_pid = int(pid_file.read_text())
     _assert_pid_gone(grand_pid)
 
 

--- a/tests/interactive_shell/shell/test_shell_parsing.py
+++ b/tests/interactive_shell/shell/test_shell_parsing.py
@@ -1,116 +1,54 @@
-"""Tests for interactive-shell command parsing.
-
-Alpha mode removed the shell-command safety policy (allowlist / restricted /
-mutating classification and the deny floor). Parsing now only decides *how* a
-command runs — via ``argv`` or through a shell — and never blocks a command for
-safety. The only non-execution outcome is empty input.
-"""
+"""Tests for shell-source input normalization."""
 
 from __future__ import annotations
 
-from tools.interactive_shell.shell.parsing import (
-    argv_for_repl_builtin_detection,
-    parse_shell_command,
-)
+import pytest
+
+from tools.interactive_shell.shell.parsing import parse_shell_command
 
 
 def test_parse_shell_command_detects_passthrough_prefix() -> None:
-    parsed = parse_shell_command("!echo hello", is_windows=False)
+    parsed = parse_shell_command("!echo hello")
 
     assert parsed.passthrough is True
-    assert parsed.use_shell is True
     assert parsed.command == "echo hello"
-    assert parsed.argv is None
     assert parsed.parse_error is None
 
 
-def test_plain_command_uses_argv_without_shell() -> None:
-    parsed = parse_shell_command("rm -rf /tmp/x", is_windows=False)
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf /tmp/x",
+        "sudo systemctl restart nginx",
+        "printf one&&printf two;printf three",
+        "echo $(date)",
+        "cd /tmp&&pwd",
+        "cd 'directory;name'",
+        'echo "unterminated',
+    ],
+)
+def test_non_empty_input_remains_opaque_shell_source(command: str) -> None:
+    parsed = parse_shell_command(command)
 
+    assert parsed.command == command
     assert parsed.passthrough is False
-    assert parsed.use_shell is False
-    assert parsed.argv == ["rm", "-rf", "/tmp/x"]
     assert parsed.parse_error is None
 
 
-def test_restricted_command_is_no_longer_blocked() -> None:
-    """``sudo`` and friends used to be a hard deny; alpha mode just runs them."""
-    parsed = parse_shell_command("sudo systemctl restart nginx", is_windows=False)
-
-    assert parsed.use_shell is False
-    assert parsed.argv == ["sudo", "systemctl", "restart", "nginx"]
-    assert parsed.parse_error is None
-
-
-def test_operators_run_through_shell_without_block() -> None:
-    parsed = parse_shell_command("ls | wc -l", is_windows=False)
-
-    assert parsed.use_shell is True
-    assert parsed.passthrough is False
-    assert parsed.argv is None
-    assert parsed.parse_error is None
-
-
-def test_command_substitution_runs_through_shell() -> None:
-    parsed = parse_shell_command("echo $(date)", is_windows=False)
-
-    assert parsed.use_shell is True
-    assert parsed.parse_error is None
-
-
-def test_quoted_heredoc_runs_through_shell() -> None:
+def test_multiline_shell_source_is_preserved() -> None:
     command = """python3 - <<'PY'
 print("hello-heredoc")
 PY"""
-    parsed = parse_shell_command(command, is_windows=False)
 
-    assert parsed.use_shell is True
-    assert parsed.argv is None
-    assert parsed.command == command.strip()
-    assert parsed.parse_error is None
-
-
-def test_unquoted_heredoc_runs_through_shell() -> None:
-    command = """cat <<EOF
-line one
-EOF"""
-    parsed = parse_shell_command(command, is_windows=False)
-
-    assert parsed.use_shell is True
-    assert parsed.argv is None
-
-
-def test_unbalanced_quotes_fall_back_to_shell() -> None:
-    parsed = parse_shell_command('echo "unterminated', is_windows=False)
-
-    assert parsed.use_shell is True
-    assert parsed.parse_error is None
+    assert parse_shell_command(command).command == command
 
 
 def test_empty_passthrough_is_parse_error() -> None:
-    parsed = parse_shell_command("!", is_windows=False)
+    parsed = parse_shell_command("!")
 
-    assert parsed.parse_error is not None
+    assert parsed.parse_error == "missing command after passthrough prefix (!)."
     assert parsed.passthrough is True
 
 
 def test_empty_command_is_parse_error() -> None:
-    parsed = parse_shell_command("   ", is_windows=False)
-
-    assert parsed.parse_error == "empty command."
-
-
-def test_argv_for_repl_builtin_detection_splits_passthrough_for_cd() -> None:
-    parsed = parse_shell_command("!cd /tmp", is_windows=False)
-    assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) == ["cd", "/tmp"]
-
-
-def test_argv_for_repl_builtin_detection_returns_plain_argv() -> None:
-    parsed = parse_shell_command("pwd", is_windows=False)
-    assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) == ["pwd"]
-
-
-def test_argv_for_repl_builtin_detection_skips_operator_command() -> None:
-    """A leading ``cd`` in an operator command must not be hijacked as a builtin."""
-    parsed = parse_shell_command("cd /tmp && ls", is_windows=False)
-    assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) is None
+    assert parse_shell_command("   ").parse_error == "empty command."

--- a/tests/interactive_shell/shell/test_working_directory.py
+++ b/tests/interactive_shell/shell/test_working_directory.py
@@ -1,0 +1,147 @@
+"""Tests for typed interactive-shell working-directory state."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from rich.console import Console
+
+from config.constants.repl_autonomy import AutoLevel
+from core.agent_harness.session.persistence.memory import InMemorySessionStore
+from core.agent_harness.tools import ActionToolScope
+from surfaces.interactive_shell.runtime.subprocess_runner.repl_presenter import make_repl_presenter
+from surfaces.interactive_shell.session import Session
+from tools.interactive_shell.actions.shell import execute_set_working_directory_tool
+from tools.interactive_shell.shared import ExecutionPolicyResult
+
+
+def _session(working_directory: Path) -> Session:
+    store = InMemorySessionStore()
+    session = Session(store=store, working_directory=str(working_directory))
+    store.open_session(session)
+    return session
+
+
+def _scope(
+    session: Session,
+    *,
+    confirm_fn: object = None,
+    is_tty: bool | None = True,
+) -> ActionToolScope:
+    console = Console(file=io.StringIO(), force_terminal=False)
+    presenter = make_repl_presenter(
+        session,
+        console,
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+    )
+    return ActionToolScope(
+        session=session,
+        console=SimpleNamespace(),
+        subprocess_presenter=presenter,
+    )
+
+
+def test_set_working_directory_resolves_relative_path(tmp_path: Path) -> None:
+    child = tmp_path / "directory with spaces"
+    child.mkdir()
+    session = _session(tmp_path)
+
+    result = execute_set_working_directory_tool(
+        {"path": child.name},
+        _scope(session),
+    )
+
+    assert result == {
+        "ok": True,
+        "working_directory": str(child.resolve()),
+        "response_text": str(child.resolve()),
+    }
+    assert session.working_directory == str(child.resolve())
+
+
+def test_set_working_directory_failure_preserves_current_directory(tmp_path: Path) -> None:
+    session = _session(tmp_path)
+
+    result = execute_set_working_directory_tool(
+        {"path": "missing"},
+        _scope(session),
+    )
+
+    assert result["ok"] is False
+    assert result["working_directory"] == str(tmp_path)
+    assert session.working_directory == str(tmp_path)
+    assert session.history[-1]["ok"] is False
+
+
+def test_set_working_directory_rejects_regular_file(tmp_path: Path) -> None:
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("not a directory", encoding="utf-8")
+    session = _session(tmp_path)
+
+    result = execute_set_working_directory_tool(
+        {"path": str(file_path)},
+        _scope(session),
+    )
+
+    assert result["ok"] is False
+    assert "not a directory" in str(result["response_text"])
+    assert session.working_directory == str(tmp_path)
+
+
+def test_session_clear_preserves_working_directory(tmp_path: Path) -> None:
+    session = _session(tmp_path)
+
+    session.clear()
+
+    assert session.working_directory == str(tmp_path)
+
+
+def test_set_working_directory_denial_does_not_mutate_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    session = _session(tmp_path)
+    monkeypatch.setattr(
+        "tools.interactive_shell.actions.shell.allow_tool",
+        lambda _tool_type: ExecutionPolicyResult(
+            verdict="deny",
+            tool_type="shell",
+            reason="blocked by host policy",
+        ),
+    )
+
+    result = execute_set_working_directory_tool(
+        {"path": str(target)},
+        _scope(session),
+    )
+
+    assert result["ok"] is False
+    assert session.working_directory == str(tmp_path)
+    assert session.history[-1]["ok"] is False
+
+
+def test_set_working_directory_confirmation_can_allow_mutation(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    session = _session(tmp_path)
+    session.terminal.auto_level = AutoLevel.MED
+    prompts: list[str] = []
+
+    def _confirm(prompt: str) -> str:
+        prompts.append(prompt)
+        return "y"
+
+    result = execute_set_working_directory_tool(
+        {"path": str(target)},
+        _scope(session, confirm_fn=_confirm),
+    )
+
+    assert result["ok"] is True
+    assert session.working_directory == str(target.resolve())
+    assert prompts == ["Approve this action?"]

--- a/tests/tools/interactive_shell/test_action_names.py
+++ b/tests/tools/interactive_shell/test_action_names.py
@@ -14,6 +14,7 @@ def test_tool_kind_members_are_stable() -> None:
         "implementation",
         "llm_provider",
         "session_goal",
+        "working_directory",
     ]
 
 
@@ -36,6 +37,7 @@ def test_tool_kind_to_name_mapping_values() -> None:
         ToolKind.IMPLEMENTATION: "code_implement",
         ToolKind.LLM_PROVIDER: "llm_set_provider",
         ToolKind.SESSION_GOAL: "session_goal_set",
+        ToolKind.WORKING_DIRECTORY: "set_working_directory",
     }
 
 
@@ -57,6 +59,7 @@ def test_action_tool_name_members_are_stable() -> None:
         "session_goal_complete",
         "session_goal_set",
         "shell_run",
+        "set_working_directory",
         "skill_view",
         "slash_invoke",
         "task_cancel",

--- a/tests/tools/interactive_shell/test_opensre_cli_plan.py
+++ b/tests/tools/interactive_shell/test_opensre_cli_plan.py
@@ -2,14 +2,38 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
+import tools.interactive_shell.cli as opensre_cli
 from tools.interactive_shell.cli import (
     OpensreCommandClass,
     OpensreExecutionMode,
+    build_opensre_cli_argv,
     build_opensre_execution_plan,
     classify_opensre_command,
 )
+
+
+def test_cli_argv_absolutizes_relative_reused_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(opensre_cli.sys, "argv", ["./.venv/bin/opensre"])
+
+    argv = build_opensre_cli_argv(["health"])
+
+    assert argv == [str((tmp_path / ".venv/bin/opensre").resolve()), "health"]
+
+
+def test_cli_argv_preserves_bare_entrypoint_for_path_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(opensre_cli.sys, "argv", ["opensre"])
+
+    assert build_opensre_cli_argv(["health"]) == ["opensre", "health"]
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/interactive_shell/test_subprocess_primitives.py
+++ b/tests/tools/interactive_shell/test_subprocess_primitives.py
@@ -8,9 +8,12 @@ import sys
 import tempfile
 import threading
 import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
+import tools.interactive_shell.subprocess as subprocess_tools
 from tools.interactive_shell.subprocess import (
     read_diag,
     subprocess_env_with_width,
@@ -45,6 +48,53 @@ def test_terminate_child_process_noop_when_exited() -> None:
     proc = subprocess.Popen(["true"])
     proc.wait()
     terminate_child_process(proc)
+
+
+def test_terminate_child_process_uses_tree_termination_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[object] = []
+    proc = MagicMock()
+    monkeypatch.setattr(subprocess_tools, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(
+        subprocess_tools,
+        "terminate_process_tree",
+        lambda pid, **options: seen.append((pid, options)),
+    )
+    proc.pid = 123
+    proc.poll.side_effect = [None, 0, 0]
+
+    terminate_child_process(proc)
+
+    assert seen == [
+        (
+            123,
+            {
+                "grace_seconds": subprocess_tools.SIGTERM_GRACE_SECONDS,
+                "force_wait_seconds": 5,
+            },
+        )
+    ]
+    proc.terminate.assert_not_called()
+
+
+def test_terminate_child_process_does_not_resolve_exited_windows_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    terminate_process_tree = MagicMock()
+    proc = MagicMock(pid=123)
+    proc.poll.return_value = 0
+    monkeypatch.setattr(subprocess_tools, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(
+        subprocess_tools,
+        "terminate_process_tree",
+        terminate_process_tree,
+    )
+
+    terminate_child_process(proc)
+
+    terminate_process_tree.assert_not_called()
+    proc.kill.assert_not_called()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="process-group cancel is POSIX")

--- a/tests/tools/test_github_issues_tool.py
+++ b/tests/tools/test_github_issues_tool.py
@@ -31,6 +31,15 @@ def test_extract_params_maps_fields() -> None:
     assert params["repo"] == "my-repo"
 
 
+def test_extract_params_allows_model_supplied_scope() -> None:
+    rt = search_github_issues.__opensre_registered_tool__
+
+    params = rt.extract_params({"github": {"connection_verified": True}})
+
+    assert params["owner"] is None
+    assert params["repo"] is None
+
+
 def test_run_returns_unavailable_when_no_config() -> None:
     with patch("integrations.github.helpers.github_mcp_config_from_env", return_value=None):
         result = search_github_issues(owner="org", repo="repo", query="crash")

--- a/tests/tools/test_gitlab_commits_tool.py
+++ b/tests/tools/test_gitlab_commits_tool.py
@@ -77,6 +77,14 @@ def test_extract_params_defaults_ref_name_to_main() -> None:
     assert params["ref_name"] == "main"
 
 
+def test_extract_params_allows_model_supplied_project() -> None:
+    rt = list_gitlab_commits.__opensre_registered_tool__
+
+    params = rt.extract_params({"gitlab": {"connection_verified": True}})
+
+    assert params["project_id"] is None
+
+
 def test_schema_does_not_expose_gitlab_credentials_as_model_inputs() -> None:
     rt = list_gitlab_commits.__opensre_registered_tool__
 

--- a/tests/tools/test_gitlab_repo_scope.py
+++ b/tests/tools/test_gitlab_repo_scope.py
@@ -89,6 +89,22 @@ def test_infer_gitlab_repo_scope_uses_environment() -> None:
     assert scope == ("group/project", "release", "docs/runbook.md")
 
 
+def test_infer_gitlab_repo_scope_can_prefer_working_directory() -> None:
+    with patch("integrations.gitlab.repo_scope.detect_git_remote_repo_scope") as detect:
+        detect.return_value = ("cwd/project", "", "")
+
+        scope = infer_gitlab_repo_scope(
+            message="read the current project",
+            conversation_messages=[],
+            env={"GITLAB_PROJECT_ID": "ambient/project"},
+            cwd="/workspace/cwd-project",
+            prefer_cwd_over_environment=True,
+        )
+
+    assert scope == ("cwd/project", "", "")
+    detect.assert_called_once_with("/workspace/cwd-project", allowed_hosts=frozenset())
+
+
 def test_infer_gitlab_repo_scope_recognizes_configured_self_hosted_host() -> None:
     """A self-hosted host that lacks the ``gitlab`` substring is trusted when it
     matches the configured ``GITLAB_BASE_URL`` host."""

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1186,6 +1186,9 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "search_github_code",
         "search_github_issues",
         "search_sentry_issues",
+        # set_working_directory catches only expected filesystem validation
+        # failures; unexpected exceptions escape to the global wrapper.
+        "set_working_directory",
         "shell_run",
         "skill_view",
         "session_goal_complete",

--- a/tools/interactive_shell/AGENTS.md
+++ b/tools/interactive_shell/AGENTS.md
@@ -9,12 +9,12 @@ This package hosts the **action-tool implementations** the agent harness calls
 during an interactive-shell turn — the concrete `run` bodies behind the action
 tools listed in `core/agent_harness/tools/action_tools.py`:
 
-- `actions/` — the action tools themselves (`shell_run`, `cli_exec`,
+- `actions/` — the action tools themselves (`shell_run`, `set_working_directory`, `cli_exec`,
   `slash_invoke`, `code_implement`, `session_goal_set`, `session_goal_complete`,
   `llm_set_provider`,
   `task_cancel`, and friends; see `action_names.py` for the closed set).
-- `shell/` — shell command parsing, execution policy, and the
-  `run_shell_command`/`run_cd`/`run_pwd` runner behind `actions/shell.py`.
+- `shell/` — shell input normalization, execution policy, and the
+  `run_shell_command` runner behind `actions/shell.py`.
 - `implementation/` — the `/implement` (Claude Code) launcher.
 - `contracts` — imported by `command_registry.slash_catalog` during early import
   wiring; see the `__init__.py` docstring for why tool submodules must be

--- a/tools/interactive_shell/action_names.py
+++ b/tools/interactive_shell/action_names.py
@@ -20,6 +20,7 @@ class ToolKind(StrEnum):
     IMPLEMENTATION = "implementation"
     LLM_PROVIDER = "llm_provider"
     SESSION_GOAL = "session_goal"
+    WORKING_DIRECTORY = "working_directory"
 
 
 class ActionToolName(StrEnum):
@@ -38,6 +39,7 @@ class ActionToolName(StrEnum):
     SESSION_GOAL_COMPLETE = "session_goal_complete"
     SESSION_GOAL_SET = "session_goal_set"
     SHELL_RUN = "shell_run"
+    SET_WORKING_DIRECTORY = "set_working_directory"
     SKILL_VIEW = "skill_view"
     SLASH_INVOKE = "slash_invoke"
     TASK_CANCEL = "task_cancel"
@@ -52,6 +54,7 @@ TOOL_KIND_TO_NAME: dict[ToolKind, ActionToolName] = {
     ToolKind.IMPLEMENTATION: ActionToolName.CODE_IMPLEMENT,
     ToolKind.LLM_PROVIDER: ActionToolName.LLM_SET_PROVIDER,
     ToolKind.SESSION_GOAL: ActionToolName.SESSION_GOAL_SET,
+    ToolKind.WORKING_DIRECTORY: ActionToolName.SET_WORKING_DIRECTORY,
 }
 
 __all__ = ["ActionToolName", "TOOL_KIND_TO_NAME", "ToolKind"]

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -13,8 +13,13 @@ from core.agent_harness.tools import (
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
+from tools.interactive_shell.shared import allow_tool
 from tools.interactive_shell.shell.runner import run_shell_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter
+from tools.interactive_shell.working_directory import (
+    resolve_working_directory,
+    session_working_directory,
+)
 
 
 def _coerce_quiet(value: Any) -> bool:
@@ -51,10 +56,75 @@ def run_shell(*, command: str, context: Any, quiet: bool = False) -> dict[str, A
     )
 
 
+def execute_set_working_directory_tool(
+    args: dict[str, Any],
+    ctx: ActionToolScope,
+) -> dict[str, Any]:
+    """Validate and commit the default directory for local session tools."""
+    path = str(args.get("path", ""))
+    if not path.strip():
+        response_text = "missing working directory path"
+        ctx.session.record("shell", "cd", ok=False, response_text=response_text)
+        return {
+            "ok": False,
+            "working_directory": session_working_directory(ctx.session),
+            "response_text": response_text,
+        }
+
+    command = f"cd {path}"
+    try:
+        resolved = resolve_working_directory(
+            path,
+            current=session_working_directory(ctx.session),
+        )
+    except (OSError, RuntimeError) as exc:
+        response_text = f"working directory unchanged: {exc}"
+        ctx.session.record("shell", command, ok=False, response_text=response_text)
+        return {
+            "ok": False,
+            "working_directory": session_working_directory(ctx.session),
+            "response_text": response_text,
+        }
+
+    presenter = require_subprocess_presenter(ctx)
+    if not presenter.execution_allowed(
+        allow_tool("shell"),
+        action_summary=f"$ {command}",
+    ):
+        response_text = "working directory unchanged: action blocked"
+        ctx.session.record("shell", command, ok=False, response_text=response_text)
+        return {
+            "ok": False,
+            "working_directory": session_working_directory(ctx.session),
+            "response_text": response_text,
+        }
+
+    ctx.session.set_working_directory(resolved)
+    ctx.session.record("shell", command, response_text=resolved)
+    return {
+        "ok": True,
+        "working_directory": resolved,
+        "response_text": resolved,
+    }
+
+
+def set_working_directory(*, path: str, context: Any) -> dict[str, Any]:
+    return execute_with_action_context(
+        {"path": path},
+        context,
+        execute_set_working_directory_tool,
+    )
+
+
 shell_run_tool = RegisteredTool(
     name="shell_run",
     description=(
-        "Run a local shell command on this machine. Use for read-only inspection, "
+        "Run a local host-shell command on this machine. The command is evaluated as "
+        "shell syntax, including quoting, expansions, redirects, and command operators. "
+        "It starts in the session working directory. A `cd` inside this command affects "
+        "only this child shell; use `set_working_directory` when later local tools should "
+        "run from another directory. "
+        "Use for read-only inspection, "
         "controlled operational steps, and user-requested local workflows — including "
         "creating files or scripts and executing multi-step sequences, one shell_run call "
         "per step when a step consumes the previous step's output. When the user asks for "
@@ -72,7 +142,7 @@ shell_run_tool = RegisteredTool(
         properties={
             "command": string_property(
                 description=(
-                    "Exact shell command to execute — a diagnostic (for example: `ls`, "
+                    "Exact host-shell command to execute — a diagnostic (for example: `ls`, "
                     "`pwd`, `git status`, `uv run python -m pytest ...`) or one step of a "
                     "local workflow the user asked for (writing a file or script, running "
                     "it, updating state a later step reads). Run a user-requested command "
@@ -105,4 +175,49 @@ shell_run_tool = RegisteredTool(
 )
 
 
-__all__ = ["execute_shell_tool", "shell_run_tool"]
+set_working_directory_tool = RegisteredTool(
+    name="set_working_directory",
+    description=(
+        "Set the default working directory for subsequent local tools in this session, "
+        "including shell_run, cli_exec, and code_implement. Use this for a standalone "
+        "directory-change request instead of interpreting `cd` inside shell source. The "
+        "path is structured data: pass it without shell quoting or environment-variable "
+        "syntax. Relative paths resolve from the current session directory and `~` is "
+        "supported. Invalid paths leave the current directory unchanged."
+    ),
+    input_schema=object_schema(
+        properties={
+            "path": string_property(
+                description=(
+                    "Directory to make current for later local tool calls. May be absolute, "
+                    "relative to the current session directory, or start with `~`."
+                ),
+                min_length=1,
+            )
+        },
+        required=("path",),
+    ),
+    source="interactive_shell",
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
+    use_cases=[
+        "The user asks to change directories before later local tool calls.",
+        "A multi-step workflow should continue from a different project directory.",
+    ],
+    anti_examples=[
+        "A compound shell command already contains its own temporary `cd`; use shell_run.",
+        "The user only asks which directory is active; use shell_run with `pwd`.",
+    ],
+    parallel_safe=False,
+    accepts_runtime_context=True,
+    run=set_working_directory,
+    is_available=lambda sources: capability_available_from_sources(sources, "shell_commands"),
+)
+
+
+__all__ = [
+    "execute_set_working_directory_tool",
+    "execute_shell_tool",
+    "set_working_directory_tool",
+    "shell_run_tool",
+]

--- a/tools/interactive_shell/cli.py
+++ b/tools/interactive_shell/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 import subprocess
 import sys
@@ -19,6 +20,7 @@ from tools.interactive_shell.subprocess import (
     SHELL_COMMAND_TIMEOUT_SECONDS,
     SubprocessPresenter,
 )
+from tools.interactive_shell.working_directory import session_working_directory
 
 # Rich style token names passed to presenter.print_command_output (resolved in surface).
 _ERROR_STYLE = "error"
@@ -115,6 +117,8 @@ def _current_opensre_entrypoint() -> str | None:
         return None
     if Path(argv0).name.lower() not in ("opensre", "opensre.exe"):
         return None
+    if os.sep in argv0 or (os.altsep is not None and os.altsep in argv0):
+        return str(Path(argv0).resolve())
     return argv0
 
 
@@ -249,6 +253,7 @@ def to_tool_execution_plan(plan: OpensreExecutionPlan) -> ToolExecutionPlan:
 def run_foreground_cli(
     argv_list: list[str],
     *,
+    cwd: str | None = None,
     timeout_seconds: int = SHELL_COMMAND_TIMEOUT_SECONDS,
 ) -> ForegroundCliResult:
     try:
@@ -258,6 +263,7 @@ def run_foreground_cli(
             text=True,
             encoding="utf-8",
             errors="replace",
+            cwd=cwd,
             timeout=timeout_seconds,
             check=False,
         )
@@ -287,7 +293,11 @@ def run_foreground_cli(
     )
 
 
-def spawn_streaming_cli(argv_list: list[str]) -> subprocess.Popen[str]:
+def spawn_streaming_cli(
+    argv_list: list[str],
+    *,
+    cwd: str | None = None,
+) -> subprocess.Popen[str]:
     return subprocess.Popen(
         argv_list,
         stdout=subprocess.PIPE,
@@ -295,6 +305,7 @@ def spawn_streaming_cli(argv_list: list[str]) -> subprocess.Popen[str]:
         text=True,
         encoding="utf-8",
         errors="replace",
+        cwd=cwd,
     )
 
 
@@ -314,7 +325,11 @@ def _run_foreground_via_presenter(
     display_command: str,
 ) -> None:
     presenter.print_bold_command(display_command)
-    result = run_foreground_cli(argv_list, timeout_seconds=SHELL_COMMAND_TIMEOUT_SECONDS)
+    result = run_foreground_cli(
+        argv_list,
+        cwd=session_working_directory(presenter.session),
+        timeout_seconds=SHELL_COMMAND_TIMEOUT_SECONDS,
+    )
     if result.start_failed:
         if result.start_error:
             presenter.report_exception(
@@ -346,7 +361,10 @@ def _run_streaming_via_presenter(
 ) -> None:
     presenter.print_bold_command(display_command)
     try:
-        proc = spawn_streaming_cli(argv_list)
+        proc = spawn_streaming_cli(
+            argv_list,
+            cwd=session_working_directory(presenter.session),
+        )
     except Exception as exc:  # noqa: BLE001
         presenter.report_exception(
             exc,

--- a/tools/interactive_shell/implementation/claude_code_executor.py
+++ b/tools/interactive_shell/implementation/claude_code_executor.py
@@ -30,6 +30,7 @@ from tools.interactive_shell.subprocess import (
     SubprocessPresenter,
     terminate_child_process,
 )
+from tools.interactive_shell.working_directory import session_working_directory
 
 _DIM_STYLE = "dim"
 _ERROR_STYLE = "error"
@@ -207,7 +208,7 @@ def run_claude_code_implementation(request: str, presenter: SubprocessPresenter)
         invocation = adapter.build(
             prompt=prompt,
             model=os.environ.get("CLAUDE_CODE_MODEL"),
-            workspace=str(Path.cwd()),
+            workspace=session_working_directory(session),
         )
     except Exception as exc:
         presenter.report_exception(exc, context="surfaces.interactive_shell.claude_code.build")

--- a/tools/interactive_shell/shell/__init__.py
+++ b/tools/interactive_shell/shell/__init__.py
@@ -3,11 +3,10 @@
 Groups the shell command-line concern next to the agent-facing
 ``tools.interactive_shell.actions.shell``:
 
-* ``parsing`` turns command text into an executable shape,
+* ``parsing`` normalizes passthrough and empty input without parsing shell syntax,
 * ``policy`` resolves the (alpha-mode, allow-everything) shell execution plan,
 * ``execution`` runs the subprocess and returns a structured result,
-* ``runner`` wires parsing, policy, builtins (``cd`` / ``pwd``), and execution
-  together and records the turn.
+* ``runner`` wires normalization, policy, and execution together and records the turn.
 
 Import submodules explicitly (for example ``tools.interactive_shell.shell.runner``)
 rather than relying on this package initializer, to keep interactive-shell

--- a/tools/interactive_shell/shell/execution.py
+++ b/tools/interactive_shell/shell/execution.py
@@ -17,7 +17,6 @@ class ShellExecutionResult:
     """Normalized command execution output."""
 
     command: str
-    argv: list[str] | None
     stdout: str
     stderr: str
     exit_code: int | None
@@ -37,8 +36,12 @@ def _shell_argv(command: str) -> list[str]:
     if os.name == "nt":
         shell = os.environ.get("COMSPEC") or "cmd.exe"
         return [shell, "/d", "/s", "/c", command]
-    shell = os.environ.get("SHELL") or "/bin/sh"
-    return [shell, "-lc", command]
+    configured_shell = os.environ.get("SHELL")
+    if configured_shell:
+        return [configured_shell, "-lc", command]
+    # /bin/sh is a compatibility fallback, not necessarily the user's login
+    # shell. Do not source a potentially bash/zsh-specific login profile in it.
+    return ["/bin/sh", "-c", command]
 
 
 def _drain_pipe(pipe: IO[str] | None, buffer: list[str]) -> None:
@@ -58,18 +61,15 @@ def _drain_pipe(pipe: IO[str] | None, buffer: list[str]) -> None:
 def _cancelled_result(
     *,
     command: str,
-    argv: list[str] | None,
-    use_shell: bool,
 ) -> ShellExecutionResult:
     return ShellExecutionResult(
         command=command,
-        argv=argv,
         stdout="",
         stderr="",
         exit_code=None,
         timed_out=False,
         truncated=False,
-        executed_with_shell=use_shell,
+        executed_with_shell=True,
         cancelled=True,
     )
 
@@ -77,8 +77,7 @@ def _cancelled_result(
 def execute_shell_command(
     *,
     command: str,
-    argv: list[str] | None,
-    use_shell: bool,
+    cwd: str,
     timeout_seconds: int,
     max_output_chars: int,
     cancel_event: threading.Event | None = None,
@@ -91,14 +90,9 @@ def execute_shell_command(
     """
     watch_cancel = cancel_event if cancel_event is not None else threading.Event()
     if watch_cancel.is_set():
-        return _cancelled_result(command=command, argv=argv, use_shell=use_shell)
+        return _cancelled_result(command=command)
 
-    if use_shell:
-        exec_argv = _shell_argv(command)
-    else:
-        if argv is None:
-            raise ValueError("argv is required for shell=False execution.")
-        exec_argv = argv
+    exec_argv = _shell_argv(command)
 
     proc = subprocess.Popen(
         exec_argv,
@@ -107,6 +101,7 @@ def execute_shell_command(
         text=True,
         encoding="utf-8",
         errors="replace",
+        cwd=cwd,
         start_new_session=True,
     )
     out_buf: list[str] = []
@@ -136,13 +131,12 @@ def execute_shell_command(
     )
     return ShellExecutionResult(
         command=command,
-        argv=argv,
         stdout=stdout,
         stderr=stderr,
         exit_code=watch.exit_code,
         timed_out=watch.timed_out,
         truncated=truncated_stdout or truncated_stderr,
-        executed_with_shell=use_shell,
+        executed_with_shell=True,
         cancelled=watch.cancelled,
     )
 

--- a/tools/interactive_shell/shell/parsing.py
+++ b/tools/interactive_shell/shell/parsing.py
@@ -1,71 +1,29 @@
-"""Shell command parsing for the interactive REPL.
+"""Input normalization for host-shell commands.
 
-Alpha mode: no command-safety policy
-------------------------------------
-While OpenSRE is in alpha we run **every** command the user or action agent
-asks for. There is intentionally no allowlist, no read-only / mutating /
-restricted classification, and no deny floor — guardrails are deliberately
-omitted to keep developer velocity high. See
-``docs/interactive-shell-action-policy.md`` for the rationale.
-
-This module's only job is to turn command text into a shape the runner can
-execute:
-
-* explicit ``!`` passthrough → run the remainder through a shell,
-* commands using shell operators / substitution / heredocs → run through a shell,
-* anything that fails to tokenize → hand the raw string to a shell,
-* everything else → split into ``argv`` and run without a shell (which also lets
-  the runner detect the ``cd`` / ``pwd`` REPL builtins so the working directory
-  persists across turns).
-
-The only non-execution outcome is a ``parse_error`` for genuinely empty input
-(e.g. a bare ``!``). That is input validation, not a safety guardrail.
+``shell_run.command`` is always host-shell source. This module deliberately
+does not interpret shell syntax; the configured platform shell is the single
+syntax authority. Parsing here is limited to the explicit ``!`` prefix and
+empty-input validation.
 """
 
 from __future__ import annotations
 
-import re
-import shlex
 from dataclasses import dataclass
 
 _EXPLICIT_SHELL_PREFIX = "!"
-_SHELL_OPERATOR_RE = re.compile(r"(^|\s)(\|\||&&|[|;<>]|>>|<<|2>)(\s|$)")
-_INLINE_SUBSHELL_RE = re.compile(r"`|\$\(")
-# Heredoc starts such as ``<<'PY'`` or ``<<EOF`` — ``<<`` alone is already covered
-# by ``_SHELL_OPERATOR_RE`` only when followed by whitespace; quoted/unquoted
-# delimiters need an explicit match so ``python3 - <<'PY'`` is not tokenized.
-_HEREDOC_START_RE = re.compile(r"(^|\s)<<-?\s*(?:'[^'\n]+'|\"[^\"\n]+\"|[^\s\\|;&<>]+)")
 
 
 @dataclass(frozen=True)
 class ParsedShellCommand:
-    """Structured command parsing result.
-
-    ``use_shell`` is True when the command must run through a real shell (explicit
-    ``!`` passthrough, shell operators / substitution, or input that could not be
-    tokenized). ``passthrough`` records only the explicit ``!`` prefix so the
-    runner can surface the "shell passthrough" hint for it.
-    """
+    """Normalized shell source plus explicit-passthrough metadata."""
 
     command: str
-    argv: list[str] | None
     passthrough: bool
-    use_shell: bool
     parse_error: str | None = None
 
 
-def _split_argv(command: str, *, is_windows: bool) -> list[str] | None:
-    try:
-        return shlex.split(command, posix=not is_windows)
-    except ValueError:
-        try:
-            return shlex.split(command, posix=False)
-        except ValueError:
-            return None
-
-
-def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand:
-    """Parse command text into an executable shape (no safety policy applied)."""
+def parse_shell_command(command: str) -> ParsedShellCommand:
+    """Normalize shell source without attempting to tokenize its language."""
     stripped = command.strip()
 
     if stripped.startswith(_EXPLICIT_SHELL_PREFIX):
@@ -73,87 +31,19 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
         if not passthrough_command:
             return ParsedShellCommand(
                 command="",
-                argv=None,
                 passthrough=True,
-                use_shell=True,
                 parse_error="missing command after passthrough prefix (!).",
             )
-        return ParsedShellCommand(
-            command=passthrough_command,
-            argv=None,
-            passthrough=True,
-            use_shell=True,
-        )
+        return ParsedShellCommand(command=passthrough_command, passthrough=True)
 
-    if (
-        _SHELL_OPERATOR_RE.search(stripped) is not None
-        or _INLINE_SUBSHELL_RE.search(stripped) is not None
-        or _HEREDOC_START_RE.search(stripped) is not None
-    ):
-        # Operators / substitution need a real shell; alpha mode runs them.
+    if not stripped:
         return ParsedShellCommand(
-            command=stripped,
-            argv=None,
+            command="",
             passthrough=False,
-            use_shell=True,
-        )
-
-    argv = _split_argv(stripped, is_windows=is_windows)
-    if argv is None:
-        # Could not tokenize (e.g. unbalanced quotes). Hand the raw string to the
-        # shell instead of blocking it.
-        return ParsedShellCommand(
-            command=stripped,
-            argv=None,
-            passthrough=False,
-            use_shell=True,
-        )
-
-    if not argv:
-        return ParsedShellCommand(
-            command=stripped,
-            argv=None,
-            passthrough=False,
-            use_shell=False,
             parse_error="empty command.",
         )
 
-    if is_windows:
-
-        def _strip_outer_quotes(value: str) -> str:
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-                return value[1:-1]
-            return value
-
-        argv = [_strip_outer_quotes(token) for token in argv]
-
-    return ParsedShellCommand(
-        command=stripped,
-        argv=argv,
-        passthrough=False,
-        use_shell=False,
-    )
+    return ParsedShellCommand(command=stripped, passthrough=False)
 
 
-def argv_for_repl_builtin_detection(
-    *, parsed: ParsedShellCommand, is_windows: bool
-) -> list[str] | None:
-    """Argv tokens for detecting ``cd`` / ``pwd`` REPL builtins.
-
-    Only the plain ``argv`` path and explicit ``!`` passthrough opt into builtin
-    detection. Operator / substitution commands run wholesale through the shell,
-    so they intentionally return ``None`` here (a leading ``cd`` in
-    ``cd /tmp && ls`` must not be hijacked by the builtin handler).
-    """
-    if parsed.argv is not None:
-        return parsed.argv
-    if not parsed.passthrough or not parsed.command.strip():
-        return None
-    return _split_argv(parsed.command.strip(), is_windows=is_windows)
-
-
-__all__ = [
-    "ParsedShellCommand",
-    "argv_for_repl_builtin_detection",
-    "parse_shell_command",
-]
+__all__ = ["ParsedShellCommand", "parse_shell_command"]

--- a/tools/interactive_shell/shell/policy.py
+++ b/tools/interactive_shell/shell/policy.py
@@ -10,7 +10,6 @@ They reuse the shared policy contracts
 
 from __future__ import annotations
 
-import config.constants.platform as _platform
 from tools.interactive_shell.shared import (
     ExecutionPolicyResult,
     ToolExecutionMode,
@@ -62,7 +61,7 @@ def plan_shell_execution(parsed: ParsedShellCommand) -> ToolExecutionPlan:
 
 def evaluate_shell_command(command: str) -> ExecutionPolicyResult:
     """Map shell policy + passthrough rules into allow/ask/deny."""
-    parsed = parse_shell_command(command, is_windows=_platform.IS_WINDOWS)
+    parsed = parse_shell_command(command)
     return evaluate_shell_from_parsed(parsed)
 
 

--- a/tools/interactive_shell/shell/runner.py
+++ b/tools/interactive_shell/shell/runner.py
@@ -2,29 +2,23 @@
 
 from __future__ import annotations
 
-import os
-import shlex
 import threading
-from pathlib import Path
 from typing import Any
 
-import config.constants.platform as _platform
 from infrastructure.terminal.theme import DIM, ERROR, GLYPH_ERROR
 from tools.interactive_shell.shell import execution as shell_execution
 from tools.interactive_shell.shell.display import (
     format_shell_command_for_display,
     summarize_shell_command,
 )
-from tools.interactive_shell.shell.parsing import (
-    argv_for_repl_builtin_detection,
-    parse_shell_command,
-)
+from tools.interactive_shell.shell.parsing import parse_shell_command
 from tools.interactive_shell.shell.policy import plan_shell_execution
 from tools.interactive_shell.subprocess import (
     MAX_COMMAND_OUTPUT_CHARS,
     SHELL_COMMAND_TIMEOUT_SECONDS,
     SubprocessPresenter,
 )
+from tools.interactive_shell.working_directory import session_working_directory
 
 
 def _shell_payload(
@@ -61,12 +55,11 @@ def run_shell_command(
     command: str,
     presenter: SubprocessPresenter,
     *,
-    argv: list[str] | None = None,
     quiet: bool = False,
     cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     session = presenter.session
-    parsed = parse_shell_command(command, is_windows=_platform.IS_WINDOWS)
+    parsed = parse_shell_command(command)
     plan = plan_shell_execution(parsed)
     display_command = format_shell_command_for_display(command)
     if not presenter.execution_allowed(
@@ -87,26 +80,15 @@ def run_shell_command(
     else:
         presenter.print_bold_command(display_command)
 
-    argv_builtin = argv_for_repl_builtin_detection(parsed=parsed, is_windows=_platform.IS_WINDOWS)
-
-    if argv_builtin is not None and argv_builtin[0].lower() == "cd":
-        return run_cd_command(parsed.command, presenter, quiet=quiet)
-    if argv_builtin is not None and argv_builtin[0].lower() == "pwd":
-        return run_pwd_command(parsed.command, presenter, quiet=quiet)
-
-    use_shell = parsed.use_shell
     if parsed.passthrough and not quiet:
         presenter.print("[dim]explicit shell passthrough enabled[/]")
-
-    exec_argv = argv if argv is not None else parsed.argv
 
     response_text: str | None = None
 
     try:
         result = shell_execution.execute_shell_command(
             command=parsed.command,
-            argv=exec_argv,
-            use_shell=use_shell,
+            cwd=session_working_directory(session),
             timeout_seconds=SHELL_COMMAND_TIMEOUT_SECONDS,
             max_output_chars=MAX_COMMAND_OUTPUT_CHARS,
             cancel_event=cancel_event,
@@ -124,7 +106,7 @@ def run_shell_command(
             ok=False,
             response_text=response_text,
             stderr=str(exc),
-            executed_with_shell=use_shell,
+            executed_with_shell=True,
         )
 
     if not quiet:
@@ -202,89 +184,4 @@ def run_shell_command(
     )
 
 
-def run_cd_command(
-    command: str,
-    presenter: SubprocessPresenter,
-    *,
-    quiet: bool = False,
-) -> dict[str, Any]:
-    session = presenter.session
-
-    def _strip_outer_quotes(value: str) -> str:
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-            return value[1:-1]
-        return value
-
-    try:
-        tokens = shlex.split(command, posix=not _platform.IS_WINDOWS)
-        if _platform.IS_WINDOWS and len(tokens) > 1:
-            tokens = [tokens[0], *(_strip_outer_quotes(token) for token in tokens[1:])]
-    except ValueError as exc:
-        response_text = f"cd failed: {str(exc)}"
-
-        if not quiet:
-            presenter.print_error(f"cd failed: {exc}")
-        session.record("shell", command, ok=False, response_text=response_text)
-        return _shell_payload(command=command, ok=False, response_text=response_text)
-
-    if len(tokens) > 2:
-        response_text = "cd failed: too many arguments"
-
-        if not quiet:
-            presenter.print("[error]cd failed:[/] too many arguments")
-        session.record("shell", command, ok=False, response_text=response_text)
-        return _shell_payload(command=command, ok=False, response_text=response_text)
-
-    target = Path(tokens[1]).expanduser() if len(tokens) == 2 else Path.home()
-    try:
-        os.chdir(target)
-    except Exception as exc:
-        presenter.report_exception(exc, context="surfaces.interactive_shell.shell_cd")
-
-        response_text = f"cd failed: {str(exc)}"
-
-        if not quiet:
-            presenter.print_error(f"cd failed: {exc}")
-        session.record("shell", command, ok=False, response_text=response_text)
-        return _shell_payload(command=command, ok=False, response_text=response_text)
-
-    cwd = str(Path.cwd())
-    if not quiet:
-        presenter.print_plain(cwd)
-    session.record("shell", command)
-    return _shell_payload(command=command, ok=True, response_text=cwd)
-
-
-def run_pwd_command(
-    command: str,
-    presenter: SubprocessPresenter,
-    *,
-    quiet: bool = False,
-) -> dict[str, Any]:
-    session = presenter.session
-    try:
-        tokens = shlex.split(command, posix=not _platform.IS_WINDOWS)
-    except ValueError as exc:
-        response_text = f"pwd failed: {str(exc)}"
-
-        if not quiet:
-            presenter.print_error(f"pwd failed: {exc}")
-        session.record("shell", command, ok=False, response_text=response_text)
-        return _shell_payload(command=command, ok=False, response_text=response_text)
-
-    if len(tokens) != 1:
-        response_text = "pwd failed: too many arguments"
-
-        if not quiet:
-            presenter.print("[error]pwd failed:[/] too many arguments")
-        session.record("shell", command, ok=False, response_text=response_text)
-        return _shell_payload(command=command, ok=False, response_text=response_text)
-
-    cwd = str(Path.cwd())
-    if not quiet:
-        presenter.print_plain(cwd)
-    session.record("shell", command)
-    return _shell_payload(command=command, ok=True, response_text=cwd, stdout=cwd)
-
-
-__all__ = ["run_cd_command", "run_pwd_command", "run_shell_command"]
+__all__ = ["run_shell_command"]

--- a/tools/interactive_shell/subprocess.py
+++ b/tools/interactive_shell/subprocess.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
 from core.agent_harness.tools import ActionToolScope
+from infrastructure.process.termination import terminate_process_tree
 from tools.interactive_shell.shared import ExecutionPolicyResult
 
 # --- constants ---
@@ -88,12 +89,33 @@ def _signal_child(
 
 
 def terminate_child_process(proc: subprocess.Popen[Any]) -> None:
-    """SIGTERM the child (and its group), then SIGKILL leftovers.
+    """Terminate the child and descendants, then forcefully reap leftovers.
 
-    Descendants that ignore SIGTERM, or are still starting when the
-    leader exits, outlive a parent-only wait. The second signal still
-    uses the snapshotted pgid so they cannot.
+    POSIX uses the process group created at launch. Windows has no equivalent
+    group-wide termination primitive, so psutil snapshots and terminates the
+    descendant tree before the shell parent can orphan it.
     """
+    if os.name == "nt":
+        pid = proc.pid
+        # Consult the Popen handle before resolving this PID through psutil. An
+        # exited child may already have had its PID reused by an unrelated
+        # process, which must never become the cleanup target.
+        if proc.poll() is None and isinstance(pid, int):
+            terminate_process_tree(
+                pid,
+                grace_seconds=SIGTERM_GRACE_SECONDS,
+                force_wait_seconds=5,
+            )
+        # Refresh Popen.returncode, with a parent-only fallback when process
+        # inspection raced exit or was denied.
+        if proc.poll() is None:
+            with contextlib.suppress(OSError):
+                proc.kill()
+        if proc.poll() is None:
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=5)
+        return
+
     group_pid = _process_group_leader_pid(proc)
     if proc.poll() is None:
         _signal_child(proc, forceful=False, group_pid=group_pid)

--- a/tools/interactive_shell/working_directory.py
+++ b/tools/interactive_shell/working_directory.py
@@ -1,0 +1,28 @@
+"""Working-directory helpers shared by local interactive-shell tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def session_working_directory(session: Any) -> str:
+    """Return the session directory, falling back for structural test doubles."""
+    value = getattr(session, "working_directory", None)
+    if isinstance(value, str) and value.strip():
+        return value
+    return str(Path.cwd())
+
+
+def resolve_working_directory(path: str, *, current: str) -> str:
+    """Resolve and validate a typed working-directory path."""
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path(current) / candidate
+    resolved = candidate.resolve(strict=True)
+    if not resolved.is_dir():
+        raise NotADirectoryError(f"not a directory: {resolved}")
+    return str(resolved)
+
+
+__all__ = ["resolve_working_directory", "session_working_directory"]

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -97,6 +97,13 @@ def _fallback_descriptors() -> tuple[ToolDescriptor, ...]:
             "tools.interactive_shell.actions.shell",
         ),
         ToolDescriptor(
+            "set_working_directory",
+            (ToolSurface.ACTION,),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.shell",
+        ),
+        ToolDescriptor(
             "propose_scheduled_delivery",
             (ToolSurface.ACTION,),
             "interactive_shell",


### PR DESCRIPTION
Fixes #6206

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Treat every non-empty `shell_run.command` as host-shell source, so compact operators, redirects, quoting, expansions, and heredocs are interpreted by the installed platform shell; an unset `SHELL` uses non-login `/bin/sh -c` fallback semantics.
- Replace custom `cd`/`pwd` parsing and process-global `os.chdir` with a typed `set_working_directory(path)` action and explicit session-scoped working-directory state.
- Pass the session directory through `cwd=` to `shell_run`, foreground/background `cli_exec`, repository-scope resolution, and `code_implement`.
- Persist directory changes as branch-scoped session state, restore only still-valid directories, refresh repository-aware tool scope immediately, and suppress successful directory-change replays across provider batches while preserving intentional same-batch relative changes.
- Separate tool advertisement from current scope availability so configured GitHub/GitLab repository tools remain callable in the same ReAct turn that changes into a repository.
- Mark repository identifiers as public context parameters so refreshed runtime scope replaces stale defaults while explicitly different cross-repository targets remain intact.
- Use the existing `psutil` runtime to terminate Windows shell descendants on cancellation or timeout; POSIX continues to terminate the isolated process group.
- Add regression and boundary coverage for compact shell syntax, heredocs, relative paths with spaces, invalid paths, child-shell `cd` isolation, policy denial/confirmation, session resume/branching, same-turn repository changes, and cross-platform process-tree cleanup.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```text
$ make lint && make format-check && make typecheck
All checks passed!
3215 files already formatted
Success: no issues found in 1859 source files

$ uv run python -m pytest <focused shell/dedup/process suites> -q
29 passed in 3.25s

$ uv run python -m pytest <repository tool/registry suites> -q
537 passed

$ uv run python -m pytest -p tests.ci_sharding -n auto <cli-runtime-2 shard> -q
529 passed in 25.69s

$ gh pr checks 6209
CI Gate and all required jobs passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

The old path tried to decide which strings contained shell syntax. That cannot remain complete across POSIX shells and Windows command syntax, and it caused #6206 when separators had no surrounding whitespace. I considered broadening the scanner and adding a shell-parser dependency, but both would create a second, incomplete syntax authority. The durable contract is simpler: `shell_run` supplies source to the actual host shell and does not parse that language itself.

A persistent directory is application state rather than shell syntax. `set_working_directory` accepts a structured path, resolves it with `pathlib` relative to the current session directory, validates and authorizes it before assignment, and never changes the Python process directory. Local subprocess entry points read that state and pass it explicitly as `cwd`, avoiding cross-session races and keeping background work consistent. Directory changes are persisted in the existing branch-aware JSONL session log, and the harness refreshes the live repository scope before later tools in the same sequential batch run. Tool registration now distinguishes schema advertisement from fully resolved runtime availability: credentialed repository tools are advertised before a repository is known. Repository identifiers are declared as public context parameters. Execution snapshots their batch-start defaults, replaces only omitted or unchanged stale values after a scope refresh, and preserves explicitly different cross-repository targets. Explicit directory refresh also prefers the new checkout over ambient repository identity variables without discarding provider configuration.

For cancellation, POSIX uses the existing isolated process group. Windows has no equivalent group-wide termination signal, so the shared subprocess utility uses the project's existing `psutil` dependency to snapshot descendants, terminate them before the shell parent, and force-kill survivors after the grace period.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.




