### PR TITLE
fix: isolate CI repair counter caches and lazy exports

### DIFF
--- a/integrations/github/__init__.py
+++ b/integrations/github/__init__.py
@@ -12,10 +12,11 @@ import importlib
 from typing import TYPE_CHECKING
 
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
-from integrations.github.tools.ci_fix.ledger import count_ci_fixes, get_ci_fix_counter
 
 #: Public name -> the submodule that defines it, imported on first access.
 _LAZY_EXPORTS: dict[str, str] = {
+    "count_ci_fixes": "integrations.github.tools.ci_fix.ledger",
+    "get_ci_fix_counter": "integrations.github.tools.ci_fix.ledger",
     "github_creds": "integrations.github.helpers",
     "saved_github_username": "integrations.github.identity",
     "GitHubLoginResult": "integrations.github.login",
@@ -102,6 +103,7 @@ if TYPE_CHECKING:
         schedule_ci_reliability_loop,
     )
     from integrations.github.tools.ci_analytics.render import ci_report_headline
+    from integrations.github.tools.ci_fix.ledger import count_ci_fixes, get_ci_fix_counter
 
 
 __all__ = [

--- a/integrations/github/tools/ci_fix/ledger.py
+++ b/integrations/github/tools/ci_fix/ledger.py
@@ -91,9 +91,24 @@ class CiFixCounter:
             except Exception:
                 logger.debug("CI fix count listener failed", exc_info=True)
 
+    def reset(self) -> None:
+        """Discard cached identities and listeners without modifying the ledger."""
+        with self._lock:
+            self._identities.clear()
+            self._listeners.clear()
+            self._known = False
+
 
 _counters: dict[Path, CiFixCounter] = {}
 _counters_lock = RLock()
+
+
+def reset_ci_fix_counters() -> None:
+    """Clear process caches and subscriptions when no repairs are in flight."""
+    with _counters_lock:
+        for counter in _counters.values():
+            counter.reset()
+        _counters.clear()
 
 
 def get_ci_fix_counter() -> CiFixCounter:
@@ -146,4 +161,10 @@ def _repair_identity(output: Mapping[str, object]) -> str | None:
     return hashlib.sha256(json.dumps(parts, separators=(",", ":")).encode()).hexdigest()
 
 
-__all__ = ["CiFixCounter", "count_ci_fixes", "get_ci_fix_counter", "record_ci_fix_outcome"]
+__all__ = [
+    "CiFixCounter",
+    "count_ci_fixes",
+    "get_ci_fix_counter",
+    "record_ci_fix_outcome",
+    "reset_ci_fix_counters",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from collections.abc import Iterator
 
 import pytest
@@ -144,6 +145,22 @@ def _isolate_opensre_home_files(request, monkeypatch, tmp_path) -> None:
     # secret would otherwise land it in the developer's
     # ~/.opensre/credentials.json.
     monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path / "opensre-home")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ci_fix_counters() -> Iterator[None]:
+    """Release counter caches and listeners without importing unused GitHub modules."""
+
+    def reset() -> None:
+        ledger = sys.modules.get("integrations.github.tools.ci_fix.ledger")
+        if ledger is not None:
+            ledger.reset_ci_fix_counters()
+
+    reset()
+    try:
+        yield
+    finally:
+        reset()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integrations/github/test_ci_fix_ledger.py
+++ b/tests/integrations/github/test_ci_fix_ledger.py
@@ -29,6 +29,18 @@ def _outcome(**changes: object) -> dict[str, object]:
     }
 
 
+def test_public_api_uses_the_same_process_counter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import integrations.github as github
+
+    monkeypatch.setenv(CI_FIX_LEDGER_PATH_ENV, str(tmp_path / "ci_fixes.json"))
+    counter = github.get_ci_fix_counter()
+    assert counter is ledger.get_ci_fix_counter()
+    counter.record("a" * 64)
+    assert github.count_ci_fixes() == 1
+
+
 def test_only_verified_identifiable_repairs_count(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -55,6 +67,26 @@ def test_only_verified_identifiable_repairs_count(
     assert len(data["fixes"]) == len(set(data["fixes"])) == 5
     assert all(len(identity) == 64 for identity in data["fixes"])
     assert "Example" not in path.read_text()
+
+
+def test_reset_releases_cached_counts_and_listeners(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(CI_FIX_LEDGER_PATH_ENV, str(tmp_path / "ci_fixes.json"))
+    counter = ledger.get_ci_fix_counter()
+    observed: list[int] = []
+    stop = counter.subscribe(lambda: observed.append(counter.count()))
+    counter.record("a" * 64)
+    ledger.reset_ci_fix_counters()
+
+    replacement = ledger.get_ci_fix_counter()
+    assert replacement is not counter
+    assert replacement.count() == 1
+    assert counter.count() == 0
+    counter.reload()
+    replacement.record("b" * 64)
+    assert observed == [1]
+    stop()
 
 
 def test_failed_save_updates_memory_before_io_and_reconciles_without_duplicates(

--- a/tests/interactive_shell/ui/test_banner_launch_status_imports.py
+++ b/tests/interactive_shell/ui/test_banner_launch_status_imports.py
@@ -10,6 +10,8 @@ def test_load_launch_status_does_not_import_skill_harness() -> None:
     """Skills chip is a filesystem count — not ``list_action_skills`` / prompt_toolkit."""
     probe = (
         "import sys; "
+        "import integrations.github; "
+        "print('EAGER_LEDGER', 'integrations.github.tools.ci_fix.ledger' in sys.modules); "
         "from surfaces.shared.terminal.banner.banner_state import load_launch_status; "
         "status = load_launch_status(); "
         "heavy = [n for n in sys.modules if n == 'prompt_toolkit' "
@@ -25,4 +27,5 @@ def test_load_launch_status_does_not_import_skill_harness() -> None:
         check=True,
     )
     assert "HEAVY none" in result.stdout, result.stdout + result.stderr
+    assert "EAGER_LEDGER False" in result.stdout, result.stdout + result.stderr
     assert "STATUS" in result.stdout


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Follow-up to #6219: the new process-wide CI repair counter retained cached identities and listeners across tests, and its public GitHub exports loaded the ledger eagerly.

Add a deterministic reset hook for the counter registry, cached state, and subscriptions. The pytest fixture invokes it before and after tests only when the ledger module is already loaded. Export the counter APIs through the GitHub package's existing lazy mechanism, keeping ordinary GitHub imports free of the counter's storage dependencies.

Regression tests verify that resetting releases old state/listeners while preserving the disk ledger, public APIs share the same counter, and a fresh GitHub import does not load the ledger. The public API characterization test passed before changing export loading.

### Demo/Screenshot for feature changes and bug fixes -

Validation output from the final implementation:
```text
519 passed in 9.24s
All checks passed!
3231 files already formatted
Success: no issues found in 1870 source files
```

Commands:
```bash
make lint
make format-check
make typecheck
uv run python -m pytest tests/integrations/github/ tests/tools/test_github_ci_fix.py tests/tools/test_github_ci_fix_verification.py tests/interactive_shell/ui/ tests/shared/test_integrations_api_border.py tests/config/test_package_exports.py -q
```
The branch was based on the merged #6219 commit; its resulting tree matches the locally validated revision exactly.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Implemented and reviewed by Codex. Resetting is explicitly restricted to periods with no repairs in flight and never modifies persisted data. The fixture checks already-loaded modules so unrelated tests do not acquire new imports. Existing public counter behavior remains characterized while the package defers loading until the APIs are requested.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue (follow-up to #6219)
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
