### PR TITLE
fix(onboarding): define child handoffs and fresh demo runs

### DIFF
--- a/config/constants/skills.py
+++ b/config/constants/skills.py
@@ -2,7 +2,7 @@
 
 ONBOARDING_SKILL_NAME = "onboarding-github-ci"
 
-# Children of the onboarding tree, in demo-menu order (A-D). Product code that
+# Onboarding workflows and managed-service availability. Product code that
 # branches on one of them reads it from here so a rename is a one-line change.
 ANALYZING_GITHUB_CI_PERFORMANCE_SKILL_NAME = "analyzing-github-ci-performance"
 SCHEDULING_GITHUB_CI_FIXES_SKILL_NAME = "scheduling-github-ci-fixes"

--- a/core/agent_harness/prompts/action/active_skill.py
+++ b/core/agent_harness/prompts/action/active_skill.py
@@ -19,7 +19,9 @@ def active_skill_block(name: str | None, message: str) -> str:
         f"ACTIVE SKILL: {name}\n"
         "The user is answering this skill's question. Continue from the answer "
         "with the skill's branch for it; do not reopen the question, restart "
-        "completed steps, or replay earlier steps because a plan still lists "
-        "them. The skill decides the next tool call; update the plan to match.\n\n"
+        "steps completed in this run, or replay them because a plan still lists "
+        "them. An explicit /demo starts a fresh run; results from earlier runs "
+        "do not complete its steps. The skill decides the next tool call and "
+        "whether it owns the live plan.\n\n"
         f"{body[:_MAX_SKILL_CHARS]}"
     )

--- a/core/agent_harness/prompts/getting_started.py
+++ b/core/agent_harness/prompts/getting_started.py
@@ -18,14 +18,21 @@ GETTING_STARTED_MENU: tuple[str, ...] = (*GETTING_STARTED_OPTIONS, GETTING_START
 
 
 def load_getting_started_block() -> str:
-    """Route capability and demo requests to the master skill that owns the menu."""
+    """Separate capability answers, direct specialist requests, and guided onboarding."""
     return (
         "When the user asks what you can do, what you're capable of, how you can "
-        "help, what tools you have, or for a demo / getting-started suggestion: "
+        "help, or what tools you have, answer from the available capabilities and "
+        "offer /demo. When the user names a demo or requests a specialist's work, "
+        "load that specialist directly and carry the original request forward. "
+        "For an ambiguous CI request, clarify the desired outcome once. "
+        "For an explicit demo or onboarding request that needs path selection, "
         f'call skill_view(name="{ONBOARDING_SKILL_NAME}") and follow that master skill. '
         "It owns the Ask User menu and the references to child skills. "
         "Do not invent a separate getting-started menu. When an answer arrives, "
-        "continue the active skill instead of reopening onboarding."
+        "continue the active skill instead of reopening onboarding. "
+        "If the picker for onboarding or an ambiguous CI request is unavailable, "
+        "explain the limitation, invite a "
+        "direct task request, and stop onboarding without a replacement text menu."
     )
 
 

--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -68,7 +68,8 @@ Maintain statuses in the tool: exactly one item in_progress at a time; mark item
 Use a plan when:
 
 - The task is non-trivial and will require multiple actions over a long time horizon.
-- Every skill must have an active plan
+- The loaded skill calls for a live plan. An onboarding router delegates the
+  live plan to its child; a skill that only explains availability needs none.
 - There are logical phases or dependencies where sequencing matters.
 - The work has ambiguity that benefits from outlining high-level goals.
 - You want intermediate checkpoints for feedback and validation.
@@ -146,11 +147,14 @@ default and state it in one short sentence. Only when a genuinely blocking
 choice remains — a small fixed set of materially different paths with no safe
 default — call `ask_user_choice` instead of guessing.
 
-For a demo or getting-started request, follow the assembled getting-started
-instruction to load the master onboarding skill. That skill owns the menu and
-chooses the child skill after the answer. Do not ask a separate onboarding
-question before loading it. On a menu answer, continue the active skill from
-the clarified request without reopening its question.
+For a demo or getting-started request that needs path selection, follow the
+assembled getting-started instruction to load the master onboarding skill.
+That skill owns the menu and chooses the child skill after the answer. Do not
+ask a separate onboarding question before loading it. An explicit demo choice
+or specialist request goes directly to that specialist. On a menu answer,
+continue the active skill from the clarified request without reopening its
+question. If guided onboarding selection is unavailable, explain the
+limitation, invite a direct task request, and end onboarding without a text menu.
 
 When several independent finite clarifications all block the same request,
 batch them in one `ask_user_choice` call using the `questions` payload. Do not
@@ -164,7 +168,9 @@ own" prompt. The user's selection arrives verbatim as the next message; resume
 from that selection. If the tool reports that the menu is unavailable **and the
 choice is required to continue**, fall back to a short numbered list and ask
 the user to reply with their choice. Use this numbered fallback only for
-required clarification when TURN INTERACTION reports the menu is unavailable.
+required clarification when TURN INTERACTION reports the menu is unavailable,
+except onboarding path selection (including an ambiguous CI request), which
+ends as described above.
 
 Do **not** call `ask_user_choice` just to park an optional follow-up (run tests,
 commit, build the next component) when TURN INTERACTION says the menu is

--- a/core/agent_harness/prompts/skills/AGENTS.md
+++ b/core/agent_harness/prompts/skills/AGENTS.md
@@ -82,6 +82,11 @@ Rules:
   named in the request) say so in the step body and tell the agent to mark
   the skipped plan items satisfied rather than delete them.
 - Tool-usage cards describe one call, not a flow, and do not carry a plan.
