### PR TITLE
fix(work): keep reminder schedules in sync

### DIFF
--- a/core/domain/work_items/store.py
+++ b/core/domain/work_items/store.py
@@ -216,7 +216,9 @@ def update_work_item(
     *,
     changes: WorkItemUpdates,
     store_path: Path | None = None,
+    after_save: Callable[[WorkItem], None] | None = None,
 ) -> UpdateWorkItemResult:
+    """Update one item, rolling it back if ``after_save`` raises."""
     if not changes:
         return UpdateWorkItemResult(error="no_changes")
     path = store_path or work_items_path()
@@ -234,6 +236,12 @@ def update_work_item(
             return UpdateWorkItemResult(error=str(exc))
         saved = [updated if item.id == updated.id else item for item in items]
         _save_items_no_lock(path, saved)
+        if after_save is not None:
+            try:
+                after_save(updated)
+            except Exception:
+                _save_items_no_lock(path, items)
+                raise
         return UpdateWorkItemResult(item=updated)
 
 

--- a/infrastructure/scheduling/scheduler/storage/__init__.py
+++ b/infrastructure/scheduling/scheduler/storage/__init__.py
@@ -26,6 +26,7 @@ from infrastructure.scheduling.scheduler.storage.task_store import (
     list_tasks,
     record_task_success,
     remove_task,
+    replace_matching_tasks,
     update_task,
 )
 
@@ -47,6 +48,7 @@ __all__ = [
     "list_tasks",
     "record_task_success",
     "remove_task",
+    "replace_matching_tasks",
     "renew_claims",
     "run_database_path",
     "try_claim",

--- a/infrastructure/scheduling/scheduler/storage/task_store.py
+++ b/infrastructure/scheduling/scheduler/storage/task_store.py
@@ -8,7 +8,7 @@ import logging
 import os
 import tempfile
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -242,6 +242,48 @@ def add_task(task: ScheduledTask, store_path: Path | None = None) -> ScheduledTa
     return stored_task
 
 
+def replace_matching_tasks(
+    replacement: ScheduledTask | None,
+    *,
+    predicate: Callable[[ScheduledTask], bool],
+    store_path: Path | None = None,
+) -> tuple[ScheduledTask | None, int]:
+    """Atomically add ``replacement`` and disable enabled matching tasks.
+
+    If persisting the combined state fails, the previous store remains intact,
+    so an existing schedule is never disabled without its replacement.
+    """
+    path = store_path or default_task_store_path()
+    lock = FileLock(_lock_path(path))
+    with lock:
+        if replacement is None:
+            raw, readable = _read_raw(path)
+            if not readable:
+                return None, 0
+        else:
+            raw = _load_for_write(path)
+
+        disabled = 0
+        for entry in raw:
+            try:
+                task = ScheduledTask.model_validate(entry)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Skipping invalid task entry during replacement: %s", exc)
+                continue
+            if task.enabled and predicate(task):
+                entry["enabled"] = False
+                disabled += 1
+
+        if replacement is not None:
+            raw.append(replacement.model_dump(mode="json"))
+        if replacement is None and disabled == 0:
+            return None, 0
+        _save_raw(path, raw)
+
+    reload_signal.request_scheduler_reload()
+    return replacement, disabled
+
+
 def remove_task(task_id: str, store_path: Path | None = None) -> bool:
     """Remove a task by ID and cascade-delete its run records.
 
@@ -318,5 +360,6 @@ __all__ = [
     "list_tasks",
     "record_task_success",
     "remove_task",
+    "replace_matching_tasks",
     "update_task",
 ]

--- a/infrastructure/scheduling/scheduler/storage/task_store.py
+++ b/infrastructure/scheduling/scheduler/storage/task_store.py
@@ -243,27 +243,31 @@ def add_task(task: ScheduledTask, store_path: Path | None = None) -> ScheduledTa
 
 
 def replace_matching_tasks(
-    replacement: ScheduledTask | None,
+    replacement: ScheduledTask | None = None,
     *,
     predicate: Callable[[ScheduledTask], bool],
+    replacement_factory: Callable[[tuple[ScheduledTask, ...]], ScheduledTask | None] | None = None,
     store_path: Path | None = None,
 ) -> tuple[ScheduledTask | None, int]:
-    """Atomically add ``replacement`` and disable enabled matching tasks.
+    """Atomically disable enabled matches and optionally append a replacement.
 
-    If persisting the combined state fails, the previous store remains intact,
-    so an existing schedule is never disabled without its replacement.
+    ``replacement_factory`` runs under the store lock with the enabled matches,
+    allowing replacement configuration to inherit their state without a stale
+    read. If the combined write fails, the previous store remains intact.
     """
+    if replacement is not None and replacement_factory is not None:
+        raise ValueError("provide replacement or replacement_factory, not both")
     path = store_path or default_task_store_path()
     lock = FileLock(_lock_path(path))
     with lock:
-        if replacement is None:
+        if replacement is None and replacement_factory is None:
             raw, readable = _read_raw(path)
             if not readable:
                 return None, 0
         else:
             raw = _load_for_write(path)
 
-        disabled = 0
+        matches: list[tuple[dict[str, object], ScheduledTask]] = []
         for entry in raw:
             try:
                 task = ScheduledTask.model_validate(entry)
@@ -271,17 +275,25 @@ def replace_matching_tasks(
                 logger.warning("Skipping invalid task entry during replacement: %s", exc)
                 continue
             if task.enabled and predicate(task):
-                entry["enabled"] = False
-                disabled += 1
+                matches.append((entry, task))
 
-        if replacement is not None:
-            raw.append(replacement.model_dump(mode="json"))
-        if replacement is None and disabled == 0:
+        resolved_replacement = (
+            replacement_factory(tuple(task for _entry, task in matches))
+            if replacement_factory is not None
+            else replacement
+        )
+        for entry, _task in matches:
+            entry["enabled"] = False
+        disabled = len(matches)
+
+        if resolved_replacement is not None:
+            raw.append(resolved_replacement.model_dump(mode="json"))
+        if resolved_replacement is None and disabled == 0:
             return None, 0
         _save_raw(path, raw)
 
     reload_signal.request_scheduler_reload()
-    return replacement, disabled
+    return resolved_replacement, disabled
 
 
 def remove_task(task_id: str, store_path: Path | None = None) -> bool:

--- a/tests/core/domain/work_items/test_work_item_store.py
+++ b/tests/core/domain/work_items/test_work_item_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 from core.domain.work_items.models import WorkItemPriority, WorkItemStatus
@@ -66,3 +67,53 @@ def test_update_rejects_empty_title(tmp_path: Path) -> None:
     assert result.item is None
     listed = list_work_items(status=WorkItemStatus.OPEN, store_path=path)
     assert listed[0].title == "keep me"
+
+
+def test_failed_after_save_rolls_back_before_concurrent_update(tmp_path: Path) -> None:
+    path = _path(tmp_path)
+    item = add_work_item(title="keep me", store_path=path)
+    effect_started = threading.Event()
+    release_effect = threading.Event()
+    concurrent_started = threading.Event()
+    concurrent_finished = threading.Event()
+    failures: list[Exception] = []
+
+    def _fail_after_save(_updated: object) -> None:
+        effect_started.set()
+        assert release_effect.wait(timeout=2)
+        raise OSError("sync failed")
+
+    def _failing_update() -> None:
+        try:
+            update_work_item(
+                item.id,
+                changes={"owner": "temporary"},
+                store_path=path,
+                after_save=_fail_after_save,
+            )
+        except Exception as exc:
+            failures.append(exc)
+
+    def _concurrent_update() -> None:
+        concurrent_started.set()
+        update_work_item(item.id, changes={"notes": "newer"}, store_path=path)
+        concurrent_finished.set()
+
+    failing_thread = threading.Thread(target=_failing_update)
+    concurrent_thread = threading.Thread(target=_concurrent_update)
+    failing_thread.start()
+    assert effect_started.wait(timeout=2)
+    concurrent_thread.start()
+    assert concurrent_started.wait(timeout=2)
+    assert not concurrent_finished.wait(timeout=0.1)
+    release_effect.set()
+    failing_thread.join(timeout=2)
+    concurrent_thread.join(timeout=2)
+
+    assert not failing_thread.is_alive()
+    assert not concurrent_thread.is_alive()
+    assert len(failures) == 1
+    assert isinstance(failures[0], OSError)
+    stored = list_work_items(status=None, store_path=path)[0]
+    assert stored.owner == ""
+    assert stored.notes == "newer"

--- a/tests/scheduler/test_task_store.py
+++ b/tests/scheduler/test_task_store.py
@@ -15,6 +15,7 @@ from infrastructure.scheduling.scheduler.storage.task_store import (
     get_task,
     list_tasks,
     remove_task,
+    replace_matching_tasks,
     update_task,
 )
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
@@ -149,6 +150,44 @@ class TestStore:
             provider=Provider.TELEGRAM,
         )
         assert update_task(task, store_path) is False
+
+    def test_replacement_failure_keeps_previous_task_enabled(
+        self, store_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        previous = ScheduledTask(
+            kind=TaskKind.WORK_ITEM_REMINDER,
+            cron="0 9 12 9 *",
+            provider=Provider.SLACK,
+            chat_id="C1",
+            params={"work_item_id": "work-1"},
+        )
+        add_task(previous, store_path)
+        replacement = ScheduledTask(
+            kind=TaskKind.WORK_ITEM_REMINDER,
+            cron="0 14 12 9 *",
+            provider=Provider.SLACK,
+            chat_id="C2",
+            params={"work_item_id": "work-1"},
+        )
+
+        def _explode(_store_path: Path, _data: list[dict[str, object]]) -> None:
+            raise OSError("replacement write failed")
+
+        monkeypatch.setattr(
+            "infrastructure.scheduling.scheduler.storage.task_store._save_raw", _explode
+        )
+
+        with pytest.raises(OSError, match="replacement write failed"):
+            replace_matching_tasks(
+                replacement,
+                predicate=lambda task: task.params.get("work_item_id") == "work-1",
+                store_path=store_path,
+            )
+
+        stored = list_tasks(store_path)
+        assert len(stored) == 1
+        assert stored[0].id == previous.id
+        assert stored[0].enabled is True
 
     def test_multiple_tasks(self, store_path: Path) -> None:
         for i in range(3):

--- a/tests/scheduler/test_task_store.py
+++ b/tests/scheduler/test_task_store.py
@@ -189,6 +189,40 @@ class TestStore:
         assert stored[0].id == previous.id
         assert stored[0].enabled is True
 
+    def test_replacement_factory_inherits_state_under_store_lock(self, store_path: Path) -> None:
+        previous = ScheduledTask(
+            kind=TaskKind.WORK_ITEM_REMINDER,
+            cron="0 9 12 9 *",
+            timezone="America/New_York",
+            provider=Provider.SLACK,
+            chat_id="C1",
+            params={"work_item_id": "work-1"},
+        )
+        add_task(previous, store_path)
+
+        def _replacement(matches: tuple[ScheduledTask, ...]) -> ScheduledTask:
+            assert [task.id for task in matches] == [previous.id]
+            return ScheduledTask(
+                kind=TaskKind.WORK_ITEM_REMINDER,
+                cron="0 9 13 9 *",
+                timezone=matches[-1].timezone,
+                provider=Provider.SLACK,
+                chat_id="C2",
+                params={"work_item_id": "work-1"},
+            )
+
+        replacement, disabled = replace_matching_tasks(
+            predicate=lambda task: task.params.get("work_item_id") == "work-1",
+            replacement_factory=_replacement,
+            store_path=store_path,
+        )
+
+        assert replacement is not None
+        assert replacement.timezone == "America/New_York"
+        assert disabled == 1
+        stored = list_tasks(store_path)
+        assert [task.enabled for task in stored] == [False, True]
+
     def test_multiple_tasks(self, store_path: Path) -> None:
         for i in range(3):
             task = ScheduledTask(

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from core.domain.work_items import WorkItemChannelTarget, WorkItemPriority, make_work_item
+from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
 from infrastructure.scheduling.scheduler.types import Provider
 from tools.system.work_items._evidence import map_work_task_list, map_work_task_prioritize
 from tools.system.work_items.delivery import (
@@ -150,8 +152,6 @@ def test_reminder_scheduling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     scheduled = schedule_item_reminder(item, targets=targets, timezone="UTC")
     assert scheduled is not None
 
-    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
-
     tasks = list_tasks()
     assert len(tasks) == 1
     assert tasks[0].enabled is True
@@ -165,6 +165,98 @@ def test_reminder_scheduling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert len(tasks) == 2
     assert tasks[0].enabled is False
     assert tasks[1].enabled is True
+
+
+@pytest.fixture()
+def work_reminder_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    work_items_file = tmp_path / "work_items.json"
+    scheduler_file = tmp_path / "scheduler_tasks.json"
+    monkeypatch.setattr("tools.system.work_items.tool.work_items_path", lambda: work_items_file)
+    monkeypatch.setattr("tools.system.work_items.results.work_items_path", lambda: work_items_file)
+    monkeypatch.setattr(
+        "tools.system.work_items.reminders.work_items_path", lambda: work_items_file
+    )
+    monkeypatch.setattr("core.domain.work_items.store.work_items_path", lambda: work_items_file)
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.storage.task_store.default_task_store_path",
+        lambda: scheduler_file,
+    )
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.reload_signal.request_scheduler_reload",
+        lambda: None,
+    )
+    return scheduler_file
+
+
+def test_work_task_update_replaces_reminder_destination(
+    work_reminder_store: Path,
+) -> None:
+    created = work_task_add(
+        title="Rotate API key",
+        remind_at="2026-09-12T09:00:00Z",
+        channel_provider="slack",
+        channel_id="C1",
+    )
+
+    updated = work_task_update(
+        selector=created["task"]["id"],
+        channel_provider="slack",
+        channel_id="C2",
+    )
+
+    tasks = list_tasks(work_reminder_store)
+    active = [task for task in tasks if task.enabled]
+    assert updated["task"]["channel_targets"] == [{"provider": "slack", "chat_id": "C2"}]
+    assert len(tasks) == 2
+    assert len(active) == 1
+    assert json.loads(active[0].params["delivery_targets"]) == [
+        {"provider": "slack", "chat_id": "C2"}
+    ]
+
+
+def test_work_task_update_reschedules_existing_reminder(
+    work_reminder_store: Path,
+) -> None:
+    created = work_task_add(
+        title="Rotate API key",
+        remind_at="2026-09-12T09:00:00Z",
+        channel_provider="slack",
+        channel_id="C1",
+    )
+    original = list_tasks(work_reminder_store)[0]
+
+    updated = work_task_update(
+        selector=created["task"]["id"],
+        remind_at="2026-09-12T14:00:00Z",
+    )
+
+    tasks = list_tasks(work_reminder_store)
+    active = [task for task in tasks if task.enabled]
+    assert updated["task"]["remind_at"] == "2026-09-12T14:00:00Z"
+    assert len(tasks) == 2
+    assert len(active) == 1
+    assert active[0].id == updated["scheduled_task_id"]
+    assert active[0].cron != original.cron
+    assert next(task for task in tasks if task.id == original.id).enabled is False
+
+
+def test_work_task_update_clears_and_disables_reminder(
+    work_reminder_store: Path,
+) -> None:
+    created = work_task_add(
+        title="Rotate API key",
+        remind_at="2026-09-12T09:00:00Z",
+        channel_provider="slack",
+        channel_id="C1",
+    )
+
+    updated = work_task_update(selector=created["task"]["id"], remind_at="")
+
+    tasks = list_tasks(work_reminder_store)
+    assert updated["task"]["remind_at"] == ""
+    assert "scheduled_task_id" not in updated
+    assert len(tasks) == 1
+    assert tasks[0].enabled is False
 
 
 def test_work_task_tools_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -193,9 +193,10 @@ def test_work_task_update_replaces_reminder_destination(
 ) -> None:
     created = work_task_add(
         title="Rotate API key",
-        remind_at="2026-09-12T09:00:00Z",
+        remind_at="2026-09-12T09:00:00",
         channel_provider="slack",
         channel_id="C1",
+        timezone="America/New_York",
     )
 
     updated = work_task_update(
@@ -209,6 +210,7 @@ def test_work_task_update_replaces_reminder_destination(
     assert updated["task"]["channel_targets"] == [{"provider": "slack", "chat_id": "C2"}]
     assert len(tasks) == 2
     assert len(active) == 1
+    assert active[0].timezone == "America/New_York"
     assert json.loads(active[0].params["delivery_targets"]) == [
         {"provider": "slack", "chat_id": "C2"}
     ]
@@ -257,6 +259,41 @@ def test_work_task_update_clears_and_disables_reminder(
     assert "scheduled_task_id" not in updated
     assert len(tasks) == 1
     assert tasks[0].enabled is False
+
+
+def test_work_task_update_rolls_back_when_reminder_sync_fails(
+    work_reminder_store: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = work_task_add(
+        title="Rotate API key",
+        remind_at="2026-09-12T09:00:00Z",
+        channel_provider="slack",
+        channel_id="C1",
+    )
+
+    def _explode(_store_path: Path, _data: list[dict[str, object]]) -> None:
+        raise OSError("replacement write failed")
+
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.storage.task_store._save_raw", _explode
+    )
+
+    with pytest.raises(OSError, match="replacement write failed"):
+        work_task_update(
+            selector=created["task"]["id"],
+            channel_provider="slack",
+            channel_id="C2",
+        )
+
+    stored_item = work_task_list(status="all")["tasks"][0]
+    tasks = list_tasks(work_reminder_store)
+    assert stored_item["channel_targets"] == [{"provider": "slack", "chat_id": "C1"}]
+    assert len(tasks) == 1
+    assert tasks[0].enabled is True
+    assert json.loads(tasks[0].params["delivery_targets"]) == [
+        {"provider": "slack", "chat_id": "C1"}
+    ]
 
 
 def test_work_task_tools_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/system/work_items/reminders.py
+++ b/tools/system/work_items/reminders.py
@@ -11,25 +11,20 @@ from core.domain.work_items import (
     parse_work_item_datetime,
     work_items_path,
 )
-from infrastructure.scheduling.scheduler.storage import add_task as add_scheduled_task
-from infrastructure.scheduling.scheduler.storage import list_tasks, update_task
+from infrastructure.scheduling.scheduler.storage import replace_matching_tasks
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
 from tools.system.work_items.validation import validate_provider
 
 
 def disable_existing_item_reminders(item_id: str) -> int:
     """Disable enabled one-shot reminders for ``item_id`` so updates replace them."""
-    disabled = 0
-    for task in list_tasks():
-        if task.kind is not TaskKind.WORK_ITEM_REMINDER:
-            continue
-        if not task.enabled:
-            continue
-        if task.params.get("work_item_id", "").strip() != item_id:
-            continue
-        task.enabled = False
-        if update_task(task):
-            disabled += 1
+    _replacement, disabled = replace_matching_tasks(
+        None,
+        predicate=lambda task: (
+            task.kind is TaskKind.WORK_ITEM_REMINDER
+            and task.params.get("work_item_id", "").strip() == item_id
+        ),
+    )
     return disabled
 
 
@@ -48,8 +43,6 @@ def schedule_item_reminder(
     valid_targets = [target for target in targets if validate_provider(target.provider) is not None]
     if not valid_targets:
         return None
-    # Replace any prior reminder for this work item before scheduling a new one.
-    disable_existing_item_reminders(item.id)
     primary = valid_targets[0]
     parsed_provider = Provider(primary.provider)
     schedule_timezone = "UTC" if remind_at.tzinfo is not None else timezone
@@ -68,7 +61,14 @@ def schedule_item_reminder(
             ),
         },
     )
-    return add_scheduled_task(task)
+    stored, _disabled = replace_matching_tasks(
+        task,
+        predicate=lambda candidate: (
+            candidate.kind is TaskKind.WORK_ITEM_REMINDER
+            and candidate.params.get("work_item_id", "").strip() == item.id
+        ),
+    )
+    return stored
 
 
 _disable_existing_item_reminders = disable_existing_item_reminders

--- a/tools/system/work_items/reminders.py
+++ b/tools/system/work_items/reminders.py
@@ -11,7 +11,7 @@ from core.domain.work_items import (
     parse_work_item_datetime,
     work_items_path,
 )
-from infrastructure.scheduling.scheduler.storage import replace_matching_tasks
+from infrastructure.scheduling.scheduler.storage import list_tasks, replace_matching_tasks
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
 from tools.system.work_items.validation import validate_provider
 
@@ -26,6 +26,20 @@ def disable_existing_item_reminders(item_id: str) -> int:
         ),
     )
     return disabled
+
+
+def existing_item_reminder_timezone(item_id: str) -> str:
+    """Return the timezone of the latest enabled reminder for ``item_id``."""
+    return next(
+        (
+            task.timezone
+            for task in reversed(list_tasks())
+            if task.enabled
+            and task.kind is TaskKind.WORK_ITEM_REMINDER
+            and task.params.get("work_item_id", "").strip() == item_id
+        ),
+        "",
+    )
 
 
 def schedule_item_reminder(
@@ -78,5 +92,6 @@ __all__ = [
     "_disable_existing_item_reminders",
     "_schedule_item_reminder",
     "disable_existing_item_reminders",
+    "existing_item_reminder_timezone",
     "schedule_item_reminder",
 ]

--- a/tools/system/work_items/reminders.py
+++ b/tools/system/work_items/reminders.py
@@ -11,7 +11,7 @@ from core.domain.work_items import (
     parse_work_item_datetime,
     work_items_path,
 )
-from infrastructure.scheduling.scheduler.storage import list_tasks, replace_matching_tasks
+from infrastructure.scheduling.scheduler.storage import replace_matching_tasks
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
 from tools.system.work_items.validation import validate_provider
 
@@ -26,20 +26,6 @@ def disable_existing_item_reminders(item_id: str) -> int:
         ),
     )
     return disabled
-
-
-def existing_item_reminder_timezone(item_id: str) -> str:
-    """Return the timezone of the latest enabled reminder for ``item_id``."""
-    return next(
-        (
-            task.timezone
-            for task in reversed(list_tasks())
-            if task.enabled
-            and task.kind is TaskKind.WORK_ITEM_REMINDER
-            and task.params.get("work_item_id", "").strip() == item_id
-        ),
-        "",
-    )
 
 
 def schedule_item_reminder(
@@ -58,29 +44,34 @@ def schedule_item_reminder(
     if not valid_targets:
         return None
     primary = valid_targets[0]
-    parsed_provider = Provider(primary.provider)
-    schedule_timezone = "UTC" if remind_at.tzinfo is not None else timezone
-    task = ScheduledTask(
-        kind=TaskKind.WORK_ITEM_REMINDER,
-        cron=cron_from_datetime(remind_at),
-        timezone=schedule_timezone,
-        provider=parsed_provider,
-        chat_id=primary.chat_id,
-        params={
-            "work_item_id": item.id,
-            "store_path": str(work_items_path()),
-            "disable_after_success": "true",
-            "delivery_targets": json.dumps(
-                [target.to_dict() for target in valid_targets], separators=(",", ":")
-            ),
-        },
-    )
+
+    def _build_replacement(matches: tuple[ScheduledTask, ...]) -> ScheduledTask:
+        inherited_timezone = matches[-1].timezone if matches else "UTC"
+        schedule_timezone = (
+            "UTC" if remind_at.tzinfo is not None else timezone.strip() or inherited_timezone
+        )
+        return ScheduledTask(
+            kind=TaskKind.WORK_ITEM_REMINDER,
+            cron=cron_from_datetime(remind_at),
+            timezone=schedule_timezone,
+            provider=Provider(primary.provider),
+            chat_id=primary.chat_id,
+            params={
+                "work_item_id": item.id,
+                "store_path": str(work_items_path()),
+                "disable_after_success": "true",
+                "delivery_targets": json.dumps(
+                    [target.to_dict() for target in valid_targets], separators=(",", ":")
+                ),
+            },
+        )
+
     stored, _disabled = replace_matching_tasks(
-        task,
         predicate=lambda candidate: (
             candidate.kind is TaskKind.WORK_ITEM_REMINDER
             and candidate.params.get("work_item_id", "").strip() == item.id
         ),
+        replacement_factory=_build_replacement,
     )
     return stored
 
@@ -92,6 +83,5 @@ __all__ = [
     "_disable_existing_item_reminders",
     "_schedule_item_reminder",
     "disable_existing_item_reminders",
-    "existing_item_reminder_timezone",
     "schedule_item_reminder",
 ]

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.domain.work_items import (
     WORK_ITEM_PRIORITIES,
     WORK_ITEM_STATUSES,
+    WorkItem,
     WorkItemChannelTarget,
     WorkItemPriority,
     WorkItemUpdates,
@@ -29,6 +31,7 @@ from tools.system.work_items._evidence import map_work_task_list, map_work_task_
 from tools.system.work_items.delivery import delivery_targets, invalid_delivery_targets
 from tools.system.work_items.reminders import (
     disable_existing_item_reminders,
+    existing_item_reminder_timezone,
     schedule_item_reminder,
 )
 from tools.system.work_items.results import (
@@ -51,6 +54,8 @@ from tools.system.work_items.validation import (
     valid_status_detail,
     validate_datetime_arg,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _work_items_available(_sources: dict[str, dict[str, Any]]) -> bool:
@@ -324,7 +329,13 @@ def work_task_complete(selectors: list[str]) -> dict[str, Any]:
                     "additionalProperties": False,
                 },
             },
-            "timezone": {"type": "string", "default": "UTC"},
+            "timezone": {
+                "type": "string",
+                "description": (
+                    "IANA timezone for naive remind_at values. Omit to preserve an existing "
+                    "reminder timezone, or use UTC when adding a reminder."
+                ),
+            },
         },
         "required": ["selector"],
         "additionalProperties": False,
@@ -342,7 +353,7 @@ def work_task_update(
     channel_provider: str = "",
     channel_id: str = "",
     channel_targets: list[dict[str, str]] | None = None,
-    timezone: str = "UTC",
+    timezone: str = "",
     context: AgentToolContext | None = None,
 ) -> dict[str, Any]:
     changes: WorkItemUpdates = {}
@@ -388,23 +399,28 @@ def work_task_update(
             explicit_targets[0].to_dict() if explicit_targets else WorkItemChannelTarget().to_dict()
         )
     reminder_targets: list[WorkItemChannelTarget] = []
+    reminder_timezone = timezone.strip()
     reminder_update_requested = remind_at is not None or target_update_requested
+    existing_item: WorkItem | None = None
     if reminder_update_requested:
         existing = resolve_work_item_selector(selector)
-        if existing.item is None:
+        existing_item = existing.item
+        if existing_item is None:
             payload: dict[str, Any] = {"error": existing.error or "not_found"}
             if existing.candidates:
                 payload["candidates"] = [item_summary(item) for item in existing.candidates]
             return payload
-        effective_remind_at = remind_at if remind_at is not None else existing.item.remind_at
+        effective_remind_at = remind_at if remind_at is not None else existing_item.remind_at
         if effective_remind_at:
+            if not reminder_timezone:
+                reminder_timezone = existing_item_reminder_timezone(existing_item.id) or "UTC"
             reminder_targets = (
                 explicit_targets
                 if target_update_requested
                 else delivery_targets(
                     provider="",
                     chat_id="",
-                    item=existing.item,
+                    item=existing_item,
                     context=context,
                 )
             )
@@ -413,13 +429,13 @@ def work_task_update(
                 return {
                     "error": "invalid_delivery_target",
                     "detail": "; ".join(invalid_reminder_targets),
-                    "task": item_summary(existing.item),
+                    "task": item_summary(existing_item),
                 }
             if not reminder_targets:
                 return {
                     "error": "missing_delivery_target",
                     "detail": "remind_at needs at least one provider target",
-                    "task": item_summary(existing.item),
+                    "task": item_summary(existing_item),
                 }
     result = update_work_item(selector, changes=changes)
     if result.item is None:
@@ -429,18 +445,57 @@ def work_task_update(
         return update_error_payload
     scheduled = None
     if reminder_update_requested:
-        if result.item.remind_at:
-            scheduled = schedule_item_reminder(
-                result.item,
-                targets=reminder_targets,
-                timezone=timezone or "UTC",
+        if existing_item is None:
+            raise RuntimeError("resolved work item disappeared before reminder synchronization")
+        try:
+            if result.item.remind_at:
+                scheduled = schedule_item_reminder(
+                    result.item,
+                    targets=reminder_targets,
+                    timezone=reminder_timezone or "UTC",
+                )
+            else:
+                disable_existing_item_reminders(result.item.id)
+        except Exception:
+            rollback = update_work_item(
+                result.item.id,
+                changes=_rollback_changes(existing_item, changes),
             )
-        else:
-            disable_existing_item_reminders(result.item.id)
+            if rollback.item is None:
+                logger.critical(
+                    "Could not roll back work item %s after reminder synchronization failed: %s",
+                    result.item.id,
+                    rollback.error or "unknown error",
+                )
+            raise
     result_payload = update_result(result.item)
     if scheduled is not None:
         result_payload["scheduled_task_id"] = scheduled.id
     return result_payload
+
+
+def _rollback_changes(item: WorkItem, changes: WorkItemUpdates) -> WorkItemUpdates:
+    """Restore fields changed before a failed scheduler synchronization."""
+    rollback: WorkItemUpdates = {}
+    if "status" in changes:
+        rollback["status"] = item.status
+    if "priority" in changes:
+        rollback["priority"] = item.priority
+    if "owner" in changes:
+        rollback["owner"] = item.owner
+    if "project" in changes:
+        rollback["project"] = item.project
+    if "due_at" in changes:
+        rollback["due_at"] = item.due_at
+    if "remind_at" in changes:
+        rollback["remind_at"] = item.remind_at
+    if "notes" in changes:
+        rollback["notes"] = item.notes
+    if "channel_targets" in changes:
+        rollback["channel_targets"] = item.channel_targets
+    if "channel" in changes:
+        rollback["channel"] = item.channel
+    return rollback
 
 
 @tool(

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -27,7 +27,10 @@ from infrastructure.scheduling.scheduler.storage import add_task as add_schedule
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
 from tools.system.work_items._evidence import map_work_task_list, map_work_task_prioritize
 from tools.system.work_items.delivery import delivery_targets, invalid_delivery_targets
-from tools.system.work_items.reminders import schedule_item_reminder
+from tools.system.work_items.reminders import (
+    disable_existing_item_reminders,
+    schedule_item_reminder,
+)
 from tools.system.work_items.results import (
     added_result,
     complete_result,
@@ -299,7 +302,13 @@ def work_task_complete(selectors: list[str]) -> dict[str, Any]:
             "owner": {"type": "string"},
             "project": {"type": "string"},
             "due_at": {"type": "string"},
-            "remind_at": {"type": "string"},
+            "remind_at": {
+                "type": "string",
+                "description": (
+                    "Optional ISO-like reminder datetime; pass an empty string to clear and "
+                    "disable the reminder."
+                ),
+            },
             "notes": {"type": "string"},
             "channel_provider": {"type": "string"},
             "channel_id": {"type": "string"},
@@ -328,7 +337,7 @@ def work_task_update(
     owner: str = "",
     project: str = "",
     due_at: str = "",
-    remind_at: str = "",
+    remind_at: str | None = None,
     notes: str = "",
     channel_provider: str = "",
     channel_id: str = "",
@@ -353,14 +362,18 @@ def work_task_update(
         changes["project"] = project
     if due_at:
         changes["due_at"] = due_at
-    if remind_at:
+    if remind_at is not None:
         changes["remind_at"] = remind_at
     if notes:
         changes["notes"] = notes
-    for field_name, value in (("due_at", due_at), ("remind_at", remind_at)):
+    datetime_updates = [("due_at", due_at)]
+    if remind_at is not None:
+        datetime_updates.append(("remind_at", remind_at))
+    for field_name, value in datetime_updates:
         error = validate_datetime_arg(value, field=field_name)
         if error is not None:
             return error
+    target_update_requested = channel_targets is not None or bool(channel_provider.strip())
     explicit_targets = delivery_targets(
         provider=channel_provider,
         chat_id=channel_id,
@@ -369,39 +382,45 @@ def work_task_update(
     invalid_targets = invalid_delivery_targets(explicit_targets)
     if invalid_targets:
         return {"error": "invalid_delivery_target", "detail": "; ".join(invalid_targets)}
-    if explicit_targets:
+    if target_update_requested:
         changes["channel_targets"] = explicit_targets
         changes["channel"] = (
             explicit_targets[0].to_dict() if explicit_targets else WorkItemChannelTarget().to_dict()
         )
     reminder_targets: list[WorkItemChannelTarget] = []
-    if remind_at:
+    reminder_update_requested = remind_at is not None or target_update_requested
+    if reminder_update_requested:
         existing = resolve_work_item_selector(selector)
         if existing.item is None:
             payload: dict[str, Any] = {"error": existing.error or "not_found"}
             if existing.candidates:
                 payload["candidates"] = [item_summary(item) for item in existing.candidates]
             return payload
-        reminder_targets = delivery_targets(
-            provider=channel_provider,
-            chat_id=channel_id,
-            item=existing.item,
-            channel_targets=channel_targets,
-            context=context,
-        )
-        invalid_reminder_targets = invalid_delivery_targets(reminder_targets)
-        if invalid_reminder_targets:
-            return {
-                "error": "invalid_delivery_target",
-                "detail": "; ".join(invalid_reminder_targets),
-                "task": item_summary(existing.item),
-            }
-        if not reminder_targets:
-            return {
-                "error": "missing_delivery_target",
-                "detail": "remind_at needs at least one provider target",
-                "task": item_summary(existing.item),
-            }
+        effective_remind_at = remind_at if remind_at is not None else existing.item.remind_at
+        if effective_remind_at:
+            reminder_targets = (
+                explicit_targets
+                if target_update_requested
+                else delivery_targets(
+                    provider="",
+                    chat_id="",
+                    item=existing.item,
+                    context=context,
+                )
+            )
+            invalid_reminder_targets = invalid_delivery_targets(reminder_targets)
+            if invalid_reminder_targets:
+                return {
+                    "error": "invalid_delivery_target",
+                    "detail": "; ".join(invalid_reminder_targets),
+                    "task": item_summary(existing.item),
+                }
+            if not reminder_targets:
+                return {
+                    "error": "missing_delivery_target",
+                    "detail": "remind_at needs at least one provider target",
+                    "task": item_summary(existing.item),
+                }
     result = update_work_item(selector, changes=changes)
     if result.item is None:
         update_error_payload: dict[str, Any] = {"error": result.error or "not_found"}
@@ -409,12 +428,15 @@ def work_task_update(
             update_error_payload["candidates"] = [item_summary(item) for item in result.candidates]
         return update_error_payload
     scheduled = None
-    if remind_at:
-        scheduled = schedule_item_reminder(
-            result.item,
-            targets=reminder_targets,
-            timezone=timezone or "UTC",
-        )
+    if reminder_update_requested:
+        if result.item.remind_at:
+            scheduled = schedule_item_reminder(
+                result.item,
+                targets=reminder_targets,
+                timezone=timezone or "UTC",
+            )
+        else:
+            disable_existing_item_reminders(result.item.id)
     result_payload = update_result(result.item)
     if scheduled is not None:
         result_payload["scheduled_task_id"] = scheduled.id

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
@@ -19,7 +18,6 @@ from core.domain.work_items import (
     list_work_items,
     make_work_item,
     prioritize_work_items,
-    resolve_work_item_selector,
     update_work_item,
     work_items_path,
 )
@@ -31,7 +29,6 @@ from tools.system.work_items._evidence import map_work_task_list, map_work_task_
 from tools.system.work_items.delivery import delivery_targets, invalid_delivery_targets
 from tools.system.work_items.reminders import (
     disable_existing_item_reminders,
-    existing_item_reminder_timezone,
     schedule_item_reminder,
 )
 from tools.system.work_items.results import (
@@ -54,8 +51,6 @@ from tools.system.work_items.validation import (
     valid_status_detail,
     validate_datetime_arg,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _work_items_available(_sources: dict[str, dict[str, Any]]) -> bool:
@@ -398,104 +393,60 @@ def work_task_update(
         changes["channel"] = (
             explicit_targets[0].to_dict() if explicit_targets else WorkItemChannelTarget().to_dict()
         )
-    reminder_targets: list[WorkItemChannelTarget] = []
-    reminder_timezone = timezone.strip()
     reminder_update_requested = remind_at is not None or target_update_requested
-    existing_item: WorkItem | None = None
-    if reminder_update_requested:
-        existing = resolve_work_item_selector(selector)
-        existing_item = existing.item
-        if existing_item is None:
-            payload: dict[str, Any] = {"error": existing.error or "not_found"}
-            if existing.candidates:
-                payload["candidates"] = [item_summary(item) for item in existing.candidates]
-            return payload
-        effective_remind_at = remind_at if remind_at is not None else existing_item.remind_at
-        if effective_remind_at:
-            if not reminder_timezone:
-                reminder_timezone = existing_item_reminder_timezone(existing_item.id) or "UTC"
-            reminder_targets = (
-                explicit_targets
-                if target_update_requested
-                else delivery_targets(
-                    provider="",
-                    chat_id="",
-                    item=existing_item,
-                    context=context,
-                )
-            )
+    scheduled: ScheduledTask | None = None
+
+    def _synchronize_reminder(item: WorkItem) -> None:
+        nonlocal scheduled
+        reminder_targets = (
+            list(item.channel_targets)
+            if target_update_requested
+            else delivery_targets(provider="", chat_id="", item=item, context=context)
+        )
+        if item.remind_at:
             invalid_reminder_targets = invalid_delivery_targets(reminder_targets)
             if invalid_reminder_targets:
-                return {
-                    "error": "invalid_delivery_target",
-                    "detail": "; ".join(invalid_reminder_targets),
-                    "task": item_summary(existing_item),
-                }
+                raise _ReminderSyncValidationError(
+                    "invalid_delivery_target", "; ".join(invalid_reminder_targets)
+                )
             if not reminder_targets:
-                return {
-                    "error": "missing_delivery_target",
-                    "detail": "remind_at needs at least one provider target",
-                    "task": item_summary(existing_item),
-                }
-    result = update_work_item(selector, changes=changes)
+                raise _ReminderSyncValidationError(
+                    "missing_delivery_target", "remind_at needs at least one provider target"
+                )
+            scheduled = schedule_item_reminder(
+                item,
+                targets=reminder_targets,
+                timezone=timezone,
+            )
+        else:
+            disable_existing_item_reminders(item.id)
+
+    try:
+        result = update_work_item(
+            selector,
+            changes=changes,
+            after_save=_synchronize_reminder if reminder_update_requested else None,
+        )
+    except _ReminderSyncValidationError as exc:
+        return {"error": exc.error, "detail": exc.detail}
     if result.item is None:
         update_error_payload: dict[str, Any] = {"error": result.error or "not_found"}
         if result.candidates:
             update_error_payload["candidates"] = [item_summary(item) for item in result.candidates]
         return update_error_payload
-    scheduled = None
-    if reminder_update_requested:
-        if existing_item is None:
-            raise RuntimeError("resolved work item disappeared before reminder synchronization")
-        try:
-            if result.item.remind_at:
-                scheduled = schedule_item_reminder(
-                    result.item,
-                    targets=reminder_targets,
-                    timezone=reminder_timezone or "UTC",
-                )
-            else:
-                disable_existing_item_reminders(result.item.id)
-        except Exception:
-            rollback = update_work_item(
-                result.item.id,
-                changes=_rollback_changes(existing_item, changes),
-            )
-            if rollback.item is None:
-                logger.critical(
-                    "Could not roll back work item %s after reminder synchronization failed: %s",
-                    result.item.id,
-                    rollback.error or "unknown error",
-                )
-            raise
     result_payload = update_result(result.item)
     if scheduled is not None:
         result_payload["scheduled_task_id"] = scheduled.id
     return result_payload
 
 
-def _rollback_changes(item: WorkItem, changes: WorkItemUpdates) -> WorkItemUpdates:
-    """Restore fields changed before a failed scheduler synchronization."""
-    rollback: WorkItemUpdates = {}
-    if "status" in changes:
-        rollback["status"] = item.status
-    if "priority" in changes:
-        rollback["priority"] = item.priority
-    if "owner" in changes:
-        rollback["owner"] = item.owner
-    if "project" in changes:
-        rollback["project"] = item.project
-    if "due_at" in changes:
-        rollback["due_at"] = item.due_at
-    if "remind_at" in changes:
-        rollback["remind_at"] = item.remind_at
-    if "notes" in changes:
-        rollback["notes"] = item.notes
-    if "channel_targets" in changes:
-        rollback["channel_targets"] = item.channel_targets
-    if "channel" in changes:
-        rollback["channel"] = item.channel
-    return rollback
+class _ReminderSyncValidationError(ValueError):
+    """Carry a user-facing validation error through transactional rollback."""
+
+    def __init__(self, error: str, detail: str) -> None:
+        super().__init__(detail)
+        self.error = error
+        self.detail = detail
 
 
 @tool(


### PR DESCRIPTION
Fixes #6199

#### Describe the changes you have made in this PR -

- make scheduler reminder replacement atomic under the task-store lock, so a failed write cannot disable the previous reminder first
- reschedule an existing reminder when a work item's delivery destination changes
- preserve the existing scheduler timezone under the scheduler-store lock when a naive reminder is rescheduled without an explicit timezone
- support clearing `remind_at` with an empty string and disable the associated scheduler task
- hold the work-item lock through scheduler synchronization and restore the prior item before releasing it if synchronization fails
- add regression coverage for destination changes, reminder clearing, and replacement-write failure

### Demo/Screenshot for feature changes and bug fixes -

Before: changing an item's reminder destination from `C1` to `C2` left the scheduler task targeting `C1`, and clearing `remind_at` left the task enabled.

After: destination-only updates atomically replace the enabled scheduler task with one targeting `C2` while preserving naive-time timezone semantics under the same scheduler lock; clearing `remind_at` disables the matching task. A simulated replacement write failure preserves the previous enabled task and restores the work item to its prior destination before another work-item writer can proceed.

Validation:

- `uv run --frozen --project /Users/user/Documents/opensre make lint`
- `uv run --frozen --project /Users/user/Documents/opensre make format-check`
- `uv run --frozen --project /Users/user/Documents/opensre make typecheck` (1,857 files)
- focused work-item, task-store, and core-domain tests: 70 passed
- mapped tools, scheduler, and core-domain suites: 4,232 passed, 38 skipped; four live LLM-selection tests could not authenticate with the local Anthropic credential

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The stale-task bug had two causes: the update path only scheduled reminders when `remind_at` was truthy, and replacement disabled the old task before persisting the new one. The update tool now distinguishes an omitted reminder from an explicitly empty value, treats destination changes as reminder configuration changes when a reminder already exists, and synchronizes using the item produced inside the locked update transaction. The scheduler store exposes one locked replacement operation that disables matches and appends the replacement in a single atomic write; its replacement factory inherits a naive reminder's timezone while that same lock is held. The work-item store retains its lock through scheduler synchronization and rolls the item back before releasing the lock if synchronization fails, preventing a concurrent update from being overwritten by compensation. The same scheduler operation also supports cancellation without a replacement.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
