### PR TITLE
test: trim colocated plugin docstring to the contract

### DIFF
--- a/tests/colocated_skill_tests_plugin.py
+++ b/tests/colocated_skill_tests_plugin.py
@@ -1,21 +1,11 @@
 """Keep pytest's importlib mode from re-executing the skills package.
 
-Tests colocated beside a ``SKILL.md`` live under hyphenated directories that
-``import_module`` cannot resolve, so pytest imports them by file path and first
-spec-imports every ancestor package that is missing from ``sys.modules``.
-Executing ``core/agent_harness/prompts/__init__.py`` that way imports
-``skills`` through the regular import system, after which pytest executes
-``skills/__init__.py`` a second time as a fresh module object. That copy never
-receives its ``loader`` attribute (the submodule was already loaded, so the
-import system does not bind it again) and it is the copy left registered, so
-``monkeypatch.setattr("core.agent_harness.prompts.skills.loader.x", ...)``
-fails on any xdist worker that collected a colocated test before importing
-the package normally.
-
-Importing the package here, before collection, leaves pytest nothing to
-re-execute: it only creates namespace stand-ins for the hyphenated
-directories. The collection-finish hook turns any recurrence into a hard
-error instead of an order-dependent failure elsewhere in the run.
+Tests colocated under hyphenated skill directories are imported by file path,
+and pytest spec-imports any ancestor package still missing from
+``sys.modules`` — a second execution of a package that is already importable.
+Importing the package before collection prevents that; the collection-finish
+hook fails the session if a guarded submodule is not the object its parent
+package binds.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Follow-up to #6216, which merged before this commit was pushed. Trims the module docstring of `tests/colocated_skill_tests_plugin.py` to the contract (what the plugin guarantees and why the eager import is needed), moving the bug narration out per `AGENTS.md`'s docstring rule. Addresses the Greptile P2 on #6216. No behaviour change.

### Demo/Screenshot for feature changes and bug fixes -

```
$ git diff --stat HEAD~1
 tests/colocated_skill_tests_plugin.py | 22 ++++++----------------
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Docstring-only change; the history it used to narrate lives in the #6216 commit message and PR description.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