+- `onboarding-github-ci` is a router: its Plan section lists selection and
+  handoff, while the selected child owns the live plan. The host can open the
+  entry picker before any model step, and skill loading is bookkeeping rather
+  than evidence of completed work. The router therefore does not call
+  `update_plan`; it immediately follows the successfully loaded child.
 
 ## Colocated workflow tests
 
@@ -236,8 +241,8 @@ Current collection:
 | `onboarding-github-ci` | workflow (master menu) | `skills/onboarding-github-ci/` | — |
 | `analyzing-github-ci-performance` | workflow (demo A) | `skills/onboarding-github-ci/a-…/` | closed set |
 | `scheduling-github-ci-fixes` | workflow (demo B) | `skills/onboarding-github-ci/b-…/` | closed set |
-| `delegating-github-ci-fixes` | workflow (demo C, placeholder) | `skills/onboarding-github-ci/c-…/` | — |
-| `connecting-slack` | workflow (demo D) | `skills/onboarding-github-ci/d-…/` | `cli_exec`, `slash_invoke` |
+| `delegating-github-ci-fixes` | workflow (availability only) | `skills/delegating-github-ci-fixes/` | — |
+| `connecting-slack` | workflow (demo C) | `skills/onboarding-github-ci/c-…/` | `cli_exec`, `slash_invoke` |
 | `operating-github-cli` | tool usage | `integrations/github/tools/github_cli/` | `github_cli` |
 | `operating-github-ci-fixer` | tool usage | `integrations/github/tools/ci_fix/` | `fix_github_pr_ci` |
 | `operating-github-security-fixer` | tool usage | `integrations/github/tools/security_fix/` | `fix_github_security_alert` |

--- a/core/agent_harness/prompts/skills/delegating-github-ci-fixes/SKILL.md
+++ b/core/agent_harness/prompts/skills/delegating-github-ci-fixes/SKILL.md
@@ -3,18 +3,16 @@ name: delegating-github-ci-fixes
 description: >-
   Delegates CI/CD fixes to the hosted OpenSRE managed service. Not yet
   available; when loaded, say the option is coming soon and exit the flow.
-getting_started: Run CI/CD improvements with a managed service (coming soon)
-demo_order: 3
 metadata:
   owner: Vincent
   last_changed_by: Jan
-  last_changed_at: 2026-09-11
+  last_changed_at: 2026-09-12
   usecases:
-    - Reserved slot for the remote managed-service onboarding demo
+    - Explain managed-service availability when explicitly requested
   requires:
     - Nothing; this skill only reports that the option is not available yet
   type: onboarding
-  version: "0.1"
+  version: "0.2"
 ---
 # Remote managed service (not yet available)
 

--- a/core/agent_harness/prompts/skills/loader.py
+++ b/core/agent_harness/prompts/skills/loader.py
@@ -463,7 +463,7 @@ def load_skills_index() -> str:
         "Before answering, check this catalog for an action-shaped match",
         '(including "set up", "install", "onboard me", "demo", "audit", or "fix").',
         'For capability questions ("what can you do", "how can you help"),',
-        "follow the getting-started instruction to load the master skill.",
+        "follow the getting-started instruction to answer first and offer /demo.",
         "When the user request matches a skill below, call skill_view(name) in",
         "this turn. Read its result before creating or revising its plan or",
         "calling its workflow tools. Request dependent update_plan calls in a",

--- a/core/agent_harness/prompts/skills/onboarding-github-ci/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding-github-ci/SKILL.md
@@ -1,41 +1,39 @@
 ---
 name: onboarding-github-ci
 description: >-
-  Master onboarding skill: asks which of four CI/CD demos to run, then loads
-  and follows the selected child skill. Use on interactive-shell startup,
-  for a demo or getting-started request, or for capability questions such as
-  "what can you do?". Direct repository analysis, recurring-loop setup, Slack
-  setup, and CI-fix requests should load their specialist skill directly.
+  Routes interactive-shell startup, /demo, and explicit onboarding requests
+  through a demo picker to the selected child skill. Answer capability
+  questions first and offer /demo. Load the specialist directly when the
+  user names a demo or requests repository analysis, recurring CI fixes,
+  Slack setup, managed-service availability, or a one-off CI fix.
 metadata:
   owner: Vincent
-  last_changed_by: Vincent
-  last_changed_at: 2026-09-11
+  last_changed_by: Jan
+  last_changed_at: 2026-09-12
   usecases:
     - Interactive-shell startup and /demo
-    - When users want to see an onboarding flow
-    - Show the available onboarding paths and follow the selected child skill
-    - Answer capability and getting-started questions with an interactive demo
+    - Select an onboarding path and begin its child workflow
+    - Restart onboarding when the user explicitly requests a fresh demo
   requires:
-    - Interactive terminal for the Ask User menu
+    - Interactive terminal for guided demo selection
   type: onboarding
-  version: "2.0"
+  version: "2.1"
   dependencies:
     - core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/SKILL.md
     - core/agent_harness/prompts/skills/onboarding-github-ci/b-scheduling-github-ci-fixes/SKILL.md
-    - core/agent_harness/prompts/skills/onboarding-github-ci/c-delegating-github-ci-fixes/SKILL.md
-    - core/agent_harness/prompts/skills/onboarding-github-ci/d-connecting-slack/SKILL.md
-# The host runs this on entry (startup, /demo, skill_view) before any model step.
+    - core/agent_harness/prompts/skills/onboarding-github-ci/c-connecting-slack/SKILL.md
+    - core/agent_harness/prompts/skills/delegating-github-ci-fixes/SKILL.md
+# The host opens this menu before the model runs.
 pre_execute:
   - tool: ask_user_choice
     args:
       title: Which demo would you like me to run?
       note: >-
         Choose a demo using your own repositories or connect your team through
