### PR TITLE
test: stop importlib mode re-executing the skills package; keep buffered REPL console's NO_COLOR decision

### DIFF
--- a/core/agent_harness/prompts/skills/AGENTS.md
+++ b/core/agent_harness/prompts/skills/AGENTS.md
@@ -98,7 +98,10 @@ tools (`ask_user_choice`, `skill_view`) through
 `core.agent_harness.tools.action_tools.get_action_tool`; the registry behind it
 is installed around every test by `tests/harness_providers_plugin.py`
 (loaded from `pytest.ini`), not by `tests/conftest.py`, which does not reach
-this tree.
+this tree. `tests/colocated_skill_tests_plugin.py` imports this package before
+collection: pytest's importlib mode otherwise re-executes it while importing a
+test from a hyphenated skill directory, leaving two copies of every
+`core.agent_harness.prompts.*` module in the process.
 
 
 ## Skill metadata ownership and change date

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,8 +9,10 @@ python_functions = test_*
 # importlib avoids "import file mismatch" when two test files share a basename
 # (pytest's default prepend mode would import both as top-level test_enums).
 # The harness-providers plugin wires the tool/integration ports for every test
-# tree, including skill tests colocated under core/agent_harness/prompts/skills.
-addopts = -v --tb=short --durations=20 --import-mode=importlib -p tests.harness_providers_plugin
+# tree, including skill tests colocated under core/agent_harness/prompts/skills;
+# the colocated-skill-tests plugin keeps importlib mode from re-executing the
+# package those tests live in.
+addopts = -v --tb=short --durations=20 --import-mode=importlib -p tests.harness_providers_plugin -p tests.colocated_skill_tests_plugin
 # A hung test otherwise burns the whole job timeout (30m) and reports nothing
 # but "The operation was canceled". Fail it instead, with a stack dump of every
 # thread so a deadlock is diagnosable. Well above the slowest real test (~8s);

--- a/surfaces/shared/terminal/components/rendering.py
+++ b/surfaces/shared/terminal/components/rendering.py
@@ -101,8 +101,9 @@ def _write_repl_tty_buffered(
 ) -> None:
     """Render Rich output to a buffer and write it in one TTY-safe stdout call."""
     buf = io.StringIO()
-    # Inherit the caller's color depth so theme colours are not down-converted
-    # on a truecolor terminal (Rich would otherwise re-detect from the env).
+    # Inherit the caller's color depth and NO_COLOR decision so theme colours
+    # are not down-converted or stripped on a truecolor terminal (Rich would
+    # otherwise re-detect both from the env).
     buf_console = Console(
         file=buf,
         force_terminal=True,
@@ -112,6 +113,7 @@ def _write_repl_tty_buffered(
             Literal["auto", "standard", "256", "truecolor", "windows"],
             console.color_system or "auto",
         ),
+        no_color=console.no_color,
     )
     render_to_buffer(buf_console)
     styled = buf.getvalue()

