### PR TITLE
fix(shell): open the shell on your own model when you have no OpenSRE account

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ opensre setup
 
 Webapp contributors can run `opensre setup --dev` to authenticate through `http://localhost:3000`.
 
-**Interactive shell** — with no subcommand, `opensre` validates your account and starts a REPL (TTY required). You can exit and stay signed out, but the shell only opens for an active account. Describe incidents in plain language, watch the agent work, and use slash commands for session control (`/help`, `/status`, `/cost`, `/sessions`, `/resume`, `/compact`, `/new`, `/exit`), integrations (`/integrations list`, `/integrations verify`), and local agent fleet monitoring (`/agents`). Ctrl+C cancels an in-flight turn without losing session state. See **[interactive shell commands](https://www.opensre.com/docs/interactive-shell-commands)** for the full reference.
+**Interactive shell** — with no subcommand, `opensre` validates your account and starts a REPL (TTY required). You can exit and stay signed out; the shell also opens signed out on your own LLM provider once you configure one. Describe incidents in plain language, watch the agent work, and use slash commands for session control (`/help`, `/status`, `/cost`, `/sessions`, `/resume`, `/compact`, `/new`, `/exit`), integrations (`/integrations list`, `/integrations verify`), and local agent fleet monitoring (`/agents`). Ctrl+C cancels an in-flight turn without losing session state. See **[interactive shell commands](https://www.opensre.com/docs/interactive-shell-commands)** for the full reference.
 
 ```bash
 opensre

--- a/config/account.py
+++ b/config/account.py
@@ -200,6 +200,11 @@ def ignore_account_llm_route() -> None:
     os.environ[OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV] = "1"
 
 
+def restore_account_llm_route() -> None:
+    """Re-enable the hosted route after a login replaces the rejected session."""
+    os.environ.pop(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, None)
+
+
 def account_llm_route() -> AccountLLMRoute | None:
     """Return the hosted OpenAI route only when account metadata and token exist.
 
@@ -224,6 +229,7 @@ __all__ = [
     "AccountLLMRoute",
     "account_llm_route",
     "ignore_account_llm_route",
+    "restore_account_llm_route",
     "account_metadata_path",
     "delete_account_record",
     "delete_account_token",

--- a/config/account.py
+++ b/config/account.py
@@ -31,6 +31,8 @@ from config.secrets.store import (
 )
 
 _VERSION = 1
+#: Matches config.repl_config: an env flag is off unless set to something truthy.
+_FALSE_VALUES = ("", "0", "false", "off", "no")
 _LOCK_TIMEOUT_SECONDS = 10.0
 
 
@@ -206,8 +208,13 @@ def restore_account_llm_route() -> None:
 
 
 def account_llm_route_ignored() -> bool:
-    """Whether this process dropped the hosted route in favour of the user's own model."""
-    return bool(os.getenv(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, "").strip())
+    """Whether this process dropped the hosted route in favour of the user's own model.
+
+    Parsed like the repo's other boolean env settings: the variable is documented
+    for users now, so ``=0`` or ``=false`` must read as off rather than silently
+    routing them away from their account.
+    """
+    return os.getenv(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, "").strip().lower() not in _FALSE_VALUES
 
 
 def account_llm_route() -> AccountLLMRoute | None:

--- a/config/account.py
+++ b/config/account.py
@@ -205,6 +205,11 @@ def restore_account_llm_route() -> None:
     os.environ.pop(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, None)
 
 
+def account_llm_route_ignored() -> bool:
+    """Whether this process dropped the hosted route in favour of the user's own model."""
+    return bool(os.getenv(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, "").strip())
+
+
 def account_llm_route() -> AccountLLMRoute | None:
     """Return the hosted OpenAI route only when account metadata and token exist.
 
@@ -213,7 +218,7 @@ def account_llm_route() -> AccountLLMRoute | None:
     that let the user pick a local provider instead first call
     :func:`ignore_account_llm_route`.
     """
-    if os.getenv(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, "").strip():
+    if account_llm_route_ignored():
         return None
     record = load_account_record()
     if record is None or record.llm_provider != "openai" or not resolve_account_token():
@@ -228,6 +233,7 @@ __all__ = [
     "AccountRecord",
     "AccountLLMRoute",
     "account_llm_route",
+    "account_llm_route_ignored",
     "ignore_account_llm_route",
     "restore_account_llm_route",
     "account_metadata_path",

--- a/config/account.py
+++ b/config/account.py
@@ -20,6 +20,7 @@ from config.constants.account import (
     OPENSRE_ACCOUNT_TOKEN_ENV,
     OPENSRE_APP_URL_DEFAULT,
     OPENSRE_APP_URL_ENV,
+    OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV,
 )
 from config.constants.paths import host_home
 from config.secrets.store import (
@@ -194,8 +195,21 @@ def delete_account_token() -> None:
     delete_secret(OPENSRE_ACCOUNT_TOKEN_ENV)
 
 
+def ignore_account_llm_route() -> None:
+    """Drop the hosted route for this process; the user chose their own model."""
+    os.environ[OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV] = "1"
+
+
 def account_llm_route() -> AccountLLMRoute | None:
-    """Return the hosted OpenAI route only when account metadata and token exist."""
+    """Return the hosted OpenAI route only when account metadata and token exist.
+
+    A session the webapp rejected or could not validate still leaves its record
+    and token on disk, so the route outlives the sign-in it came from. Callers
+    that let the user pick a local provider instead first call
+    :func:`ignore_account_llm_route`.
+    """
+    if os.getenv(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, "").strip():
+        return None
     record = load_account_record()
     if record is None or record.llm_provider != "openai" or not resolve_account_token():
         return None
@@ -209,6 +223,7 @@ __all__ = [
     "AccountRecord",
     "AccountLLMRoute",
     "account_llm_route",
+    "ignore_account_llm_route",
     "account_metadata_path",
     "delete_account_record",
     "delete_account_token",

--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -766,6 +766,9 @@ if TYPE_CHECKING:
         RELEASES_API_URL_ENV as RELEASES_API_URL_ENV,
     )
     from config.constants.product import (
+        SIGN_IN_OR_OWN_MODEL_PROMPT as SIGN_IN_OR_OWN_MODEL_PROMPT,
+    )
+    from config.constants.product import (
         SIGN_IN_PROMPT as SIGN_IN_PROMPT,
     )
     from config.constants.product import (

--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
     from config.constants.account import (
         OPENSRE_APP_URL_ENV as OPENSRE_APP_URL_ENV,
     )
+    from config.constants.account import (
+        OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV as OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV,
+    )
     from config.constants.alertmanager import (
         ALERTMANAGER_BEARER_TOKEN_ENV as ALERTMANAGER_BEARER_TOKEN_ENV,
     )

--- a/config/constants/account.py
+++ b/config/constants/account.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 OPENSRE_ACCOUNT_FILENAME = "account.json"
 OPENSRE_ACCOUNT_METADATA_PATH_ENV = "OPENSRE_ACCOUNT_METADATA_PATH"
 OPENSRE_ACCOUNT_TOKEN_ENV = "OPENSRE_ACCOUNT_TOKEN"
+#: Set for this process when the user chooses their own model over a stored
+#: hosted route, so an expired or unreachable session cannot silently win.
+OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV = "OPENSRE_IGNORE_ACCOUNT_ROUTE"
 OPENSRE_ACCOUNT_LLM_BASE_PATH = "/api/llm/v1"
 OPENSRE_ACCOUNT_LOGIN_PATH = "/cli/auth/start"
 OPENSRE_ACCOUNT_LOGIN_SUCCESS_PATH = "/cli/auth/success"
@@ -25,6 +28,7 @@ __all__ = [
     "OPENSRE_ACCOUNT_EXCHANGE_PATH",
     "OPENSRE_ACCOUNT_HTTP_TIMEOUT_SECONDS",
     "OPENSRE_ACCOUNT_TOKEN_ENV",
+    "OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV",
     "OPENSRE_ACCOUNT_SESSION_PATH",
     "OPENSRE_ACCOUNT_USAGE_PATH",
     "OPENSRE_APP_URL_DEFAULT",

--- a/config/constants/exports.py
+++ b/config/constants/exports.py
@@ -310,6 +310,7 @@ EXPORTS: dict[str, str] = {
     "RELEASE_STAGE": "product",
     "RELEASE_STAGE_BANNER": "product",
     "RELEASES_API_URL_ENV": "product",
+    "SIGN_IN_OR_OWN_MODEL_PROMPT": "product",
     "SIGN_IN_PROMPT": "product",
     "UV_RUN_RECURSION_DEPTH_ENV": "product",
     "WELCOME_DESCRIPTION": "product",

--- a/config/constants/exports.py
+++ b/config/constants/exports.py
@@ -23,6 +23,7 @@ EXPORTS: dict[str, str] = {
     "OPENSRE_APP_URL_DEFAULT": "account",
     "OPENSRE_APP_URL_DEV": "account",
     "OPENSRE_APP_URL_ENV": "account",
+    "OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV": "account",
     # analytics
     "ANALYTICS_DISABLED_ENV": "analytics",
     "ANALYTICS_EVENT_SCHEMA_VERSION": "analytics",

--- a/config/constants/product.py
+++ b/config/constants/product.py
@@ -23,6 +23,12 @@ WELCOME_DESCRIPTION: Final[str] = (
 )
 SIGN_IN_PROMPT: Final[str] = "Sign in or create an OpenSRE account to use the interactive shell."
 
+#: Replaces :data:`SIGN_IN_PROMPT` when the gate can also offer the user's own
+#: provider, where an account is one way in rather than the only one.
+SIGN_IN_OR_OWN_MODEL_PROMPT: Final[str] = (
+    "Sign in to OpenSRE, or continue with the model you already configured."
+)
+
 #: Release maturity, as users see it. Keep in step with the README badge.
 RELEASE_STAGE: Final[str] = "Public Alpha"
 
@@ -48,6 +54,7 @@ __all__ = [
     "RELEASES_API_URL_ENV",
     "RELEASE_STAGE",
     "RELEASE_STAGE_BANNER",
+    "SIGN_IN_OR_OWN_MODEL_PROMPT",
     "SIGN_IN_PROMPT",
     "UV_RUN_RECURSION_DEPTH_ENV",
     "WELCOME_DESCRIPTION",

--- a/config/llm_settings.py
+++ b/config/llm_settings.py
@@ -98,6 +98,7 @@ __all__ = (
     "get_configured_llm_provider",
     "get_llm_provider_api_key_env",
     "has_credentials_for_active_llm_provider",
+    "has_user_configured_llm_provider",
     "llm_provider_error_context",
     "resolve_llm_settings",
     "resolve_llm_settings_verbose",
@@ -486,4 +487,20 @@ def has_credentials_for_active_llm_provider() -> bool:
     """Return prompt-safe auth availability for the configured LLM provider."""
     settings = resolve_llm_settings()
     auth_status = credential_status(settings.provider)
+    return auth_status.configured and not auth_status.stale
+
+
+def has_user_configured_llm_provider() -> bool:
+    """Return whether the user picked their own LLM provider and it has credentials.
+
+    "Own" means ``LLM_PROVIDER`` is set explicitly, in the environment or the
+    persisted ``.env`` the wizard writes. The built-in default provider does not
+    count, so a fresh install reports False and callers cannot mistake it for a
+    deliberate choice.
+    """
+    bootstrap_opensre_env(override=False)
+    provider = os.getenv(LLM_PROVIDER_ENV, "").strip().lower()
+    if not provider:
+        return False
+    auth_status = credential_status(provider)
     return auth_status.configured and not auth_status.stale

--- a/config/llm_settings.py
+++ b/config/llm_settings.py
@@ -499,8 +499,14 @@ def has_user_configured_llm_provider() -> bool:
     deliberate choice.
     """
     bootstrap_opensre_env(override=False)
-    provider = os.getenv(LLM_PROVIDER_ENV, "").strip().lower()
-    if not provider:
+    if not os.getenv(LLM_PROVIDER_ENV, "").strip():
         return False
-    auth_status = credential_status(provider)
+    try:
+        settings = resolve_llm_settings()
+    except Exception:
+        # Credentials alone do not make a provider usable: azure-openai needs an
+        # endpoint, vertex-ai a project. Resolving here keeps callers from
+        # offering a route that fails on the first turn.
+        return False
+    auth_status = credential_status(settings.provider)
     return auth_status.configured and not auth_status.stale

--- a/config/llm_settings.py
+++ b/config/llm_settings.py
@@ -490,6 +490,23 @@ def has_credentials_for_active_llm_provider() -> bool:
     return auth_status.configured and not auth_status.stale
 
 
+def _provider_credential_is_readable(provider: str) -> bool:
+    """Confirm the credential can actually be read, not merely that a record exists.
+
+    ``credential_status`` is contractually barred from reading secrets, so it
+    calls an API-key provider configured on the strength of its non-secret
+    record alone. That record outlives the secret (keyring disabled, credentials
+    file deleted), and acting on it hands the user a shell that fails its first
+    turn. Keyless kinds (CLI, ambient, local) resolve without touching storage.
+    """
+    from config.llm_auth.credentials import resolve_for_request
+
+    try:
+        return bool(resolve_for_request(provider).ok)
+    except Exception:
+        return False
+
+
 def has_user_configured_llm_provider() -> bool:
     """Return whether the user picked their own LLM provider and it has credentials.
 
@@ -509,4 +526,6 @@ def has_user_configured_llm_provider() -> bool:
         # offering a route that fails on the first turn.
         return False
     auth_status = credential_status(settings.provider)
-    return auth_status.configured and not auth_status.stale
+    if not auth_status.configured or auth_status.stale:
+        return False
+    return _provider_credential_is_readable(settings.provider)

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -60,8 +60,9 @@ description: "Common questions about OpenSRE."
 
   <Accordion title="What happens when I run opensre with no arguments?">
     Running `opensre` validates your OpenSRE account, then starts the interactive
-    shell. You can exit and stay signed out, but an inactive account cannot enter
-    the shell. Once signed in, you can describe issues in plain language. Slash
+    shell. Without an account you can still enter the shell on your own model, as
+    long as you configured a provider first (`opensre onboard local_llm` for a
+    local Ollama model). Once signed in, you can describe issues in plain language. Slash
     commands such as `/help`, `/status`, and `/verify datadog` are documented in
     [Shell commands](/interactive-shell-commands).
   </Accordion>

--- a/docs/install-local.mdx
+++ b/docs/install-local.mdx
@@ -69,7 +69,7 @@ When developing the webapp locally on port 3000, use:
 opensre setup --dev
 ```
 
-To remain signed out, cancel setup or choose **Exit and stay signed out** when `opensre` shows the account gate. Other CLI commands remain available; the interactive shell does not.
+To remain signed out, cancel setup or choose **Exit and stay signed out** when `opensre` shows the account gate. Other CLI commands remain available. The shell itself opens signed out only when you configured your own provider, which the gate then offers as **Continue with my own model**.
 
 ## 3. Open the shell
 

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -107,6 +107,7 @@ Full walkthrough with GIFs: [Quickstart](/quickstart).
 - **Command not found** — open a new terminal, or add the bin directory the installer printed to your PATH
 - **The shell keeps asking you to sign in** — run `opensre account status`; expired, revoked, incomplete, or unreachable sessions do not open the shell
 - **You want a local model instead of the hosted one** — run `opensre onboard local_llm`, then `opensre account logout`; the sign-in screen then offers "Continue with my own model"
+- **`opensre ask` fails with a connection error after a session expires** — the stored session still routes the model even once it stops validating. Run `opensre account logout`, or prefix a single command with `OPENSRE_IGNORE_ACCOUNT_ROUTE=1` to use your own provider instead
 - **Docker / `make` missing** — see [Quickstart troubleshooting](/quickstart#troubleshooting)
 
 Need deploy options beyond a laptop binary? See [Deployment](/deployment).

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -10,7 +10,7 @@ This page gets the `opensre` command onto your laptop or server, then walks you 
 After install, you have:
 
 - The `opensre` CLI on your PATH
-- An account-gated interactive shell when you run `opensre` with no arguments
+- An account-gated interactive shell when you run `opensre` with no arguments, or a signed-out shell on your own model once you configure a provider
 - A short webapp sign-in that also activates the OpenSRE-hosted model
 
 No sudo required on macOS/Linux in the usual case — the installer puts the binary somewhere writable (often `~/.local/bin`) and tells you if you need a PATH tweak.
@@ -106,6 +106,7 @@ Full walkthrough with GIFs: [Quickstart](/quickstart).
 
 - **Command not found** — open a new terminal, or add the bin directory the installer printed to your PATH
 - **The shell keeps asking you to sign in** — run `opensre account status`; expired, revoked, incomplete, or unreachable sessions do not open the shell
+- **You want a local model instead of the hosted one** — run `opensre onboard local_llm`, then `opensre account logout`; the sign-in screen then offers "Continue with my own model"
 - **Docker / `make` missing** — see [Quickstart troubleshooting](/quickstart#troubleshooting)
 
 Need deploy options beyond a laptop binary? See [Deployment](/deployment).

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -573,7 +573,7 @@ MCP-capable integrations only (subset of the full integration catalog).
 
 <Accordion title="/model">
 
-Show the active hosted model. An authenticated interactive shell is account-managed, so local provider/model changes are locked until sign-out; signing out closes the shell.
+Show the active hosted model. An authenticated interactive shell is account-managed, so local provider/model changes are locked until sign-out. To run your own model, configure a provider first (`opensre onboard local_llm` for Ollama), then sign out. `/account logout` keeps the shell open on that provider, and the startup sign-in screen offers "Continue with my own model".
 
 ```text
 /model show
@@ -833,7 +833,7 @@ These spawn `opensre …` subprocesses. Output is captured into the REPL buffer 
 /account logout
 ```
 
-Sign in to a personal OpenSRE account, inspect the local login, open the credits and top-up page (`/account usage`, opens your browser; from a chat it replies with the link), or sign out. Same as `opensre account`. The browser opens the OpenSRE sign-up page, where you can use email or any enabled sign-in provider. The shell starts only for an `active` account state. `/account logout` revokes the saved session, invalidates the hosted-model route, and closes the shell before another turn. If `OPENSRE_ACCOUNT_TOKEN` is set in the environment, it overrides the token saved by login until you unset it.
+Sign in to a personal OpenSRE account, inspect the local login, open the credits and top-up page (`/account usage`, opens your browser; from a chat it replies with the link), or sign out. Same as `opensre account`. The browser opens the OpenSRE sign-up page, where you can use email or any enabled sign-in provider. The shell starts only for an `active` account state. `/account logout` revokes the saved session and invalidates the hosted-model route. The shell then closes, unless you configured your own LLM provider, in which case it stays open on that provider. If `OPENSRE_ACCOUNT_TOKEN` is set in the environment, it overrides the token saved by login until you unset it.
 
 </Accordion>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -85,7 +85,7 @@ slug: "quickstart"
   <Step title="Ask your first question">
     Choose either path — both use the same local `opensre` binary:
 
-    **Interactive prompt shell** — start OpenSRE with no arguments (TTY). The shell opens only after the webapp validates your account; choosing **Exit and stay signed out** leaves account-independent CLI commands available:
+    **Interactive prompt shell** — start OpenSRE with no arguments (TTY). The shell opens after the webapp validates your account, or on your own configured provider via **Continue with my own model**; choosing **Exit and stay signed out** leaves account-independent CLI commands available:
 
     ```bash
     opensre
@@ -147,4 +147,4 @@ opensre uninstall --yes
 - **Docker is not running**: Start Docker Desktop, OrbStack, or Colima before running setup.
 - **`make` is missing**: Install it via your package manager (`brew install make` on macOS, `choco install make` on Windows).
 - **The shell does not open after login**: Run `opensre account status`. The webapp must be reachable and the stored account token and metadata must both be valid.
-- **You want to stay signed out**: Choose **Exit and stay signed out** at startup. Commands such as `opensre account`, `opensre doctor`, and `opensre integrations` remain available, but the interactive shell stays closed.
+- **You want to stay signed out**: Choose **Exit and stay signed out** at startup. Commands such as `opensre account`, `opensre doctor`, and `opensre integrations` remain available, and the shell stays closed unless you configured your own provider and pick **Continue with my own model**.

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -258,8 +258,14 @@ def _cmd_account(session: Session, console: Console, args: list[str]) -> bool:  
     )
     if subcommand == "logout" and session_terminal(session) is not None:
         from config.account import account_llm_route
+        from config.llm_settings import has_user_configured_llm_provider
 
         if account_llm_route() is None:
+            # Logging out to reach a local model is the documented route off the
+            # hosted lock, so keep the shell open when the user has a provider.
+            if has_user_configured_llm_provider():
+                console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
+                return handled
             console.print(f"[{DIM}]Signed out. Closing the interactive shell.[/]")
             return False
     return handled

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -256,6 +256,14 @@ def _cmd_account(session: Session, console: Console, args: list[str]) -> bool:  
     handled = run_cli_command(
         console, ["account", *cli_args], capture_output=capture_output, session=session
     )
+    if subcommand == "login" and handled:
+        from config.account import restore_account_llm_route
+        from surfaces.shared.account_session import account_status
+
+        if account_status().authenticated:
+            # A signed-in shell is hosted-routed again, even if the user entered
+            # it earlier by choosing their own model.
+            restore_account_llm_route()
     if subcommand == "logout" and session_terminal(session) is not None:
         from config.account import account_llm_route
         from config.llm_settings import has_user_configured_llm_provider

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -272,7 +272,9 @@ def _cmd_account(session: Session, console: Console, args: list[str]) -> bool:  
             # Logging out to reach a local model is the documented route off the
             # hosted lock, so keep the shell open when the user has a provider.
             if has_user_configured_llm_provider():
-                console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
+                from surfaces.interactive_shell.ui.sign_in import render_own_model_notice
+
+                render_own_model_notice(console)
                 return handled
             console.print(f"[{DIM}]Signed out. Closing the interactive shell.[/]")
             return False

--- a/surfaces/interactive_shell/command_registry/model/switching.py
+++ b/surfaces/interactive_shell/command_registry/model/switching.py
@@ -16,6 +16,7 @@ from surfaces.shared.terminal.components.choice_menu import print_valid_choice_l
 def _account_model_change_is_locked(console: Console) -> bool:
     """Explain and enforce the hosted model lock for signed-in accounts."""
     from config.account import account_llm_route
+    from config.llm_settings import has_user_configured_llm_provider
 
     route = account_llm_route()
     if route is None:
@@ -28,6 +29,13 @@ def _account_model_change_is_locked(console: Console) -> bool:
         f"[{DIM}]Run[/] [bold]opensre account logout[/bold] "
         f"[{DIM}]before configuring a different provider or model.[/]"
     )
+    if not has_user_configured_llm_provider():
+        # Logging out with no provider of your own leaves no way back into the
+        # shell, so name the command that configures one first.
+        console.print(
+            f"[{DIM}]Set one up first with[/] [bold]opensre onboard local_llm[/bold] "
+            f"[{DIM}]for a local Ollama model.[/]"
+        )
     return True
 
 

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 import click
 from rich.console import Console
 
+from config.account import account_llm_route_ignored
 from config.repl_config import ReplConfig
 from core.agent_harness import SessionManager
 from infrastructure.analytics.github_identity import identify_saved_github_username
@@ -22,6 +23,7 @@ from surfaces.interactive_shell.runtime.startup.account_gate import (
 )
 from surfaces.interactive_shell.runtime.startup.demo_picker import offer_demo
 from surfaces.interactive_shell.runtime.startup.initial_input import run_initial_input
+from surfaces.interactive_shell.ui.sign_in import render_own_model_notice
 from surfaces.interactive_shell.ui.terminal_ui import render_terminal_ui
 from surfaces.shared.terminal.banner import animate_launch_wordmark
 from surfaces.shared.terminal.components.rendering import repl_clear_screen
@@ -41,6 +43,7 @@ async def run_repl_async(
     cli_command_group: click.Command | None = None,
     finish_banner: Callable[[], None] | None = None,
     after_banner: Callable[[], None] | None = None,
+    announce_own_model: bool = False,
 ) -> int:
     """Run the shell on an existing event loop and return its exit code.
 
@@ -87,6 +90,10 @@ async def run_repl_async(
     # with it for the interpreter.
     if after_banner is not None:
         after_banner()
+    # The gate cannot say this itself: ``run_repl`` clears the screen between
+    # the choice and the banner, so the notice only survives here.
+    if announce_own_model:
+        render_own_model_notice(out)
 
     try:
         if resume_session_id:
@@ -161,10 +168,15 @@ def run_repl(
         return 0
 
     finish_banner: Callable[[], None] | None = None
+    announce_own_model = False
     try:
         if not initial_input:
+            # A route already ignored on entry was the caller's own env var, not
+            # a choice made here, so only a flip during the gate is ours to announce.
+            route_was_live = not account_llm_route_ignored()
             if not pass_sign_in_gate(out):
                 return 0
+            announce_own_model = route_was_live and account_llm_route_ignored()
             # Wipe the calling shell or completed sign-in screen so the REPL
             # reads as its own screen, then boot it under the launch animation.
             repl_clear_screen()
@@ -178,6 +190,7 @@ def run_repl(
                 console=out,
                 cli_command_group=cli_command_group,
                 finish_banner=finish_banner,
+                announce_own_model=announce_own_model,
                 after_banner=after_banner,
             )
         )

--- a/surfaces/interactive_shell/runtime/startup/account_gate.py
+++ b/surfaces/interactive_shell/runtime/startup/account_gate.py
@@ -20,6 +20,13 @@ def account_is_signed_in() -> bool:
     return account_status().authenticated
 
 
+def own_llm_provider_configured() -> bool:
+    """Return whether a user-selected LLM provider can serve the shell signed out."""
+    from config.llm_settings import has_user_configured_llm_provider
+
+    return has_user_configured_llm_provider()
+
+
 def account_login(*, console: Console | None = None) -> bool:
     """Run the canonical webapp login command and verify its resulting session."""
     from infrastructure.terminal.theme import ERROR
@@ -60,11 +67,13 @@ def pass_sign_in_gate(console: Console) -> bool:
         console,
         is_signed_in=account_is_signed_in,
         login=_login,
+        has_own_provider=own_llm_provider_configured,
     )
 
 
 __all__ = [
     "account_is_signed_in",
     "account_login",
+    "own_llm_provider_configured",
     "pass_sign_in_gate",
 ]

--- a/surfaces/interactive_shell/runtime/startup/account_gate.py
+++ b/surfaces/interactive_shell/runtime/startup/account_gate.py
@@ -27,6 +27,13 @@ def own_llm_provider_configured() -> bool:
     return has_user_configured_llm_provider()
 
 
+def use_own_llm_provider() -> None:
+    """Drop a stored hosted route so the user's own provider serves this shell."""
+    from config.account import ignore_account_llm_route
+
+    ignore_account_llm_route()
+
+
 def account_login(*, console: Console | None = None) -> bool:
     """Run the canonical webapp login command and verify its resulting session."""
     from infrastructure.terminal.theme import ERROR
@@ -68,6 +75,7 @@ def pass_sign_in_gate(console: Console) -> bool:
         is_signed_in=account_is_signed_in,
         login=_login,
         has_own_provider=own_llm_provider_configured,
+        on_own_provider=use_own_llm_provider,
     )
 
 
@@ -76,4 +84,5 @@ __all__ = [
     "account_login",
     "own_llm_provider_configured",
     "pass_sign_in_gate",
+    "use_own_llm_provider",
 ]

--- a/surfaces/interactive_shell/runtime/startup/account_gate.py
+++ b/surfaces/interactive_shell/runtime/startup/account_gate.py
@@ -54,7 +54,13 @@ def account_login(*, console: Console | None = None) -> bool:
         if console is not None:
             console.print(f"[{ERROR}]OpenSRE account sign-in did not complete.[/]")
         return False
-    return account_is_signed_in()
+    if not account_is_signed_in():
+        return False
+    # This login supersedes any earlier own-model choice in this process.
+    from config.account import restore_account_llm_route
+
+    restore_account_llm_route()
+    return True
 
 
 def pass_sign_in_gate(console: Console) -> bool:

--- a/surfaces/interactive_shell/ui/sign_in.py
+++ b/surfaces/interactive_shell/ui/sign_in.py
@@ -81,6 +81,7 @@ def run_sign_in_gate(
     is_signed_in: Callable[[], bool],
     login: Callable[[], bool],
     has_own_provider: Callable[[], bool] = lambda: False,
+    on_own_provider: Callable[[], None] = lambda: None,
 ) -> bool:
     """Gate the REPL behind sign-in; return ``True`` to proceed, ``False`` to exit.
 
@@ -88,8 +89,10 @@ def run_sign_in_gate(
     screen and loops the menu. A user who configured their own LLM provider is
     offered a third choice that enters the shell signed out, which is the only
     way to run a local model: an account session pins the shell to the hosted
-    route. On non-interactive stdin the gate fails closed and prints the command
-    that can establish an account.
+    route. Picking it calls ``on_own_provider``, which drops any stored hosted
+    route so a rejected or unvalidated session cannot override the choice. On
+    non-interactive stdin the gate fails closed and prints the command that can
+    establish an account.
     """
     if is_signed_in():
         return True
@@ -108,6 +111,7 @@ def run_sign_in_gate(
                 return True
             continue  # login failed — offer the choice again
         if choice is SignInChoice.OWN_MODEL:
+            on_own_provider()
             console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
             return True
         return False  # Exit or Esc

--- a/surfaces/interactive_shell/ui/sign_in.py
+++ b/surfaces/interactive_shell/ui/sign_in.py
@@ -17,7 +17,12 @@ from rich.console import Console, Group, RenderableType
 from rich.panel import Panel
 from rich.text import Text
 
-from config.constants import SIGN_IN_PROMPT, WELCOME_DESCRIPTION, WELCOME_TITLE
+from config.constants import (
+    SIGN_IN_OR_OWN_MODEL_PROMPT,
+    SIGN_IN_PROMPT,
+    WELCOME_DESCRIPTION,
+    WELCOME_TITLE,
+)
 from infrastructure.terminal.theme import DIM, ERROR, HIGHLIGHT, SECONDARY, TEXT
 from surfaces.shared.terminal.banner import animate_launch_wordmark, build_launch_banner
 from surfaces.shared.terminal.components.choice_menu import repl_choose_one, repl_tty_interactive
@@ -45,13 +50,19 @@ def build_welcome_box() -> RenderableType:
     return Panel(body, box=ROUNDED, border_style=str(DIM), padding=(1, 2))
 
 
-def render_sign_in_screen(console: Console) -> None:
-    """Paint the launch banner, the welcome box, and the sign-in prompt line."""
+def render_sign_in_screen(console: Console, *, offer_own_model: bool = False) -> None:
+    """Paint the launch banner, the welcome box, and the sign-in prompt line.
+
+    ``offer_own_model`` must match what the menu below will offer: the default
+    prompt calls an account mandatory, which is untrue once the own-model choice
+    is on screen.
+    """
+    prompt = SIGN_IN_OR_OWN_MODEL_PROMPT if offer_own_model else SIGN_IN_PROMPT
     screen = Group(
         build_launch_banner(console),
         build_welcome_box(),
         Text(),
-        Text(SIGN_IN_PROMPT, style=str(SECONDARY)),
+        Text(prompt, style=str(SECONDARY)),
     )
     animate_launch_wordmark(console)
     console.print(screen)
@@ -73,6 +84,11 @@ def prompt_login_or_exit(*, offer_own_model: bool = False) -> SignInChoice | Non
         numbered=False,
     )
     return next((choice for choice in offered if picked == choice), None)
+
+
+def render_own_model_notice(console: Console) -> None:
+    """Say the shell is running signed out on the user's own configured provider."""
+    console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
 
 
 def run_sign_in_gate(
@@ -102,8 +118,8 @@ def run_sign_in_gate(
         )
         console.print("Run [bold]opensre account login[/bold] from an interactive terminal.")
         return False
-    render_sign_in_screen(console)
     offer_own_model = has_own_provider()
+    render_sign_in_screen(console, offer_own_model=offer_own_model)
     while True:
         choice = prompt_login_or_exit(offer_own_model=offer_own_model)
         if choice is SignInChoice.LOGIN:
@@ -112,7 +128,8 @@ def run_sign_in_gate(
             continue  # login failed — offer the choice again
         if choice is SignInChoice.OWN_MODEL:
             on_own_provider()
-            console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
+            # No notice here: ``run_repl`` clears the screen before the REPL
+            # paints, so the shell announces the choice after its banner.
             return True
         return False  # Exit or Esc
 
@@ -121,6 +138,7 @@ __all__ = [
     "SignInChoice",
     "build_welcome_box",
     "prompt_login_or_exit",
+    "render_own_model_notice",
     "render_sign_in_screen",
     "run_sign_in_gate",
 ]

--- a/surfaces/interactive_shell/ui/sign_in.py
+++ b/surfaces/interactive_shell/ui/sign_in.py
@@ -24,9 +24,14 @@ from surfaces.shared.terminal.components.choice_menu import repl_choose_one, rep
 
 
 class SignInChoice(enum.StrEnum):
-    """The two actions offered on the forced sign-in screen."""
+    """The actions offered on the forced sign-in screen.
+
+    ``OWN_MODEL`` is offered only when the user already configured their own
+    provider, so a fresh install still sees the two-way sign-in choice.
+    """
 
     LOGIN = "Sign in or create account"
+    OWN_MODEL = "Continue with my own model"
     EXIT = "Exit and stay signed out"
 
 
@@ -52,22 +57,22 @@ def render_sign_in_screen(console: Console) -> None:
     console.print(screen)
 
 
-def prompt_login_or_exit() -> SignInChoice | None:
-    """Show the Login/Exit menu; return the choice, or ``None`` on Esc.
+def prompt_login_or_exit(*, offer_own_model: bool = False) -> SignInChoice | None:
+    """Show the sign-in menu; return the choice, or ``None`` on Esc.
 
     The sign-in prompt is already printed by ``render_sign_in_screen`` above the
     menu, so the menu itself carries no title (avoids repeating the prompt).
     """
+    offered = [SignInChoice.LOGIN]
+    if offer_own_model:
+        offered.append(SignInChoice.OWN_MODEL)
+    offered.append(SignInChoice.EXIT)
     picked = repl_choose_one(
         title="",
-        choices=[(SignInChoice.LOGIN, SignInChoice.LOGIN), (SignInChoice.EXIT, SignInChoice.EXIT)],
+        choices=[(choice, choice) for choice in offered],
         numbered=False,
     )
-    if picked == SignInChoice.LOGIN:
-        return SignInChoice.LOGIN
-    if picked == SignInChoice.EXIT:
-        return SignInChoice.EXIT
-    return None
+    return next((choice for choice in offered if picked == choice), None)
 
 
 def run_sign_in_gate(
@@ -75,12 +80,16 @@ def run_sign_in_gate(
     *,
     is_signed_in: Callable[[], bool],
     login: Callable[[], bool],
+    has_own_provider: Callable[[], bool] = lambda: False,
 ) -> bool:
     """Gate the REPL behind sign-in; return ``True`` to proceed, ``False`` to exit.
 
     Returns immediately when already signed in. Otherwise renders the sign-in
-    screen and loops the sign-in/stay-signed-out menu. On non-interactive stdin
-    the gate fails closed and prints the command that can establish an account.
+    screen and loops the menu. A user who configured their own LLM provider is
+    offered a third choice that enters the shell signed out, which is the only
+    way to run a local model: an account session pins the shell to the hosted
+    route. On non-interactive stdin the gate fails closed and prints the command
+    that can establish an account.
     """
     if is_signed_in():
         return True
@@ -91,12 +100,16 @@ def run_sign_in_gate(
         console.print("Run [bold]opensre account login[/bold] from an interactive terminal.")
         return False
     render_sign_in_screen(console)
+    offer_own_model = has_own_provider()
     while True:
-        choice = prompt_login_or_exit()
+        choice = prompt_login_or_exit(offer_own_model=offer_own_model)
         if choice is SignInChoice.LOGIN:
             if login():
                 return True
             continue  # login failed — offer the choice again
+        if choice is SignInChoice.OWN_MODEL:
+            console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
+            return True
         return False  # Exit or Esc
 
 

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -199,3 +199,20 @@ def test_ignoring_the_account_route_survives_a_stored_session(
     restore_account_llm_route()
 
     assert account_llm_route() is not None
+
+
+def test_ignore_route_flag_reads_conventional_false_values_as_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The variable is documented for users now, so "=0" must not silently route
+    # someone away from their account.
+    from config.account import account_llm_route_ignored
+    from config.constants import OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV
+
+    for off in ("", "0", "false", "FALSE", "off", "no"):
+        monkeypatch.setenv(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, off)
+        assert account_llm_route_ignored() is False, off
+
+    for on in ("1", "true", "yes"):
+        monkeypatch.setenv(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, on)
+        assert account_llm_route_ignored() is True, on

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -166,7 +166,12 @@ def test_ignoring_the_account_route_survives_a_stored_session(
 ) -> None:
     # A rejected or unreachable login keeps its record and token on disk, so the
     # hosted route outlives the sign-in. Choosing a local model must win.
-    from config.account import AccountRecord, account_llm_route, ignore_account_llm_route
+    from config.account import (
+        AccountRecord,
+        account_llm_route,
+        ignore_account_llm_route,
+        restore_account_llm_route,
+    )
 
     record = AccountRecord(
         user_id="u1",
@@ -188,3 +193,9 @@ def test_ignoring_the_account_route_survives_a_stored_session(
     ignore_account_llm_route()
 
     assert account_llm_route() is None
+
+    # A later successful login replaces the rejected session, so the hosted
+    # route has to come back; otherwise the shell stays local until restart.
+    restore_account_llm_route()
+
+    assert account_llm_route() is not None

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -159,3 +159,32 @@ def test_resolve_for_request_stales_when_credential_is_genuinely_absent(
     record = resolve_provider_auth_record("deepseek")
     assert record["stale"] == "true"
     assert record["verified"] == "false"
+
+
+def test_ignoring_the_account_route_survives_a_stored_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A rejected or unreachable login keeps its record and token on disk, so the
+    # hosted route outlives the sign-in. Choosing a local model must win.
+    from config.account import AccountRecord, account_llm_route, ignore_account_llm_route
+
+    record = AccountRecord(
+        user_id="u1",
+        email="dev@example.com",
+        app_url="https://app.opensre.com",
+        llm_provider="openai",
+        llm_model="gpt-5.4-mini",
+        organization_id="org1",
+        signed_in_at="2026-09-08T00:00:00Z",
+        token_expires_at="2026-12-08T00:00:00Z",
+    )
+    monkeypatch.setattr("config.account.load_account_record", lambda: record)
+    monkeypatch.setattr("config.account.resolve_account_token", lambda: "token")
+    # setenv (not delenv) so monkeypatch removes the flag this test sets below.
+    monkeypatch.setenv("OPENSRE_IGNORE_ACCOUNT_ROUTE", "")
+
+    assert account_llm_route() is not None
+
+    ignore_account_llm_route()
+
+    assert account_llm_route() is None

--- a/tests/config/test_llm_settings.py
+++ b/tests/config/test_llm_settings.py
@@ -441,3 +441,56 @@ def test_user_configured_provider_rejects_settings_that_cannot_resolve(monkeypat
     monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
 
     assert has_user_configured_llm_provider() is False
+
+
+def test_own_provider_gate_rejects_a_record_whose_secret_is_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # credential_status may not read secrets, so it calls an API-key provider
+    # configured on its non-secret record alone. Entering the shell on that
+    # record hands the user a session that fails its first turn.
+    from types import SimpleNamespace
+
+    import config.llm_settings as llm_settings
+
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(llm_settings, "bootstrap_opensre_env", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        llm_settings, "resolve_llm_settings", lambda: SimpleNamespace(provider="openai")
+    )
+    monkeypatch.setattr(
+        llm_settings,
+        "credential_status",
+        lambda _provider: SimpleNamespace(configured=True, stale=False),
+    )
+    monkeypatch.setattr(
+        "config.llm_auth.credentials.resolve_for_request",
+        lambda _provider: SimpleNamespace(ok=False),
+    )
+
+    assert llm_settings.has_user_configured_llm_provider() is False
+
+
+def test_own_provider_gate_accepts_a_credential_that_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    import config.llm_settings as llm_settings
+
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setattr(llm_settings, "bootstrap_opensre_env", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        llm_settings, "resolve_llm_settings", lambda: SimpleNamespace(provider="ollama")
+    )
+    monkeypatch.setattr(
+        llm_settings,
+        "credential_status",
+        lambda _provider: SimpleNamespace(configured=True, stale=False),
+    )
+    monkeypatch.setattr(
+        "config.llm_auth.credentials.resolve_for_request",
+        lambda _provider: SimpleNamespace(ok=True),
+    )
+
+    assert llm_settings.has_user_configured_llm_provider() is True

--- a/tests/config/test_llm_settings.py
+++ b/tests/config/test_llm_settings.py
@@ -431,3 +431,13 @@ def test_user_configured_provider_ignores_the_built_in_default(monkeypatch) -> N
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
 
     assert has_user_configured_llm_provider() is True
+
+
+def test_user_configured_provider_rejects_settings_that_cannot_resolve(monkeypatch) -> None:
+    # An API key is not enough for azure-openai: without an endpoint every turn
+    # fails, so this must not read as a provider the shell can run on.
+    monkeypatch.setenv("LLM_PROVIDER", "azure-openai")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "sk-not-a-real-key")
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+
+    assert has_user_configured_llm_provider() is False

--- a/tests/config/test_llm_settings.py
+++ b/tests/config/test_llm_settings.py
@@ -10,6 +10,7 @@ from config.llm_settings import (
     LLMSettings,
     describe_llm_resolution,
     has_credentials_for_active_llm_provider,
+    has_user_configured_llm_provider,
     llm_provider_error_context,
     resolve_llm_settings,
     resolve_llm_settings_verbose,
@@ -418,3 +419,15 @@ def test_llm_provider_error_context_never_raises(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "not-a-real-provider")
 
     assert llm_provider_error_context() == ""
+
+
+def test_user_configured_provider_ignores_the_built_in_default(monkeypatch) -> None:
+    # An unset LLM_PROVIDER still resolves to a default provider; that is not a
+    # choice the user made, and the shell's sign-in gate must not read it as one.
+    monkeypatch.setenv("LLM_PROVIDER", "")
+
+    assert has_user_configured_llm_provider() is False
+
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+
+    assert has_user_configured_llm_provider() is True

--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -21,6 +21,13 @@ def _console() -> Console:
     return Console(file=io.StringIO(), force_terminal=False, highlight=False, width=80)
 
 
+def _login_subprocess_succeeds(
+    command: list[str], **_kwargs: Any
+) -> subprocess.CompletedProcess[str]:
+    """Stand in for the webapp login subprocess; the session check decides the outcome."""
+    return subprocess.CompletedProcess(command, 0)
+
+
 def test_account_is_signed_in_requires_active_webapp_status(monkeypatch: Any) -> None:
     status = SimpleNamespace(authenticated=True)
     monkeypatch.setattr("surfaces.shared.account_session.account_status", lambda: status)
@@ -86,7 +93,8 @@ def test_pass_sign_in_gate_allows_only_valid_account(monkeypatch: Any) -> None:
     monkeypatch.setattr(account_gate, "account_is_signed_in", lambda: False)
     monkeypatch.setattr("surfaces.interactive_shell.ui.sign_in.repl_tty_interactive", lambda: True)
     monkeypatch.setattr(
-        "surfaces.interactive_shell.ui.sign_in.render_sign_in_screen", lambda _console: None
+        "surfaces.interactive_shell.ui.sign_in.render_sign_in_screen",
+        lambda _console, **_kwargs: None,
     )
     monkeypatch.setattr(account_gate, "own_llm_provider_configured", lambda: False)
     monkeypatch.setattr(
@@ -106,7 +114,8 @@ def test_pass_sign_in_gate_offers_the_configured_provider_instead_of_an_account(
     monkeypatch.setattr(account_gate, "own_llm_provider_configured", lambda: True)
     monkeypatch.setattr("surfaces.interactive_shell.ui.sign_in.repl_tty_interactive", lambda: True)
     monkeypatch.setattr(
-        "surfaces.interactive_shell.ui.sign_in.render_sign_in_screen", lambda _console: None
+        "surfaces.interactive_shell.ui.sign_in.render_sign_in_screen",
+        lambda _console, **_kwargs: None,
     )
     offered: list[bool] = []
 
@@ -229,3 +238,176 @@ def test_run_repl_async_always_offers_the_demo(monkeypatch: Any) -> None:
 
     assert asyncio.run(main_entrypoint.run_repl_async()) == 0
     assert offered == [True]
+
+
+def test_shell_announces_the_own_model_choice_after_the_banner(monkeypatch: Any) -> None:
+    # The gate's own message is wiped by the pre-banner clear, so the only place
+    # the user can read it is here, once the banner has painted.
+    order: list[str] = []
+
+    class _Controller:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return
+
+        async def start_interactive_shell(self) -> None:
+            order.append("shell")
+
+    class _SessionStore:
+        def open_store(self, _session: object) -> None:
+            return
+
+        def close(self, _session: object) -> None:
+            return
+
+    monkeypatch.setattr(main_entrypoint, "identify_saved_github_username", lambda: None)
+    monkeypatch.setattr(
+        main_entrypoint,
+        "create_repl_runtime",
+        lambda **_kwargs: SimpleNamespace(session=Session(), inbox=None),
+    )
+    monkeypatch.setattr(main_entrypoint.SessionManager, "for_session", lambda _s: _SessionStore())
+    monkeypatch.setattr(main_entrypoint, "offer_demo", lambda *_a, **_k: None)
+    monkeypatch.setattr(main_entrypoint, "InteractiveShellController", _Controller)
+    monkeypatch.setattr(
+        main_entrypoint, "render_own_model_notice", lambda _c: order.append("notice")
+    )
+
+    def _finish_banner() -> None:
+        order.append("banner")
+
+    asyncio.run(
+        main_entrypoint.run_repl_async(
+            config=ReplConfig(enabled=True, layout="classic"),
+            console=_console(),
+            finish_banner=_finish_banner,
+            announce_own_model=True,
+        )
+    )
+
+    assert order == ["banner", "notice", "shell"]
+
+
+def test_shell_stays_quiet_when_the_hosted_route_was_never_dropped(monkeypatch: Any) -> None:
+    notices: list[str] = []
+
+    class _Controller:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return
+
+        async def start_interactive_shell(self) -> None:
+            return
+
+    class _SessionStore:
+        def open_store(self, _session: object) -> None:
+            return
+
+        def close(self, _session: object) -> None:
+            return
+
+    monkeypatch.setattr(main_entrypoint, "identify_saved_github_username", lambda: None)
+    monkeypatch.setattr(
+        main_entrypoint,
+        "create_repl_runtime",
+        lambda **_kwargs: SimpleNamespace(session=Session(), inbox=None),
+    )
+    monkeypatch.setattr(main_entrypoint.SessionManager, "for_session", lambda _s: _SessionStore())
+    monkeypatch.setattr(main_entrypoint, "offer_demo", lambda *_a, **_k: None)
+    monkeypatch.setattr(main_entrypoint, "InteractiveShellController", _Controller)
+    monkeypatch.setattr(
+        main_entrypoint, "render_own_model_notice", lambda _c: notices.append("notice")
+    )
+
+    asyncio.run(
+        main_entrypoint.run_repl_async(
+            config=ReplConfig(enabled=True, layout="classic"),
+            console=_console(),
+        )
+    )
+
+    assert notices == []
+
+
+def test_gate_login_restores_a_hosted_route_dropped_earlier_in_this_process(
+    monkeypatch: Any,
+) -> None:
+    # Entering on your own model sets the ignore flag for the whole process. A
+    # later login must clear it, or the signed-in shell keeps using the local
+    # provider and the account's hosted model is silently ignored.
+    from config.account import account_llm_route_ignored, ignore_account_llm_route
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.subprocess_runner.build_opensre_cli_argv",
+        lambda args: ["opensre", *args],
+    )
+    monkeypatch.setattr(account_gate.subprocess, "run", _login_subprocess_succeeds)
+    monkeypatch.setattr(account_gate, "account_is_signed_in", lambda: True)
+
+    ignore_account_llm_route()
+    assert account_llm_route_ignored() is True
+
+    assert account_gate.account_login() is True
+    assert account_llm_route_ignored() is False
+
+
+def test_gate_login_that_fails_keeps_the_own_model_choice(monkeypatch: Any) -> None:
+    from config.account import account_llm_route_ignored, ignore_account_llm_route
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.subprocess_runner.build_opensre_cli_argv",
+        lambda args: ["opensre", *args],
+    )
+    monkeypatch.setattr(account_gate.subprocess, "run", _login_subprocess_succeeds)
+    monkeypatch.setattr(account_gate, "account_is_signed_in", lambda: False)
+
+    ignore_account_llm_route()
+
+    assert account_gate.account_login() is False
+    assert account_llm_route_ignored() is True
+
+
+def test_run_repl_announces_only_a_route_the_gate_itself_dropped(monkeypatch: Any) -> None:
+    # Someone who exported OPENSRE_IGNORE_ACCOUNT_ROUTE is already signed in as
+    # far as the gate is concerned; telling them they are signed out is wrong.
+    from config.account import ignore_account_llm_route
+
+    announced: list[bool] = []
+    monkeypatch.setattr(main_entrypoint.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(main_entrypoint, "repl_clear_screen", lambda: None)
+    monkeypatch.setattr(main_entrypoint, "_start_launch_banner", lambda _console: lambda: None)
+    monkeypatch.setattr(main_entrypoint, "pass_sign_in_gate", lambda _console: True)
+
+    async def _run_async(**kwargs: Any) -> int:
+        announced.append(bool(kwargs["announce_own_model"]))
+        return 0
+
+    monkeypatch.setattr(main_entrypoint, "run_repl_async", _run_async)
+
+    ignore_account_llm_route()
+    main_entrypoint.run_repl(config=ReplConfig(enabled=True, layout="classic"))
+
+    assert announced == [False]
+
+
+def test_run_repl_announces_a_route_dropped_during_the_gate(monkeypatch: Any) -> None:
+    from config.account import ignore_account_llm_route
+
+    announced: list[bool] = []
+    monkeypatch.setattr(main_entrypoint.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(main_entrypoint, "repl_clear_screen", lambda: None)
+    monkeypatch.setattr(main_entrypoint, "_start_launch_banner", lambda _console: lambda: None)
+
+    def _gate(_console: Console) -> bool:
+        ignore_account_llm_route()
+        return True
+
+    monkeypatch.setattr(main_entrypoint, "pass_sign_in_gate", _gate)
+
+    async def _run_async(**kwargs: Any) -> int:
+        announced.append(bool(kwargs["announce_own_model"]))
+        return 0
+
+    monkeypatch.setattr(main_entrypoint, "run_repl_async", _run_async)
+
+    main_entrypoint.run_repl(config=ReplConfig(enabled=True, layout="classic"))
+
+    assert announced == [True]

--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -88,12 +88,36 @@ def test_pass_sign_in_gate_allows_only_valid_account(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "surfaces.interactive_shell.ui.sign_in.render_sign_in_screen", lambda _console: None
     )
+    monkeypatch.setattr(account_gate, "own_llm_provider_configured", lambda: False)
     monkeypatch.setattr(
         "surfaces.interactive_shell.ui.sign_in.prompt_login_or_exit",
-        lambda: SignInChoice.EXIT,
+        lambda **_kwargs: SignInChoice.EXIT,
     )
 
     assert account_gate.pass_sign_in_gate(_console()) is False
+
+
+def test_pass_sign_in_gate_offers_the_configured_provider_instead_of_an_account(
+    monkeypatch: Any,
+) -> None:
+    # Pins the seam: without it the shell never offers the signed-out local-model path.
+    monkeypatch.setattr(account_gate, "is_test_run", lambda: False)
+    monkeypatch.setattr(account_gate, "account_is_signed_in", lambda: False)
+    monkeypatch.setattr(account_gate, "own_llm_provider_configured", lambda: True)
+    monkeypatch.setattr("surfaces.interactive_shell.ui.sign_in.repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.sign_in.render_sign_in_screen", lambda _console: None
+    )
+    offered: list[bool] = []
+
+    def _prompt(*, offer_own_model: bool) -> SignInChoice:
+        offered.append(offer_own_model)
+        return SignInChoice.OWN_MODEL
+
+    monkeypatch.setattr("surfaces.interactive_shell.ui.sign_in.prompt_login_or_exit", _prompt)
+
+    assert account_gate.pass_sign_in_gate(_console()) is True
+    assert offered == [True]
 
 
 def test_run_repl_stops_before_runtime_when_sign_in_is_declined(monkeypatch: Any) -> None:

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -134,6 +134,48 @@ class TestDispatchSlash:
         assert dispatch_slash("/account logout", Session(), console) is True
         assert "Closing the interactive shell" not in output.getvalue()
 
+    def test_account_login_restores_a_hosted_route_dropped_for_an_own_model_shell(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Someone who entered on their own model can sign in mid-session. Without
+        # this the process keeps the ignore flag and the account's hosted model
+        # is silently skipped for the rest of the shell.
+        from types import SimpleNamespace
+
+        from config.account import account_llm_route_ignored, ignore_account_llm_route
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        monkeypatch.setattr(m, "run_cli_command", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(
+            "surfaces.shared.account_session.account_status",
+            lambda: SimpleNamespace(authenticated=True),
+        )
+        console, _ = _capture()
+        ignore_account_llm_route()
+
+        assert dispatch_slash("/account login", Session(), console) is True
+        assert account_llm_route_ignored() is False
+
+    def test_account_login_that_does_not_authenticate_keeps_the_own_model_choice(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from types import SimpleNamespace
+
+        from config.account import account_llm_route_ignored, ignore_account_llm_route
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        monkeypatch.setattr(m, "run_cli_command", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(
+            "surfaces.shared.account_session.account_status",
+            lambda: SimpleNamespace(authenticated=False),
+        )
+        console, _ = _capture()
+        ignore_account_llm_route()
+
+        dispatch_slash("/account login", Session(), console)
+
+        assert account_llm_route_ignored() is True
+
     def test_help_lists_all_commands(self) -> None:
         session = Session()
         console, buf = _capture()

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -113,10 +113,26 @@ class TestDispatchSlash:
 
         monkeypatch.setattr(m, "run_cli_command", lambda *_args, **_kwargs: True)
         monkeypatch.setattr("config.account.account_llm_route", lambda: None)
+        monkeypatch.setattr("config.llm_settings.has_user_configured_llm_provider", lambda: False)
         console, output = _capture()
 
         assert dispatch_slash("/account logout", Session(), console) is False
         assert "Closing the interactive shell" in output.getvalue()
+
+    def test_account_logout_keeps_the_shell_on_a_configured_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # /model sends users here to reach a local model; closing the shell would
+        # leave that instruction with nowhere to land.
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        monkeypatch.setattr(m, "run_cli_command", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr("config.account.account_llm_route", lambda: None)
+        monkeypatch.setattr("config.llm_settings.has_user_configured_llm_provider", lambda: True)
+        console, output = _capture()
+
+        assert dispatch_slash("/account logout", Session(), console) is True
+        assert "Closing the interactive shell" not in output.getvalue()
 
     def test_help_lists_all_commands(self) -> None:
         session = Session()

--- a/tests/interactive_shell/test_model_credential_entry.py
+++ b/tests/interactive_shell/test_model_credential_entry.py
@@ -90,6 +90,7 @@ def test_account_login_blocks_every_model_change(monkeypatch: Any, change: Any) 
         "config.account.account_llm_route",
         lambda: SimpleNamespace(model="gpt-5.4-mini"),
     )
+    monkeypatch.setattr("config.llm_settings.has_user_configured_llm_provider", lambda: True)
     console = _Console()
 
     assert change(console) is False
@@ -182,3 +183,31 @@ def test_custom_provider_no_model_uses_legacy_model(monkeypatch: Any) -> None:
     monkeypatch.setenv(provider.legacy_model_env, "gateway-model")
 
     assert switching._resolve_omitted_model(provider) == "gateway-model"
+
+
+def test_model_lock_names_the_setup_command_when_no_provider_is_configured(
+    monkeypatch: Any,
+) -> None:
+    # "Log out first" dead-ends for someone with no provider of their own: the
+    # logout then closes the shell. The lock has to name the way out.
+    monkeypatch.setattr(
+        "config.account.account_llm_route",
+        lambda: SimpleNamespace(model="gpt-5.4-mini"),
+    )
+    monkeypatch.setattr("config.llm_settings.has_user_configured_llm_provider", lambda: False)
+    console = _Console()
+
+    assert switching.switch_llm_provider("anthropic", console) is False
+    assert any("opensre onboard local_llm" in line for line in console.printed)
+
+
+def test_model_lock_omits_the_setup_command_when_a_provider_exists(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        "config.account.account_llm_route",
+        lambda: SimpleNamespace(model="gpt-5.4-mini"),
+    )
+    monkeypatch.setattr("config.llm_settings.has_user_configured_llm_provider", lambda: True)
+    console = _Console()
+
+    assert switching.switch_llm_provider("anthropic", console) is False
+    assert not any("opensre onboard local_llm" in line for line in console.printed)

--- a/tests/interactive_shell/ui/test_sign_in.py
+++ b/tests/interactive_shell/ui/test_sign_in.py
@@ -77,7 +77,7 @@ def test_gate_logs_in_then_proceeds(monkeypatch) -> None:
     login_calls: list[bool] = []
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
-    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda: SignInChoice.LOGIN)
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.LOGIN)
     console, _ = _console()
 
     def _login() -> bool:
@@ -93,7 +93,7 @@ def test_gate_logs_in_then_proceeds(monkeypatch) -> None:
 def test_gate_exit_declines(monkeypatch) -> None:
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
-    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda: SignInChoice.EXIT)
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.EXIT)
     console, _ = _console()
 
     result = run_sign_in_gate(console, is_signed_in=lambda: False, login=lambda: False)
@@ -110,9 +110,43 @@ def test_gate_retries_after_a_failed_login_then_exits(monkeypatch) -> None:
     choices = iter([SignInChoice.LOGIN, SignInChoice.EXIT])
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
-    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda: next(choices))
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: next(choices))
     console, _ = _console()
 
     result = run_sign_in_gate(console, is_signed_in=lambda: False, login=lambda: False)
 
     assert result is False
+
+
+def test_gate_enters_the_shell_on_a_configured_provider_without_signing_in(monkeypatch) -> None:
+    # The only path to a local model: an account session pins the shell to the hosted route.
+    monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.OWN_MODEL)
+    console, _ = _console()
+
+    result = run_sign_in_gate(
+        console,
+        is_signed_in=lambda: False,
+        login=lambda: False,
+        has_own_provider=lambda: True,
+    )
+
+    assert result is True
+
+
+def test_menu_hides_the_own_model_row_without_a_configured_provider(monkeypatch) -> None:
+    # A fresh install keeps the two-way gate: no provider means no way past sign-in.
+    offered: list[list[str]] = []
+
+    def _choose(*, choices: list[tuple[str, str]], **_kwargs: object) -> None:
+        offered.append([value for value, _label in choices])
+        return None
+
+    monkeypatch.setattr(sign_in, "repl_choose_one", _choose)
+
+    sign_in.prompt_login_or_exit(offer_own_model=False)
+    sign_in.prompt_login_or_exit(offer_own_model=True)
+
+    assert offered[0] == [SignInChoice.LOGIN, SignInChoice.EXIT]
+    assert SignInChoice.OWN_MODEL in offered[1]

--- a/tests/interactive_shell/ui/test_sign_in.py
+++ b/tests/interactive_shell/ui/test_sign_in.py
@@ -54,7 +54,9 @@ def test_welcome_title_renders_in_the_accent_colour() -> None:
 def test_gate_proceeds_immediately_when_already_signed_in(monkeypatch) -> None:
     # No screen, no menu when the user is already signed in.
     rendered: list[bool] = []
-    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: rendered.append(True))
+    monkeypatch.setattr(
+        sign_in, "render_sign_in_screen", lambda _c, **_kwargs: rendered.append(True)
+    )
     console, _ = _console()
 
     result = run_sign_in_gate(console, is_signed_in=lambda: True, login=lambda: False)
@@ -76,7 +78,7 @@ def test_gate_fails_closed_on_non_interactive_stdin(monkeypatch) -> None:
 def test_gate_logs_in_then_proceeds(monkeypatch) -> None:
     login_calls: list[bool] = []
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
-    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
+    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c, **_kwargs: None)
     monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.LOGIN)
     console, _ = _console()
 
@@ -92,7 +94,7 @@ def test_gate_logs_in_then_proceeds(monkeypatch) -> None:
 
 def test_gate_exit_declines(monkeypatch) -> None:
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
-    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
+    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c, **_kwargs: None)
     monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.EXIT)
     console, _ = _console()
 
@@ -109,7 +111,7 @@ def test_gate_retries_after_a_failed_login_then_exits(monkeypatch) -> None:
     # Login fails once, then the user picks Exit — the gate re-prompts, does not loop forever.
     choices = iter([SignInChoice.LOGIN, SignInChoice.EXIT])
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
-    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
+    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c, **_kwargs: None)
     monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: next(choices))
     console, _ = _console()
 
@@ -124,7 +126,7 @@ def test_gate_enters_the_shell_on_a_configured_provider_without_signing_in(monke
     # local model must drop it or the shell keeps calling the hosted proxy.
     dropped: list[bool] = []
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
-    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
+    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c, **_kwargs: None)
     monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.OWN_MODEL)
     console, _ = _console()
 
@@ -158,3 +160,35 @@ def test_menu_hides_the_own_model_row_without_a_configured_provider(monkeypatch)
 
     assert offered[0] == [SignInChoice.LOGIN, SignInChoice.EXIT]
     assert SignInChoice.OWN_MODEL in offered[1]
+
+
+def test_prompt_line_stops_claiming_an_account_is_required_when_it_is_not() -> None:
+    # The default copy calls an account mandatory. Printing it above a menu that
+    # offers a way in without one contradicts the row directly below it.
+    from config.constants import SIGN_IN_OR_OWN_MODEL_PROMPT
+
+    console, buf = _console()
+    render_sign_in_screen(console, offer_own_model=True)
+
+    out = buf.getvalue()
+    assert SIGN_IN_OR_OWN_MODEL_PROMPT in out
+    assert SIGN_IN_PROMPT not in out
+
+
+def test_gate_leaves_the_own_model_notice_to_the_shell(monkeypatch) -> None:
+    # run_repl clears the screen between this choice and the banner, so anything
+    # the gate prints here is wiped before the user can read it.
+    monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c, **_kwargs: None)
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.OWN_MODEL)
+    console, output = _console()
+
+    result = run_sign_in_gate(
+        console,
+        is_signed_in=lambda: False,
+        login=lambda: False,
+        has_own_provider=lambda: True,
+    )
+
+    assert result is True
+    assert output.getvalue() == ""

--- a/tests/interactive_shell/ui/test_sign_in.py
+++ b/tests/interactive_shell/ui/test_sign_in.py
@@ -120,19 +120,27 @@ def test_gate_retries_after_a_failed_login_then_exits(monkeypatch) -> None:
 
 def test_gate_enters_the_shell_on_a_configured_provider_without_signing_in(monkeypatch) -> None:
     # The only path to a local model: an account session pins the shell to the hosted route.
+    # A rejected or unreachable session leaves that route on disk, so picking the
+    # local model must drop it or the shell keeps calling the hosted proxy.
+    dropped: list[bool] = []
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
     monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.OWN_MODEL)
     console, _ = _console()
+
+    def _on_own_provider() -> None:
+        dropped.append(True)
 
     result = run_sign_in_gate(
         console,
         is_signed_in=lambda: False,
         login=lambda: False,
         has_own_provider=lambda: True,
+        on_own_provider=_on_own_provider,
     )
 
     assert result is True
+    assert dropped == [True]
 
 
 def test_menu_hides_the_own_model_row_without_a_configured_provider(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #6112

#### Describe the changes you have made in this PR -

Adds a **Continue with my own model** row to the sign-in gate, so someone running Ollama or their own API key can open the shell without an OpenSRE account. The row appears only when a provider is configured and its credentials resolve, so a fresh install still sees the original two-way choice.

Picking it drops any stored hosted route for the process. That part matters: a session the webapp rejected or could not reach still leaves its record and token on disk, so without dropping it the dead route beats the working local provider. A later `/account login` puts the hosted route back.

Three corrections in the same area:

- The prompt line above the menu said an account was required for the shell. It now matches whatever the menu actually offers.
- The "using your configured provider" notice was printed into a screen `run_repl` clears a moment later, so nobody read it. It moved into the shell, after the banner, and fires only when the gate itself dropped the route. A route already ignored on entry came from the caller's own env var, and telling a signed-in user they are signed out would be wrong.
- `/model` now names `opensre onboard local_llm` when it tells you to log out and you have no provider of your own, since logging out would otherwise close the shell with no way back in.

`README.md` still said the shell "only opens for an active account". Install troubleshooting picks up `OPENSRE_IGNORE_ACCOUNT_ROUTE`, the escape hatch for #6223, where a stale session keeps routing the model on every non-shell surface and `opensre ask` dies with a bare connection error.

### Demo/Screenshot for feature changes and bug fixes -

Signed out with `LLM_PROVIDER` configured. Before, the prompt line contradicted the row under it:

```
Sign in or create an OpenSRE account to use the interactive shell.

  ❯ Sign in or create account
    Continue with my own model
    Exit and stay signed out
```

After:

```
Sign in to OpenSRE, or continue with the model you already configured.

  ❯ Sign in or create account
    Continue with my own model
    Exit and stay signed out
```

Choosing that row, the notice now survives the screen clear and lands under the banner:

```
                        Skills (8) ✓     CI/CD fixes (0)

Signed out. Using your configured LLM provider.

  Ask User
  Which demo would you like me to run?
```

The shell then runs a real turn on the local provider, with no account:

```
$ /model show
LLM connection · local configuration

provider │ reasoning model │ toolcall model
━━━━━━━━━┿━━━━━━━━━━━━━━━━━┿━━━━━━━━━━━━━━━
openai   │ gpt-5.4         │ gpt-5.4

> In one sentence, what does a SIGTERM do to a process?

Ω SIGTERM asks a process to terminate gracefully, giving it a chance to catch
  the signal, clean up, and exit before being forcibly killed.
```

Same flow with a hosted record on disk pointing at an unreachable app URL: the gate still offers the row, and `/model show` reports `local configuration` rather than the dead route. A fresh install (empty `HOME`, no `LLM_PROVIDER`) keeps the two-row gate and the original prompt copy.

Checks run locally: `make lint`, `make format-check`, `make typecheck`, and `uv run python -m pytest tests/config/ tests/interactive_shell/ tests/core/runtime/llm/ tests/quality/ tests/shared/` (2587 passed, 1 skipped).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a dead end that users hit in practice: the shell demands an account, a signed-in shell is pinned to the hosted model, and the `/model` lock tells you to log out, which closes the shell. There was no supported way to reach a local model.

I kept the gate rather than weakening it. The new row is gated on `has_user_configured_llm_provider()`, which requires `LLM_PROVIDER` to be set explicitly and its credentials to resolve. The built-in default does not count, so the row cannot appear on a fresh install and become a way around sign-in.

The alternative I considered was letting the gate auto-pass whenever a local provider exists. I did not do that, because it silently removes the gate for anyone with a stray `LLM_PROVIDER` in their environment. Making it an explicit choice keeps the decision with the user.

Dropping the hosted route needed process-wide state, since `account_llm_route()` is consulted from the LLM factory and the cache key, not just the gate. `OPENSRE_IGNORE_ACCOUNT_ROUTE` does that, and because it feeds `current_llm_client_cache_key()`, cached clients rebuild against the local provider instead of being served stale.

For the notice, I first keyed it on the env var, then changed it: a user who exports that variable themselves is not making a choice in the gate, and could be signed in, so the message would have lied. `run_repl` now compares the route state either side of the gate and only announces a flip it caused.

Key pieces: `run_sign_in_gate` owns the choice loop and stays injection-based; `account_llm_route_ignored()` is the predicate both the route resolver and the shell read; `render_own_model_notice()` is shared by the gate path and `/account logout` so the wording cannot drift.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