-        Slack. The managed-service option is coming soon.
+        Slack.
       options:
         - Explore a repo and analyze its CI/CD performance (recommended)
         - Set up an agent that improves CI/CD reliability over time
-        - Run CI/CD improvements with a managed service (coming soon)
         - Connect OpenSRE to Slack and hand off DevOps chores for your team
         - Skip the demo and open the shell
       allow_custom: false
@@ -43,45 +41,74 @@ pre_execute:
 
 # CI/CD onboarding
 
-This master skill owns the onboarding question. Its menu is declared in
-`pre_execute`; the entry result reports whether it opened. If the current message
-already answers it, continue directly to the selected child. Never ask the
-onboarding question twice for one request.
+Resolve the user's demo choice and hand execution to its child skill.
+The child owns the work, its prerequisites, authorization, and follow-up.
 
-## Ask User
+## Plan
 
-Read the `pre_execute` results before deciding what to do:
+The selected child owns the live plan and its `update_plan` calls. This
+router's two steps below track selection and handoff only; leave the live
+plan to the child. The host may pause for its entry menu before any model
+step can run.
 
-- `menu: queued`: end the turn and wait for the selection. The host owns the
-  menu; do not call `ask_user_choice` again or repeat its options as text.
-- `menu: suppressed`: no new menu opened. Continue the current request using
-  the existing answer. If the user explicitly requests the demo menu again,
-  call `slash_invoke` with `/demo`; a greeting does not request reopening.
-- `menu: unavailable`: show the `pre_execute` options as a numbered list and
-  wait for a reply.
-- A hook error without a menu status: explain that the picker could not open
-  and show the options as a numbered list.
+- [ ] Step 1. Resolve the demo selection from the request or the host's ask_user_choice menu.
+- [ ] Step 2. Load the selected child's instructions with skill_view.
 
-Only a queued menu justifies telling the user to select from an open picker.
-The menu has no free-text row. Its last option opens the plain shell; the
-shell handles Skip and Escape without sending an answer to the model.
+## Workflow
 
-## Follow the selected child
+### 1. Resolve selection
 
-The next message carries the question and the user's answer. Call `skill_view`
-with the matching name, then follow its returned instructions in the same turn:
+Use an explicit demo choice in the current request or the answer to the
+onboarding question. Carry the original request, including any repository,
+constraints, and existing approvals, into the handoff. The child determines
+its own prerequisites; analysis still follows its scan and repository picker.
 
-- Option A: `analyzing-github-ci-performance` —
-  [analyze CI performance](a-analyzing-github-ci-performance/SKILL.md).
-- Option B: `scheduling-github-ci-fixes` —
-  [schedule the CI fix loop](b-scheduling-github-ci-fixes/SKILL.md).
-- Option C: `delegating-github-ci-fixes` —
-  [delegate to the managed service](c-delegating-github-ci-fixes/SKILL.md).
-- Option D: `connecting-slack` — [connect Slack](d-connecting-slack/SKILL.md).
+When selection is unresolved, read the `pre_execute` result:
 
-Do not perform the child workflow from this summary; load its full skill first.
-The managed-service child explains that it is unavailable and ends the flow.
-For a custom answer, treat that text as the user's request and act on it using
-the appropriate tools or skill. Do not reopen this menu or force a demo choice.
-After a child asks its own question, continue that child rather than returning
-to this master menu. Escape cancels onboarding; wait for a fresh user request.
+- `menu: queued`: end the turn and wait for the answer. The host has opened
+  the picker; neither another tool call nor a text copy of its options is needed.
+- `menu: suppressed`: continue from an applicable existing answer. A greeting
+  is an ordinary conversation turn. For an explicit request to reopen the
+  demo menu, call `slash_invoke` with `/demo` and wait for its new selection.
+- `menu: unavailable`, a hook error, or no menu result: explain that guided
+  selection is unavailable in this session, invite a direct task request,
+  and end onboarding. There is no replacement text menu.
+
+An ambiguous CI request needs one focused clarification about the desired
+outcome before selecting a child. Use `ask_user_choice` when available and
+end the turn; otherwise follow the unavailable-picker behavior above.
+Handle unrelated requests as the user's new task.
+
+Skip and Escape end onboarding in the shell without an answer for the model.
+An explicit `/demo` starts a fresh run: carry inputs from the new request,
+and perform the selected workflow again rather than crediting earlier results
+as completed work.
+
+Complete when the user's intended child is unambiguous. Opening a menu is
+a pause, not a selection; cancellation and unavailable selection end this
+flow without a handoff.
+
+### 2. Load the child
+
+Call `skill_view` with the name matching the selected path:
+
+| Path | Skill |
+| --- | --- |
+| A. Analyze CI performance | [`analyzing-github-ci-performance`](a-analyzing-github-ci-performance/SKILL.md) |
+| B. Set up ongoing CI fixes | [`scheduling-github-ci-fixes`](b-scheduling-github-ci-fixes/SKILL.md) |
+| C. Connect Slack | [`connecting-slack`](c-connecting-slack/SKILL.md) |
+| Managed service, direct requests only | [`delegating-github-ci-fixes`](../delegating-github-ci-fixes/SKILL.md) |
+
+If loading fails, report that the selected demo could not load, retain the
+choice, and stop. Leave handoff incomplete; a new user request can retry it.
+The child's description is insufficient to execute its workflow.
+
+Complete when `skill_view` successfully returns the selected child's full
+instructions. A hook error inside a successfully loaded child belongs to
+that child's workflow.
+
+Immediately follow the child's first unmet step in the same turn, continuing
+until its own pause or completion condition. The child starts its live plan
+and handles any missing authorization, preserving approvals already given.
+Resume that child on its answers; loading it is not a reason to end execution
+or return to this menu.

