### PR TITLE
fix(remote-sync): isolate organization members

### DIFF
--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -55,7 +55,7 @@ A bucket name alone does nothing — you must also set `OPENSRE_REMOTE_SYNC=1` (
 | `OPENSRE_REMOTE_SYNC` | `1` / `true` turns sync on |
 | `OPENSRE_REMOTE_SYNC_PROVIDER` | `aws` (default), `gcs`, `vercel`, `azure`, or `s3compat` |
 | `OPENSRE_REMOTE_SYNC_BUCKET` | Bucket, container, or Blob store name (required when on) |
-| `OPENSRE_REMOTE_SYNC_PREFIX` | Key prefix (default `opensre`). Same prefix = shared history |
+| `OPENSRE_REMOTE_SYNC_PREFIX` | Key prefix (default `opensre`). Same prefix shares personal history; organization members remain isolated |
 | `OPENSRE_REMOTE_SYNC_REGION` | AWS region (AWS only) |
 | `OPENSRE_REMOTE_SYNC_PROFILE` | AWS profile name, or Azure storage account name when `provider=azure` |
 | `OPENSRE_REMOTE_SYNC_ENDPOINT_URL` | Custom S3 endpoint when `provider=s3compat` (MinIO / R2 / Spaces) |
@@ -89,7 +89,9 @@ session remains manual-only. If the automatic sync fails, OpenSRE prints a
 warning without changing the shell's exit status.
 
 <Warning>
-Remote sync is for a **personal machine**. Org-bound Slack/Discord turns are refused — those already persist under the org context root.
+Unbound local turns use the configured prefix directly. Organization-bound gateway turns
+use a separate `orgs/&lt;organization&gt;/users/&lt;member&gt;/` namespace beneath it, so members
+using the same store and configured prefix cannot read one another's history.
 </Warning>
 
 ## Providers

--- a/infrastructure/filestorage/engine.py
+++ b/infrastructure/filestorage/engine.py
@@ -36,6 +36,7 @@ from infrastructure.filestorage.contracts import ObjectStore, RemoteObject
 from infrastructure.filestorage.enums import SyncDirection
 from infrastructure.filestorage.errors import RemoteSyncConfigError, UnsyncablePathError
 from infrastructure.filestorage.exclusions import NO_EXCLUSIONS, ExclusionRules
+from infrastructure.filestorage.key_namespace import resolved_key_prefix
 from infrastructure.filestorage.syncable import SyncRoot, resolved_roots, syncable_roots
 
 logger = logging.getLogger(__name__)
@@ -193,6 +194,7 @@ def push(
     dry_run: bool = False,
     on_progress: ProgressCallback | None = None,
     max_parallel_uploads: int = DEFAULT_MAX_PARALLEL_UPLOADS,
+    object_key_prefix: str | None = None,
 ) -> SyncReport:
     """Upload local files whose contents differ from the bucket.
 
@@ -218,10 +220,15 @@ def push(
     local file at all (nothing pulled it before) never reaches the scan below,
     so it is counted as skipped separately — a real sync would have written it
     and then found this same scan matching it.
+
+    ``object_key_prefix`` is an optional namespace for unbound low-level
+    callers. A bound organization scope always uses its organization/member
+    namespace, even when an empty override is supplied.
     """
     roots = roots if roots is not None else syncable_roots()
     result = report if report is not None else SyncReport()
-    listing = remote if remote is not None else store.list_objects("")
+    key_prefix = resolved_key_prefix(object_key_prefix)
+    listing = remote if remote is not None else store.list_objects(key_prefix)
     by_key = {obj.key: obj for obj in listing}
     # Resolve each root once rather than per file: this loop touches every
     # session and memory file on the machine.
@@ -240,11 +247,11 @@ def push(
             if not allowed.contains(path):
                 # Reaching here means a root pointed somewhere it should not.
                 raise UnsyncablePathError(f"refusing to upload {path}")
-            key = relative_key(root, path)
-            if exclusions.excludes(key):
-                result.excluded.add(key)
+            logical_key = relative_key(root, path)
+            if exclusions.excludes(logical_key):
+                result.excluded.add(logical_key)
                 continue
-            planned.append((key, path))
+            planned.append((f"{key_prefix}{logical_key}", path))
 
     total = len(planned)
 
@@ -319,17 +326,20 @@ def pull(
     exclusions: ExclusionRules = NO_EXCLUSIONS,
     dry_run: bool = False,
     on_progress: ProgressCallback | None = None,
+    object_key_prefix: str | None = None,
 ) -> SyncReport:
     """Download bucket objects missing locally, or newer than the local copy.
 
     Under ``dry_run`` nothing is fetched or written: the listing already has
     the size needed to report what would move, so previewing costs no request
-    beyond the one listing call.
+    beyond the one listing call. ``object_key_prefix`` follows :func:`push`'s
+    bound-organization safety rule.
     """
     roots = roots if roots is not None else syncable_roots()
     result = report if report is not None else SyncReport()
     by_name = {root.name: root for root in roots}
-    listing = remote if remote is not None else store.list_objects("")
+    key_prefix = resolved_key_prefix(object_key_prefix)
+    listing = remote if remote is not None else store.list_objects(key_prefix)
     total = len(listing)
 
     def _report(key: str, completed: int) -> None:
@@ -337,15 +347,19 @@ def pull(
             on_progress(SyncProgress(SyncDirection.PULL, key, completed, total))
 
     for completed, obj in enumerate(listing, start=1):
-        target = _local_path_for(obj, by_name)
+        if key_prefix and not obj.key.startswith(key_prefix):
+            _report(obj.key, completed)
+            continue
+        logical_key = obj.key[len(key_prefix) :]
+        target = _local_path_for(logical_key, by_name)
         if target is None:
             _report(obj.key, completed)
             continue
         # Excluding a path means it does not belong on this machine, so the
         # pattern holds in both directions: a file another machine still
         # uploads is not pulled back down here.
-        if exclusions.excludes(obj.key):
-            result.excluded.add(obj.key)
+        if exclusions.excludes(logical_key):
+            result.excluded.add(logical_key)
             _report(obj.key, completed)
             continue
         if not _should_download(obj, target):
@@ -365,12 +379,12 @@ def pull(
     return result
 
 
-def _local_path_for(obj: RemoteObject, by_name: dict[str, SyncRoot]) -> Path | None:
+def _local_path_for(key: str, by_name: dict[str, SyncRoot]) -> Path | None:
     """Local file for one object key, or None when the key is not ours."""
-    head, _, tail = obj.key.partition("/")
+    head, _, tail = key.partition("/")
     root = by_name.get(head)
     if root is None or not tail:
-        logger.debug("[remote-sync] ignoring unrecognised key %s", obj.key)
+        logger.debug("[remote-sync] ignoring unrecognised key %s", key)
         return None
     # A key may not climb out of its root.
     candidate = (root.path / tail).resolve()
@@ -399,6 +413,7 @@ def run_sync(
     dry_run: bool = False,
     on_progress: ProgressCallback | None = None,
     max_parallel_uploads: int = DEFAULT_MAX_PARALLEL_UPLOADS,
+    object_key_prefix: str | None = None,
 ) -> SyncReport:
     """Move files in ``direction``. Both ways pulls first, so an offline edit wins.
 
@@ -409,10 +424,12 @@ def run_sync(
     for the push pass — see :data:`ProgressCallback`. ``max_parallel_uploads``
     caps concurrent uploads in the push pass; callers that built the store from
     a config should pass the provider's own declared limit rather than rely on
-    the conservative default.
+    the conservative default. ``object_key_prefix`` follows :func:`push`'s
+    bound-organization safety rule.
     """
     report = SyncReport()
-    listing = store.list_objects("")
+    key_prefix = resolved_key_prefix(object_key_prefix)
+    listing = store.list_objects(key_prefix)
     if direction is not SyncDirection.PUSH:
         pull(
             store,
@@ -422,6 +439,7 @@ def run_sync(
             exclusions=exclusions,
             dry_run=dry_run,
             on_progress=on_progress,
+            object_key_prefix=key_prefix,
         )
     if direction is not SyncDirection.PULL:
         push(
@@ -433,6 +451,7 @@ def run_sync(
             dry_run=dry_run,
             on_progress=on_progress,
             max_parallel_uploads=max_parallel_uploads,
+            object_key_prefix=key_prefix,
         )
     return report
 

--- a/infrastructure/filestorage/key_namespace.py
+++ b/infrastructure/filestorage/key_namespace.py
@@ -1,0 +1,44 @@
+"""Object-key namespaces for remote-sync storage scopes."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from config.constants.paths import ORGS_DIR_NAME, USERS_DIR_NAME
+from config.principal import PrincipalKind, StorageScope
+from config.scope_context import current_scope
+
+
+def _encoded_segment(value: str) -> str:
+    """Encode one opaque identity without allowing key-path delimiters."""
+    return quote(value, safe="").replace(".", "%2E")
+
+
+def normalized_key_prefix(prefix: str) -> str:
+    """Return an empty prefix or one ending in exactly one slash."""
+    stripped = prefix.strip("/")
+    return f"{stripped}/" if stripped else ""
+
+
+def scope_key_prefix(scope: StorageScope | None) -> str:
+    """Return the isolated object-key prefix for an organization member."""
+    if scope is None or scope.principal.kind is not PrincipalKind.ORG:
+        return ""
+    organization = _encoded_segment(scope.principal.id)
+    member = _encoded_segment(scope.actor.id)
+    return f"{ORGS_DIR_NAME}/{organization}/{USERS_DIR_NAME}/{member}/"
+
+
+def resolved_key_prefix(explicit: str | None) -> str:
+    """Resolve a key prefix without allowing an organization scope to flatten."""
+    scoped = scope_key_prefix(current_scope())
+    if scoped:
+        return scoped
+    return normalized_key_prefix(explicit or "")
+
+
+__all__ = [
+    "normalized_key_prefix",
+    "resolved_key_prefix",
+    "scope_key_prefix",
+]

--- a/infrastructure/filestorage/operations.py
+++ b/infrastructure/filestorage/operations.py
@@ -32,9 +32,9 @@ from infrastructure.filestorage.engine import (
     run_sync,
 )
 from infrastructure.filestorage.enums import SyncDirection, SyncRootName
-from infrastructure.filestorage.errors import OrgScopeNotSupportedError
 from infrastructure.filestorage.exclusions import NO_EXCLUSIONS, ExclusionRules
 from infrastructure.filestorage.exposure import PublicAccessStatus
+from infrastructure.filestorage.key_namespace import scope_key_prefix
 from infrastructure.filestorage.providers import (
     build_object_store,
     check_bucket_exposure,
@@ -95,21 +95,6 @@ def _owned_report(report: SyncReport) -> SyncReport:
     )
 
 
-def _refuse_org_scoped_turn() -> None:
-    """Fail closed when the caller is an organization member, not a laptop user.
-
-    Object keys carry no principal or actor, so every member of an organization
-    would write and read the same keys.
-    """
-    scope = current_scope()
-    if scope is not None and scope.principal.kind == "org":
-        raise OrgScopeNotSupportedError(
-            "Remote sync mirrors a personal machine. This conversation belongs to "
-            "an organization, whose history already persists in the shared context "
-            "root, so nothing is mirrored."
-        )
-
-
 def _root_status(root: SyncRoot, exclusions: ExclusionRules) -> SyncRootStatus:
     """Describe one root, counting held-back files only when asked to.
 
@@ -136,7 +121,6 @@ def get_sync_status() -> SyncStatus:
     is on, and only if the provider registered a checker; see
     :func:`~infrastructure.filestorage.providers.check_bucket_exposure`.
     """
-    _refuse_org_scoped_turn()
     config = load_remote_sync_config()
     exclusions = config.exclude if config is not None else NO_EXCLUSIONS
     roots = tuple(_root_status(root, exclusions) for root in syncable_roots())
@@ -162,7 +146,6 @@ def run_remote_sync(
     single place CLI and slash both get live progress from, so neither
     re-derives it. See :class:`infrastructure.filestorage.engine.SyncProgress`.
     """
-    _refuse_org_scoped_turn()
     resolved = (
         direction
         if direction is not None
@@ -183,6 +166,7 @@ def run_remote_sync(
             on_progress=on_progress,
             # The backend, not the engine, knows how hard it can be pushed.
             max_parallel_uploads=max_parallel_uploads_for_provider(config.provider),
+            object_key_prefix=scope_key_prefix(current_scope()),
         )
     )
 

--- a/infrastructure/filestorage/providers/vercel.py
+++ b/infrastructure/filestorage/providers/vercel.py
@@ -6,7 +6,7 @@ import os
 from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 import httpx
 
@@ -188,7 +188,8 @@ def _store_id_from_token(token: str) -> str:
 
 
 def _private_blob_url(store_id: str, pathname: str) -> str:
-    return f"https://{store_id}.private.blob.vercel-storage.com/{pathname.lstrip('/')}"
+    encoded_path = quote(pathname.lstrip("/"), safe="/")
+    return f"https://{store_id}.private.blob.vercel-storage.com/{encoded_path}"
 
 
 def _parse_uploaded_at(value: object) -> datetime:

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -7,6 +7,7 @@ file are excluded by an allowlist of roots and again by name.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -50,9 +51,12 @@ class FakeObjectStore:
         self.objects: dict[str, bytes] = {}
         self.modified: dict[str, datetime] = {}
         self.listings = 0
+        self.listed_prefixes: list[str] = []
+        self.read_keys: list[str] = []
 
     def list_objects(self, prefix: str) -> list[RemoteObject]:
         self.listings += 1
+        self.listed_prefixes.append(prefix)
         return [
             RemoteObject(
                 key=key,
@@ -65,6 +69,7 @@ class FakeObjectStore:
         ]
 
     def get_object(self, key: str) -> bytes:
+        self.read_keys.append(key)
         return self.objects[key]
 
     def put_object(self, key: str, data: bytes) -> None:
@@ -1100,27 +1105,111 @@ def test_env_enabled_overrides_a_malformed_stored_enabled(
     assert load_remote_sync_config() is None
 
 
-# ── Org-scoped turns must not sync (keys carry no principal or actor) ────────
+# ── Org-scoped turns namespace keys by organization and member ──────────────
 
 
-def test_org_scoped_turn_refuses_to_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Two members of one org would otherwise share every object key."""
+def test_org_members_cannot_read_each_others_objects(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Similar member ids still get exact, non-overlapping list prefixes."""
     # Arrange
+    from config.constants import paths
     from config.principal import Actor, Principal, StorageScope
     from config.scope_context import bound_storage_scope
-    from infrastructure.filestorage.errors import OrgScopeNotSupportedError
-    from infrastructure.filestorage.operations import get_sync_status, run_remote_sync
+    from infrastructure.filestorage import operations
+    from infrastructure.filestorage.enums import BucketExposure
+    from infrastructure.filestorage.exposure import PublicAccessStatus
 
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", home)
+    monkeypatch.delenv(paths.CONTEXT_ROOT_ENV, raising=False)
     monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
     monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "shared-bucket")
-    scope = StorageScope(principal=Principal.org("org_acme"), actor=Actor(id="U_ALICE"))
+    store = FakeObjectStore()
+    monkeypatch.setattr(operations, "build_object_store", lambda _config: store)
+    unknown = PublicAccessStatus(BucketExposure.UNKNOWN)
+    monkeypatch.setattr(operations, "check_bucket_exposure", lambda _config: unknown)
 
-    # Act / Assert: both entry points fail closed while the scope is bound.
+    organization = Principal.org("org_acme")
+    member_u1 = StorageScope(principal=organization, actor=Actor(id="U1"))
+    member_u10 = StorageScope(principal=organization, actor=Actor(id="U10"))
+    u1_session = home / "orgs" / "org_acme" / "users" / "U1" / "sessions" / "shared.jsonl"
+    u10_session = home / "orgs" / "org_acme" / "users" / "U10" / "sessions" / "shared.jsonl"
+    u1_session.parent.mkdir(parents=True)
+    u10_session.parent.mkdir(parents=True)
+    u1_session.write_bytes(b"member U1")
+    u10_session.write_bytes(b"member U10")
+
+    # Act: each member pushes, then U1 restores its deleted local copy.
+    with bound_storage_scope(member_u1):
+        assert operations.get_sync_status().enabled is True
+        operations.run_remote_sync(push_only=True)
+    with bound_storage_scope(member_u10):
+        operations.run_remote_sync(push_only=True)
+    u1_session.unlink()
+    store.read_keys.clear()
+    with bound_storage_scope(member_u1):
+        operations.run_remote_sync(pull_only=True)
+
+    # Assert: the trailing delimiter prevents U1 from listing U10's objects.
+    assert store.objects["orgs/org_acme/users/U1/sessions/shared.jsonl"] == b"member U1"
+    assert store.objects["orgs/org_acme/users/U10/sessions/shared.jsonl"] == b"member U10"
+    assert all(
+        key.startswith(("orgs/org_acme/users/U1/", "orgs/org_acme/users/U10/"))
+        for key in store.objects
+    )
+    assert all(LEAKED_SECRET.encode() not in data for data in store.objects.values())
+    assert store.listed_prefixes[-1] == "orgs/org_acme/users/U1/"
+    assert store.read_keys == ["orgs/org_acme/users/U1/sessions/shared.jsonl"]
+    assert u1_session.read_bytes() == b"member U1"
+
+
+def test_org_namespace_encodes_key_path_delimiters() -> None:
+    """Opaque identity values cannot inject or escape namespace segments."""
+    from config.principal import Actor, Principal, StorageScope
+    from infrastructure.filestorage.key_namespace import scope_key_prefix
+
+    scope = StorageScope(
+        principal=Principal.org("../org/acme"),
+        actor=Actor(id="../U/1"),
+    )
+
+    assert scope_key_prefix(scope) == "orgs/%2E%2E%2Forg%2Facme/users/%2E%2E%2FU%2F1/"
+
+
+@pytest.mark.parametrize("sync_operation", (push, pull, run_sync))
+def test_public_engine_entry_points_default_to_the_bound_org_namespace(
+    sync_operation: Callable[..., object],
+    roots: tuple[SyncRoot, ...],
+) -> None:
+    """Direct callers cannot accidentally fall back to flat organization keys."""
+    from config.principal import Actor, Principal, StorageScope
+    from config.scope_context import bound_storage_scope
+
+    store = FakeObjectStore()
+    scope = StorageScope(principal=Principal.org("org_acme"), actor=Actor(id="U1"))
+
     with bound_storage_scope(scope):
-        with pytest.raises(OrgScopeNotSupportedError):
-            run_remote_sync()
-        with pytest.raises(OrgScopeNotSupportedError):
-            get_sync_status()
+        sync_operation(store, roots=roots)
+
+    assert store.listed_prefixes == ["orgs/org_acme/users/U1/"]
+    assert all(key.startswith("orgs/org_acme/users/U1/") for key in store.objects)
+
+
+def test_bound_org_namespace_cannot_be_overridden_with_a_flat_prefix(
+    roots: tuple[SyncRoot, ...],
+) -> None:
+    """The low-level override cannot reopen the cross-member key space."""
+    from config.principal import Actor, Principal, StorageScope
+    from config.scope_context import bound_storage_scope
+
+    store = FakeObjectStore()
+    scope = StorageScope(principal=Principal.org("org_acme"), actor=Actor(id="U1"))
+
+    with bound_storage_scope(scope):
+        run_sync(store, roots=roots, object_key_prefix="")
+
+    assert store.listed_prefixes == ["orgs/org_acme/users/U1/"]
+    assert all(key.startswith("orgs/org_acme/users/U1/") for key in store.objects)
 
 
 def test_unbound_laptop_turn_still_syncs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/filestorage/test_vercel_provider.py
+++ b/tests/filestorage/test_vercel_provider.py
@@ -152,6 +152,18 @@ def test_put_list_get_round_trip() -> None:
     assert "opensre/sessions/a.jsonl" in transport.objects
 
 
+def test_encoded_org_namespace_round_trip() -> None:
+    """A literal percent escape in a scoped key survives private-CDN URL parsing."""
+    transport = _FakeTransport()
+    store = _store(transport)
+    key = "orgs/org%2Eacme/users/U%2E1/sessions/a.jsonl"
+
+    store.put_object(key, b"scoped history")
+
+    assert [obj.key for obj in store.list_objects("orgs/org%2Eacme/users/U%2E1/")] == [key]
+    assert store.get_object(key) == b"scoped history"
+
+
 def test_list_prefix_isolation() -> None:
     transport = _FakeTransport()
     store = _store(transport)


### PR DESCRIPTION
Fixes #4560

#### Describe the changes you have made in this PR -

- Namespace organization-bound remote-sync objects as `orgs/<organization>/users/<member>/...` while preserving flat keys for unbound local turns.
- Use an exact trailing-delimiter listing prefix so similar member IDs such as `U1` and `U10` cannot overlap.
- Percent-encode identity path delimiters and dot segments before they become object-key segments.
- Make the bound organization scope authoritative in every public engine entry point, including when a caller supplies an empty low-level prefix override.
- Keep user exclusion patterns matched against logical `sessions/...` and `memory/...` paths.
- Remove the organization-scope refusal from the shared operations and document the new behavior.
- Preserve percent-encoded namespaces when Vercel Blob builds private download URLs.
- Add an in-memory isolation regression test that pushes as two members, restores one member's data, and verifies the other member's object is never read; retain the credential canary assertion.

### Demo/Screenshot for feature changes and bug fixes -

Focused validation output:

```text
tests/filestorage/ ...
tests/surfaces/test_remote_sync_surface_contract.py ......
290 passed

make lint         -> All checks passed!
make format-check -> 3212 files already formatted
make typecheck    -> Success: no issues found in 1858 source files
```

The regression uses members `U1` and `U10` and asserts that the restore lists exactly `orgs/org_acme/users/U1/` and reads only `orgs/org_acme/users/U1/sessions/shared.jsonl`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The object-store protocol already exposes prefix-filtered listing, reads, and writes, so it did not need a tenancy-specific fifth method. The operations layer derives an organization/member namespace from the bound storage scope and passes it to the provider-independent sync engine. Every public engine entry point also derives that namespace by default and refuses to flatten a bound organization through its low-level override. The engine normalizes the prefix once, lists only the exact slash-delimited namespace, qualifies uploads, strips the namespace before local path and exclusion handling, and rejects any foreign object returned by an injected or non-conforming listing.

I considered putting namespace logic into every provider, but that would duplicate tenant policy across AWS/S3, GCS, Azure, Vercel, and community adapters. Keeping it in the engine preserves the four-method `ObjectStore` contract and applies the same isolation rule to every backend. Identity components are encoded so opaque provider IDs cannot inject `/`, `.` or `..` key segments.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