--- a/tests/colocated_skill_tests_plugin.py
+++ b/tests/colocated_skill_tests_plugin.py
@@ -1,0 +1,56 @@
+"""Keep pytest's importlib mode from re-executing the skills package.
+
+Tests colocated beside a ``SKILL.md`` live under hyphenated directories that
+``import_module`` cannot resolve, so pytest imports them by file path and first
+spec-imports every ancestor package that is missing from ``sys.modules``.
+Executing ``core/agent_harness/prompts/__init__.py`` that way imports
+``skills`` through the regular import system, after which pytest executes
+``skills/__init__.py`` a second time as a fresh module object. That copy never
+receives its ``loader`` attribute (the submodule was already loaded, so the
+import system does not bind it again) and it is the copy left registered, so
+``monkeypatch.setattr("core.agent_harness.prompts.skills.loader.x", ...)``
+fails on any xdist worker that collected a colocated test before importing
+the package normally.
+
+Importing the package here, before collection, leaves pytest nothing to
+re-execute: it only creates namespace stand-ins for the hyphenated
+directories. The collection-finish hook turns any recurrence into a hard
+error instead of an order-dependent failure elsewhere in the run.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+import core.agent_harness.prompts.skills  # noqa: F401  (eager import is the fix)
+
+_GUARDED_PACKAGE = "core.agent_harness.prompts"
+
+
+def _duplicated_submodules() -> list[str]:
+    """Submodules under the guarded package whose parent binds a different object."""
+    prefix = _GUARDED_PACKAGE + "."
+    duplicated: list[str] = []
+    for name, module in list(sys.modules.items()):
+        if not name.startswith(prefix) or module is None:
+            continue
+        parent_name, _, child = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if not isinstance(parent, ModuleType):
+            continue
+        if getattr(parent, child, None) is not module:
+            duplicated.append(name)
+    return sorted(duplicated)
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    duplicated = _duplicated_submodules()
+    if not duplicated:
+        return
+    session.shouldfail = (
+        "collection re-executed an already imported package; these modules are "
+        "not the object their parent package binds: " + ", ".join(duplicated)
+    )

--- a/tests/interactive_shell/ui/test_rendering.py
+++ b/tests/interactive_shell/ui/test_rendering.py
@@ -119,7 +119,15 @@ def test_print_repl_renderable_keeps_truecolor_and_crlf(monkeypatch: pytest.Monk
 
     fake = _FakeStdout()
     monkeypatch.setattr("surfaces.shared.terminal.components.rendering.sys.stdout", fake)
-    console = Console(file=fake, force_terminal=True, highlight=False, color_system="truecolor")
+    # ``no_color=False`` pins the decision Rich would otherwise take from the
+    # developer's ``NO_COLOR`` env; the buffered path must inherit it.
+    console = Console(
+        file=fake,
+        force_terminal=True,
+        highlight=False,
+        color_system="truecolor",
+        no_color=False,
+    )
     monkeypatch.setattr(console, "file", fake)
 
     # Rich memoizes a style's ANSI codes at its first render and shares Style


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Two order-/environment-dependent test failures surfaced while landing #6203; both are fixed at the root.

**1. `test_action_prompt::test_skill_body_appends_sibling_report_template_but_index_stays_thin` (xdist order-dependent)**

The colocated skill test added in #6211 lives under hyphenated directories (`onboarding-github-ci/a-analyzing-github-ci-performance/`). Pytest's `--import-mode=importlib` cannot resolve that as a dotted module, falls back to importing by path, and first spec-imports every ancestor package missing from `sys.modules`. Executing `core/agent_harness/prompts/__init__.py` that way imports `skills` through the regular import system, after which pytest executes `skills/__init__.py` a *second* time as a fresh module object. Its `from …skills.loader import …` finds `loader` already loaded, so the import system never binds `skills.loader` on the copy, and the copy is what stays registered. Any worker that collected the colocated test before importing the package normally then fails `monkeypatch.setattr("core.agent_harness.prompts.skills.loader.skills_dir", …)`. The guard below showed ten `core.agent_harness.prompts.*` modules duplicated in that state.

Fix: `tests/colocated_skill_tests_plugin.py` (loaded from `pytest.ini`) imports the package before collection so pytest has nothing to re-execute, and a `pytest_collection_finish` hook fails the session if any submodule under `core.agent_harness.prompts` is not the object its parent binds — a recurrence becomes a hard error, not a flake elsewhere.

**2. `test_rendering::test_print_repl_renderable_keeps_truecolor_and_crlf` (developer env)**

Rich reads `NO_COLOR` when constructing a `Console`; with `NO_COLOR=1` exported, both the test console and the buffered console created by `_write_repl_tty_buffered` stripped colour and the `38;2;…` assertion failed. The buffered console now inherits the caller's `no_color` the same way it already inherits `color_system`, and the test pins `no_color=False` on its console.

### Demo/Screenshot for feature changes and bug fixes -

Guard firing with the eager import disabled (plain and `-n 2`):

```
! collection re-executed an already imported package; these modules are not the object their parent package binds: core.agent_harness.prompts.action, core.agent_harness.prompts.getting_started, core.agent_harness.prompts.grounding, core.agent_harness.prompts.kernel, core.agent_harness.prompts.memory, core.agent_harness.prompts.runtime_facts, core.agent_harness.prompts.skills.loader, core.agent_harness.prompts.skills.naming, core.agent_harness.prompts.skills.schedule, core.agent_harness.prompts.system_prompt !
exit(xdist, broken)=2
```

With the fix, the previously failing combination (`core/agent_harness/prompts/skills tests/core tests/tools tests/interactive_shell tests/shared tests/quality gateway/tests`, `-n auto`) passes, and the truecolor test passes under `NO_COLOR=1 TERM=dumb`:

```
============================== 16 passed in 2.78s ==============================
============================== 1 passed in 1.45s ===============================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Alternatives considered: renaming skill directories to identifiers (breaks the kebab-case skill naming), moving colocated tests back under `tests/` (contradicts the colocation policy from #6211), switching to `prepend` import mode (basename collisions, the reason importlib mode was chosen), or making `test_action_prompt` patch the module object instead of the dotted string (hides the duplicate-module state rather than fixing it). Pre-importing the package is the smallest change that removes the re-execution, and the collection-finish guard keeps it from silently regressing.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