--- a/core/agent_harness/prompts/skills/onboarding-github-ci/c-connecting-slack/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding-github-ci/c-connecting-slack/SKILL.md
@@ -8,11 +8,11 @@ description: >-
   hand off DevOps chores for your team". Never post, reply, or send to Slack
   in this flow. Multi-step; load before acting.
 getting_started: Connect OpenSRE to Slack and hand off DevOps chores for your team
-demo_order: 4
+demo_order: 3
 metadata:
   owner: Vincent
   last_changed_by: Jan
-  last_changed_at: 2026-09-11
+  last_changed_at: 2026-09-12
   usecases:
     - First-experience demo: connect OpenSRE to Slack and show the handoff path
     - Verify Slack is configured, then run the Slack setup wizard if it is missing
@@ -21,7 +21,7 @@ metadata:
     - Slack workspace the user can add the OpenSRE bot to
     - Interactive terminal for `/integrations setup slack` when Slack is not configured
   type: onboarding
-  version: "1.1"
+  version: "1.2"
 tools:
   - cli_exec
   - slash_invoke

--- a/core/agent_harness/prompts/skills/onboarding-github-ci/test_onboarding_workflow.py
+++ b/core/agent_harness/prompts/skills/onboarding-github-ci/test_onboarding_workflow.py
@@ -1,0 +1,161 @@
+"""The shipped router pauses at its real entry hook and hands off through skill_view."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from config.constants import OPENSRE_MEMORY_AUTOEXTRACT_DISABLED_ENV, OPENSRE_MEMORY_DIR_ENV
+from config.constants.skills import (
+    ANALYZING_GITHUB_CI_PERFORMANCE_SKILL_NAME,
+    ONBOARDING_SKILL_NAME,
+)
+from core.agent_harness.ports import TurnBinding
+from core.agent_harness.prompts.skills.loader import list_action_skills, load_skill_body
+from core.agent_harness.session.pending_choice import PendingUserChoice, format_ask_user_answers
+from core.agent_harness.tools.action_tools import get_action_tool
+from core.agent_harness.tools.tool_provider import DefaultToolProvider
+from core.agent_harness.turns.headless_adapters import (
+    BufferOutputSink,
+    EmptyPromptContextProvider,
+    InMemorySessionState,
+)
+from core.agent_harness.turns.headless_build import InMemoryHeadlessBuild
+from core.llm.types import AgentLLMResponse
+from core.tool import RegisteredTool
+from tests.core.agent.orchestration.action_execution_test_harness import (
+    FakeActionLLM,
+    tool_response,
+)
+
+
+@dataclass
+class _Terminal:
+    pending_prompt_default: str | None = None
+    awaiting_handoff_answer: bool = False
+
+    def set_auto_command(self, command: str) -> None:
+        self.pending_prompt_default = command
+
+
+@dataclass
+class _Session(InMemorySessionState):
+    active_skill: str | None = None
+    active_skill_tools: tuple[str, ...] = ()
+    pending_user_choice: PendingUserChoice | None = None
+    skill_hooks_fired: set[str] = field(default_factory=set)
+    skills_already_prompted: set[str] = field(default_factory=set)
+    questions_already_answered: set[str] = field(default_factory=set)
+    skill_question_keys: dict[str, set[str]] = field(default_factory=dict)
+    terminal: _Terminal = field(default_factory=_Terminal)
+
+
+class _Ports:
+    def tty_interactive(self) -> bool:
+        return True
+
+
+def _action_tool(name: str) -> RegisteredTool:
+    tool = get_action_tool(name)
+    assert tool is not None, f"action tool {name!r} is not registered"
+    return tool
+
+
+def test_onboarding_waits_for_selection_then_runs_the_child_in_the_answer_turn(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(OPENSRE_MEMORY_AUTOEXTRACT_DISABLED_ENV, "1")
+    monkeypatch.setenv(OPENSRE_MEMORY_DIR_ENV, str(tmp_path / "memory"))
+    skill = next(s for s in list_action_skills() if s.path == Path(__file__).with_name("SKILL.md"))
+    session = _Session(configured_integrations_known=True, resolved_integrations_cache={})
+    work: list[str] = []
+
+    def scan() -> dict[str, Any]:
+        work.append("scan")
+        return {"success": True, "repos": [{"github": "acme/one", "has_workflows": True}]}
+
+    scan_tool = RegisteredTool(
+        name="scan_local_git_workspace",
+        description="Discover local repositories",
+        input_schema={"type": "object", "properties": {}},
+        source="interactive_shell",
+        run=scan,
+        parallel_safe=False,
+    )
+    load_parent = tool_response("skill_view", {"name": skill.name})
+    premature_scan = tool_response(scan_tool.name)
+
+    class SkillLLM(FakeActionLLM):
+        def invoke(
+            self,
+            messages: list[dict[str, Any]],
+            *,
+            system: str | None = None,
+            tools: list[dict[str, Any]] | None = None,
+        ) -> AgentLLMResponse:
+            if self.invocations:
+                assert any(
+                    load_skill_body(skill.name) in str(m.get("content", "")) for m in messages
+                )
+            return super().invoke(messages, system=system, tools=tools)
+
+    llm = SkillLLM(
+        [
+            AgentLLMResponse(
+                content="",
+                tool_calls=[*load_parent.tool_calls, *premature_scan.tool_calls],
+                raw_content=None,
+            ),
+            tool_response("skill_view", {"name": ANALYZING_GITHUB_CI_PERFORMANCE_SKILL_NAME}),
+            tool_response(scan_tool.name),
+            tool_response(
+                "ask_user_choice",
+                {
+                    "title": "Which repository should I analyze?",
+                    "options": ["acme/one", "Tracer-Cloud/opensre"],
+                },
+            ),
+        ]
+    )
+    output = BufferOutputSink()
+    provider = DefaultToolProvider(
+        session,
+        output,
+        precomputed_action_tools=[
+            _action_tool("skill_view"),
+            _action_tool("ask_user_choice"),
+            scan_tool,
+        ],
+        slash_ports_factory=_Ports,
+    )
+    agent = InMemoryHeadlessBuild(session=session, output=output).agent(
+        tools=provider,
+        prompts=EmptyPromptContextProvider(),
+        llm_factory=lambda: llm,
+    )
+    binding = TurnBinding(is_tty=True)
+
+    agent.handle("Show me a demo", binding)
+
+    pending = session.pending_user_choice
+    assert pending is not None
+    assert pending.title == skill.pre_execute[0].args["title"]
+    assert session.active_skill == ONBOARDING_SKILL_NAME
+    assert work == []
+    assert llm.invocations == 1
+    session.pending_user_choice = None
+    session.terminal.pending_prompt_default = None
+    session.terminal.awaiting_handoff_answer = False
+    answer = format_ask_user_answers(pending.items(), (pending.options[0],))
+
+    agent.handle(answer, binding)
+
+    assert session.active_skill == ANALYZING_GITHUB_CI_PERFORMANCE_SKILL_NAME
+    assert work == ["scan"]
+    assert session.pending_user_choice is not None
+    assert session.pending_user_choice.title == "Which repository should I analyze?"
+    assert llm.invocations == 4
+    assert not llm.responses

--- a/core/agent_harness/session/session_core.py
+++ b/core/agent_harness/session/session_core.py
@@ -176,6 +176,9 @@ class SessionCore:
     restored either.
     """
 
+    skill_question_keys: dict[str, set[str]] = field(default_factory=dict)
+    """Queued question keys by owning skill, for explicit workflow restarts."""
+
     skills_already_prompted: set[str] = field(default_factory=set)
     """Skills whose ``pre_execute`` menu this session has already opened.
 
@@ -432,6 +435,7 @@ class SessionCore:
         self.gather_unreachable_tools.clear()
         self.gather_unreachable_sources.clear()
         self.questions_already_answered.clear()
+        self.skill_question_keys.clear()
         self.skills_already_prompted.clear()
         if rotate_identity:
             # Rotate session identity so the new post-reset session gets its own ID and file.

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -43,6 +43,7 @@ from surfaces.shared.terminal.components.choice_menu import (
 
 _CANCELLED = "Selection cancelled — type a reply instead."
 _DEMO_SKIPPED = "Demo skipped — type a request, or /demo to come back to it."
+_DEMO_UNAVAILABLE = "Guided demo selection is unavailable here — request a task directly."
 
 
 def _remember_answered(session: Session, *titles: str) -> None:
@@ -81,6 +82,9 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         return True
 
     if not repl_tty_interactive():
+        if session.active_skill == ONBOARDING_SKILL_NAME:
+            _leave_menu(session, console, _DEMO_UNAVAILABLE)
+            return True
         for question in pending.items():
             print_valid_choice_list(
                 console,

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -11,6 +11,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from config.constants.skills import ONBOARDING_SKILL_NAME
+from core.agent_harness.spi.grounding import getting_started_skills
 from core.agent_harness.tools import ActionToolScope
 from infrastructure.analytics.capture import capture_onboarding_demo_prompted
 from infrastructure.analytics.source import is_test_run
@@ -65,6 +66,11 @@ def offer_demo(session: Session, console: Console | None = None, *, force: bool 
         session.active_skill_tools = ()
         session.skill_hooks_fired = set()
         return False
+    # A new demo may ask its children's questions again, while unrelated
+    # decisions and their authorization remain part of this session.
+    for skill in getting_started_skills():
+        previous = session.skill_question_keys.pop(skill.name, ())
+        session.questions_already_answered.difference_update(previous)
     try:
         capture_onboarding_demo_prompted()
     except Exception:

--- a/tests/core/agent/orchestration/test_action_prompt.py
+++ b/tests/core/agent/orchestration/test_action_prompt.py
@@ -268,7 +268,7 @@ def test_skill_matches_take_priority_over_generic_docs_answer() -> None:
 
     assert "Skill matches outrank a generic docs/how-to answer" in index
     assert '"onboard me"' in index
-    assert "owns the onboarding question" in body
+    assert "hand execution to its child skill" in body
     # Skills index still rides the assembled prompt after the markdown base.
     assert SKILLS_HEADER in prompt
     assert ONBOARDING_SKILL_NAME in prompt

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -1,4 +1,4 @@
-"""The master skill owns the menu and refers to four independently loadable children."""
+"""The master skill routes three demos and keeps specialists independently loadable."""
 
 from __future__ import annotations
 
@@ -32,20 +32,18 @@ def test_child_directories_are_letter_prefixed_skill_names() -> None:
         assert suffix == skill.name, directory
 
 
-def test_master_menu_matches_four_unique_children_and_preserves_specialists() -> None:
+def test_master_menu_matches_selectable_children_and_preserves_specialists() -> None:
     loader.clear_skills_caches()
     children = getting_started_skills()
     assert [s.name for s in children] == [
         "analyzing-github-ci-performance",
         "scheduling-github-ci-fixes",
-        "delegating-github-ci-fixes",
         "connecting-slack",
     ]
-    assert [s.demo_order for s in children] == [1, 2, 3, 4]
+    assert [s.demo_order for s in children] == [1, 2, 3]
     assert GETTING_STARTED_OPTIONS == (
         "Explore a repo and analyze its CI/CD performance (recommended)",
         "Set up an agent that improves CI/CD reliability over time",
-        "Run CI/CD improvements with a managed service (coming soon)",
         "Connect OpenSRE to Slack and hand off DevOps chores for your team",
     )
     master = loader.load_skill_body(ONBOARDING_SKILL_NAME)
@@ -100,6 +98,9 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
     assert menu["allow_custom"] is False
     assert GETTING_STARTED_CUSTOM not in master
     assert "not implemented yet" in loader.load_skill_body("delegating-github-ci-fixes")
+    managed = next(s for s in loader.list_action_skills() if s.name == "delegating-github-ci-fixes")
+    assert managed.getting_started is None
+    assert managed.demo_order is None
     discovered = [
         loader._load_action_skill(path) for path in loader._iter_skill_paths(loader.skills_dir())
     ]
@@ -131,7 +132,7 @@ def test_multi_step_skills_track_progress_with_update_plan_not_step_headers() ->
         assert "### [" not in loader.load_skill_body(name), name
 
 
-def test_capability_and_demo_prompts_load_master_instead_of_defining_another_menu() -> None:
+def test_capability_answers_and_direct_requests_do_not_require_onboarding() -> None:
     snapshot = TurnSnapshot(
         text="What can you do?",
         conversation_messages=(),
@@ -143,6 +144,12 @@ def test_capability_and_demo_prompts_load_master_instead_of_defining_another_men
     )
     prompt = " ".join(build_action_system_prompt(snapshot).split())
     assert f'call skill_view(name="{ONBOARDING_SKILL_NAME}")' in prompt
+    assert "answer first and offer /demo" in prompt
+    assert "An onboarding router delegates the live plan to its child" in prompt
+    assert "For an ambiguous CI request, clarify the desired outcome once" in prompt
+    assert "load that specialist directly and carry the original request forward" in prompt
+    assert "an explicit demo or onboarding request that needs path selection" in prompt
+    assert "stop onboarding without a replacement text menu" in prompt
     assert "Do not ask a separate onboarding question before loading it" in prompt
     assert "are NOT a skill_view match" not in prompt
     assert "Which demo would you like me to run?" not in load_getting_started_block()

--- a/tests/core/agent_harness/prompts/test_skill_metadata.py
+++ b/tests/core/agent_harness/prompts/test_skill_metadata.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -58,7 +58,9 @@ def test_every_skill_card_has_the_metadata_block(card: Path) -> None:
         f"{card.parent.name}: metadata.last_changed_at must be an unquoted ISO date "
         f"(YYYY-MM-DD), got {changed_at!r}"
     )
-    assert changed_at <= date.today(), (
+    # Editors can already be on tomorrow's UTC date, as far ahead as UTC+14.
+    latest_calendar_date = (datetime.now(UTC) + timedelta(hours=14)).date()
+    assert changed_at <= latest_calendar_date, (
         f"{card.parent.name}: metadata.last_changed_at {changed_at} is in the future"
     )
 

--- a/tests/core/agent_harness/session/test_session_characterization.py
+++ b/tests/core/agent_harness/session/test_session_characterization.py
@@ -29,6 +29,7 @@ _CORE_FIELDS = (
     "active_skill",
     "active_skill_tools",
     "questions_already_answered",
+    "skill_question_keys",
     "skill_hooks_fired",
     "skills_already_prompted",
     "task_plan",

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -35,10 +35,7 @@ _TITLE = "Which demo would you like me to run?"
 _REPOSITORY_TITLE = "Which repository should I analyze?"
 _REPOSITORY = "acme/one"
 _REPOSITORY_OPTIONS = (_REPOSITORY, "Tracer-Cloud/opensre")
-_NOTE = (
-    "Choose a demo using your own repositories or connect your team through Slack. "
-    "The managed-service option is coming soon."
-)
+_NOTE = "Choose a demo using your own repositories or connect your team through Slack."
 
 
 def _offerable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -141,7 +138,7 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
 
     def pick(**kwargs: Any) -> str:
         picker_calls.append(kwargs)
-        return GETTING_STARTED_OPTIONS[0]
+        return _REPOSITORY if kwargs["title"] == _REPOSITORY_TITLE else GETTING_STARTED_OPTIONS[0]
 
     asked: list[str] = []
 
@@ -200,8 +197,8 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
     envelope = build_action_system_prompt_envelope(
         TurnSnapshot.from_session(answer, session, surface="interactive_shell")
     )
-    assert "## Follow the selected child" in envelope.render_ephemeral()
-    assert "## Follow the selected child" not in envelope.render_cached()
+    assert "### 2. Load the child" in envelope.render_ephemeral()
+    assert "### 2. Load the child" not in envelope.render_cached()
 
     run_action_tool_turn(answer, session, console, is_tty=True, llm_factory=lambda: llm)
     assert len(scans) == 1
@@ -213,6 +210,33 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
     # Raw-data analysis retains the full catalog for model-selected collection.
     assert session.active_skill_tools == ()
     assert onboarding_outcomes == [("ci_analytics", False)]
+
+    # An explicit new demo may ask the child's repository question again,
+    # while unrelated answered questions remain settled.
+    choice_prompt._cmd_choose(session, console, [])
+    _take_prompt(session)
+    session.questions_already_answered.add("deploy to production?")
+    assert demo_picker.offer_demo(session, console, force=True)
+    _take_prompt(session)
+    choice_prompt._cmd_choose(session, console, [])
+    replay_answer = _take_prompt(session)
+    replay_llm = FakeActionLLM(
+        [
+            tool_response("skill_view", {"name": "analyzing-github-ci-performance"}),
+            tool_response("scan_local_git_workspace"),
+            tool_response(
+                "ask_user_choice",
+                {"title": _REPOSITORY_TITLE, "options": list(_REPOSITORY_OPTIONS)},
+            ),
+        ]
+    )
+    run_action_tool_turn(
+        replay_answer, session, console, is_tty=True, llm_factory=lambda: replay_llm
+    )
+    assert len(scans) == 2
+    assert session.pending_user_choice is not None
+    assert session.pending_user_choice.title == _REPOSITORY_TITLE
+    assert "deploy to production?" in session.questions_already_answered
 
 
 @pytest.mark.parametrize("answer", [None, "Inspect the deployment logs", "/help"])
@@ -272,7 +296,6 @@ def test_onboarding_outcomes_keep_stable_ids_and_exclude_child_menus(
     assert onboarding_outcomes == [
         ("ci_analytics", False),
         ("ci_agent", False),
-        ("remote_managed_service", False),
         ("slack", False),
     ]
 
@@ -350,14 +373,14 @@ def test_startup_and_demo_respect_tty_and_pending_input(monkeypatch: pytest.Monk
 def test_model_load_of_the_master_skill_opens_the_menu_and_ends_the_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Mid-session "what can you do?" needs one model step, not a second one for the menu."""
+    """An explicit demo request loads the skill and lets its hook open the menu."""
     _offerable(monkeypatch)
     session = Session()
     session.resolved_integrations_cache = {}
     console = Console(file=io.StringIO(), highlight=False)
     llm = FakeActionLLM([tool_response("skill_view", {"name": ONBOARDING_SKILL_NAME})])
 
-    run_action_tool_turn("What can you do?", session, console, is_tty=True, llm_factory=lambda: llm)
+    run_action_tool_turn("Show me a demo", session, console, is_tty=True, llm_factory=lambda: llm)
 
     assert llm.invocations == 1
     assert session.active_skill == ONBOARDING_SKILL_NAME
@@ -380,6 +403,27 @@ def test_startup_without_a_menu_hook_does_not_fall_back_to_a_model_turn(
     assert not demo_picker.offer_demo(session, force=True)
     assert session.terminal.pending_prompt_default is None
     assert session.active_skill is None
+
+
+def test_onboarding_losing_its_terminal_ends_without_a_text_menu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _offerable(monkeypatch)
+    session = Session()
+    output = io.StringIO()
+    console = Console(file=output)
+    assert demo_picker.offer_demo(session, console)
+    _take_prompt(session)
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: False)
+
+    choice_prompt._cmd_choose(session, console, [])
+
+    assert "request a task directly" in output.getvalue()
+    assert all(option not in output.getvalue() for option in GETTING_STARTED_OPTIONS)
+    assert session.active_skill is None
+    assert session.pending_user_choice is None
+    assert not session.terminal.awaiting_handoff_answer
+    assert not session.terminal.pending_prompt_default
 
 
 def test_demo_skills_expose_their_intended_tool_scopes() -> None:

--- a/tests/interactive_shell/runtime/test_demo_repository.py
+++ b/tests/interactive_shell/runtime/test_demo_repository.py
@@ -39,7 +39,6 @@ def test_bundled_demos_leave_the_repository_question_to_the_model() -> None:
     assert questions == {
         "analyzing-github-ci-performance": None,
         "scheduling-github-ci-fixes": None,
-        "delegating-github-ci-fixes": None,
         "connecting-slack": None,
     }
 

--- a/tests/interactive_shell/session/test_session_facets.py
+++ b/tests/interactive_shell/session/test_session_facets.py
@@ -16,15 +16,6 @@ from core.domain.alerts.inbox import IncomingAlert
 from surfaces.interactive_shell.session.session import Session
 
 # Core fields are inherited from SessionCore; the shell adds these two facets.
-# Includes pending_schedule_offer (structured yes → /cron confirmations),
-# pending_user_choice (structured decision → /choose selection menu), and
-# pending_recovery_note (WAL recovery note for the first turn after /resume),
-# plus the session-goal trio (session_goal, pending_integration_setup_offer,
-# offered_upgrade_ctas), and the host-owned task-plan work log
-# (task_plan_work, task_plan_work_step_texts, task_plan_breakdown_emitted),
-# and the two 'do not ask twice' sets (questions_already_answered,
-# skills_already_prompted).
-_CORE_FIELD_COUNT = 34
 _FACET_FIELDS = ("alerts", "terminal")
 
 
@@ -35,9 +26,8 @@ def _session() -> Session:
 def test_session_is_a_session_core_with_two_facets() -> None:
     assert issubclass(Session, SessionCore)
     field_names = {f.name for f in dataclasses.fields(Session)}
-    assert "terminal" in field_names
-    assert "alerts" in field_names
-    assert len(field_names) == _CORE_FIELD_COUNT + len(_FACET_FIELDS)
+    core_field_names = {f.name for f in dataclasses.fields(SessionCore)}
+    assert field_names == core_field_names | set(_FACET_FIELDS)
 
 
 def test_alert_inbox_facet_holds_the_relocated_alert_state() -> None:

--- a/tests/tools/interactive_shell/test_skill_entry.py
+++ b/tests/tools/interactive_shell/test_skill_entry.py
@@ -278,10 +278,12 @@ def test_a_fresh_session_forgets_what_was_answered() -> None:
     session = Session()
     enter_skill(ONBOARDING_SKILL_NAME, _scope(session))
     session.questions_already_answered.add("which demo would you like me to run? (esc to skip)")
+    assert session.skill_question_keys
 
     # Act
     session.clear()
 
     # Assert
     assert session.questions_already_answered == set()
+    assert session.skill_question_keys == {}
     assert session.skills_already_prompted == set()

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -38,7 +38,8 @@ _CHOOSE_COMMAND = "/choose"
 _DEFAULT_HEADER = "Ask User"
 
 _FALLBACK_INSTRUCTION = (
-    "No interactive selection menu is available on this surface. If the choice "
+    "No interactive selection menu is available on this surface. Follow the "
+    "active skill's unavailable-menu instructions first. Otherwise, if the choice "
     "is required for work to continue, present a short numbered list and ask "
     "the user to reply. If this was only an optional follow-up, do NOT park a "
     "numbered question — finish with one sentence of instructions."
@@ -291,6 +292,10 @@ def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolScope) -> 
         return {"ok": True, "menu": "unavailable", "instruction": _FALLBACK_INSTRUCTION}
 
     ctx.session.pending_user_choice = pending
+    skill = getattr(ctx.session, "active_skill", None)
+    by_skill = getattr(ctx.session, "skill_question_keys", None)
+    if skill and isinstance(by_skill, dict):
+        by_skill.setdefault(skill, set()).update(question_key(q.title) for q in pending.items())
     if questions:
         ctx.session.ask_user_rounds = getattr(ctx.session, "ask_user_rounds", 0) + 1
     set_auto_command(ctx.session, _CHOOSE_COMMAND)
@@ -343,7 +348,8 @@ ask_user_choice_tool = RegisteredTool(
         "user what you are about to ask and that they can type their own "
         "answer if none fit. The menu opens after the turn ends; answers "
         "arrive verbatim as the next user message. If the result says the "
-        "menu is unavailable, fall back to a numbered list."
+        "menu is unavailable, follow the active skill's recovery instructions; "
+        "otherwise fall back to a numbered list."
     ),
     use_cases=[
         (


### PR DESCRIPTION
User-requested onboarding improvement; no existing issue.

#### Describe the changes you have made in this PR -

Onboarding now resolves a demo choice and hands execution to its child, with explicit completion conditions and child-owned live progress. Capability questions receive an answer and an offer to run `/demo`; explicit specialist requests go directly to their skill. An unavailable picker ends guided onboarding without a text-menu replacement, and failed child loading retains the choice without claiming a completed handoff.

The picker offers CI analysis, scheduling, Slack, and Skip. Managed-service availability remains directly accessible as a skill but is no longer a selectable demo. Skill names remain unchanged; Slack's directory and menu order now match its third position.

An explicit `/demo` starts a fresh run. Session question ownership allows the child to ask its questions again while preserving unrelated answered questions. A real-loop regression reproduced the previous failure: the top-level picker reopened, but the child's already-answered repository question was refused. The analytics child's existing scan, repository picker, and five-step plan are unchanged. Session-facet tests now compare the actual inherited field set, and skill metadata accepts the current calendar date in any editor timezone while continuing to reject future dates.

### Demo/Screenshot for feature changes and bug fixes -

Actual menu loaded from the bundled skill:

```text
Which demo would you like me to run?
1. Explore a repo and analyze its CI/CD performance (recommended)
2. Set up an agent that improves CI/CD reliability over time
3. Connect OpenSRE to Slack and hand off DevOps chores for your team
4. Skip the demo and open the shell
```

Offline real-loop coverage verifies that the entry hook pauses execution until selection, the selected child begins work in the answer turn, and a fresh demo can repeat the repository question. Terminal-loss coverage verifies that onboarding exits without rendering a fallback list. These use scripted model responses and real skill loading/hooks; natural-language routing changes were additionally forward-reviewed against the assembled instructions.

Validation:

- `make lint`
- `make format-check`
- `make typecheck` — 1,865 source files
- `uv run python -m pytest core/agent_harness/prompts/skills/ tests/core/agent_harness/prompts/ tests/core/agent/prompts/ tests/core/agent_harness/session/ tests/interactive_shell/runtime/test_demo_picker.py tests/interactive_shell/command_registry/test_choice_prompt_skip.py tests/tools/interactive_shell/test_skill_entry.py tests/packaging/test_release_manifest.py -q` — 239 passed, 1 existing xfailed
- `uv run python -m pytest tests/core/agent/orchestration/test_ask_choice_tool.py tests/core/agent/orchestration/test_menu_turn_end.py tests/interactive_shell/command_registry/test_choice_prompt_demo_repository.py tests/interactive_shell/command_registry/test_slash_catalog.py tests/shared/test_surface_border.py tests/shared/test_integrations_api_border.py tests/shared/test_tool_api_border.py -q` — 59 passed

- `TZ=UTC uv run python -m pytest tests/interactive_shell/runtime/test_demo_repository.py tests/interactive_shell/session/test_session_facets.py tests/core/agent_harness/prompts/test_skill_metadata.py tests/core/agent/orchestration/test_action_prompt.py -q` — 49 passed; reproduces and covers the first CI run's failures

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Codex implemented and self-reviewed this change after a user-approved design interview. Human review remains pending. The router owns selection and skill loading, while each child retains its execution, prerequisites, and authorization. Shared prompt rules agree with those boundaries. Runtime changes are limited to tracking queued question ownership for fresh demo runs and ending onboarding if its terminal becomes unavailable; existing plan-completion rules are preserved.

---

## Checklist before requesting a review
- [x] I have added a proper PR title (user-requested work; no existing issue)
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
