### PR TITLE
fix(work-items): schedule reminders at exact requested time

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -1111,6 +1111,9 @@ if TYPE_CHECKING:
     from config.constants.work_items import (
         OPENSRE_WORK_ITEMS_DIR_ENV as OPENSRE_WORK_ITEMS_DIR_ENV,
     )
+    from config.constants.work_items import (
+        WORK_ITEM_REMINDER_RUN_AT_PARAM as WORK_ITEM_REMINDER_RUN_AT_PARAM,
+    )
     from config.constants.x_mcp import (
         X_MCP_AUTH_TOKEN_ENV as X_MCP_AUTH_TOKEN_ENV,
     )

--- a/config/constants/exports.py
+++ b/config/constants/exports.py
@@ -453,6 +453,7 @@ EXPORTS: dict[str, str] = {
     "VERCEL_TEAM_ID_ENV": "vercel",
     # work_items
     "OPENSRE_WORK_ITEMS_DIR_ENV": "work_items",
+    "WORK_ITEM_REMINDER_RUN_AT_PARAM": "work_items",
     # x_mcp
     "X_MCP_AUTH_TOKEN_ENV": "x_mcp",
     "X_MCP_URL_ENV": "x_mcp",

--- a/config/constants/work_items.py
+++ b/config/constants/work_items.py
@@ -1,7 +1,8 @@
-"""Environment names for durable work-item storage."""
+"""Constants for durable work-item storage and scheduling."""
 
 from __future__ import annotations
 
 OPENSRE_WORK_ITEMS_DIR_ENV = "OPENSRE_WORK_ITEMS_DIR"
+WORK_ITEM_REMINDER_RUN_AT_PARAM = "run_at"
 
-__all__ = ["OPENSRE_WORK_ITEMS_DIR_ENV"]
+__all__ = ["OPENSRE_WORK_ITEMS_DIR_ENV", "WORK_ITEM_REMINDER_RUN_AT_PARAM"]

--- a/core/domain/work_items/__init__.py
+++ b/core/domain/work_items/__init__.py
@@ -29,7 +29,6 @@ from core.domain.work_items.reminders import (
     build_work_item_reminder_message,
 )
 from core.domain.work_items.schedule import (
-    InvalidWorkItemLocalTime,
     cron_from_datetime,
     parse_work_item_datetime,
     resolve_work_item_datetime,
@@ -71,7 +70,6 @@ __all__ = [
     "WorkItemStatus",
     "WorkItemStoreError",
     "WorkItemUpdates",
-    "InvalidWorkItemLocalTime",
     "add_work_item",
     "build_work_item_checkin_message",
     "build_work_item_reminder_message",

--- a/core/domain/work_items/__init__.py
+++ b/core/domain/work_items/__init__.py
@@ -29,6 +29,7 @@ from core.domain.work_items.reminders import (
     build_work_item_reminder_message,
 )
 from core.domain.work_items.schedule import (
+    InvalidWorkItemLocalTime,
     cron_from_datetime,
     parse_work_item_datetime,
     resolve_work_item_datetime,
@@ -70,6 +71,7 @@ __all__ = [
     "WorkItemStatus",
     "WorkItemStoreError",
     "WorkItemUpdates",
+    "InvalidWorkItemLocalTime",
     "add_work_item",
     "build_work_item_checkin_message",
     "build_work_item_reminder_message",

--- a/core/domain/work_items/__init__.py
+++ b/core/domain/work_items/__init__.py
@@ -28,7 +28,11 @@ from core.domain.work_items.reminders import (
     build_work_item_checkin_message,
     build_work_item_reminder_message,
 )
-from core.domain.work_items.schedule import cron_from_datetime, parse_work_item_datetime
+from core.domain.work_items.schedule import (
+    cron_from_datetime,
+    parse_work_item_datetime,
+    resolve_work_item_datetime,
+)
 from core.domain.work_items.scoring import (
     DEFAULT_PRIORITY_LIMIT,
     PRIORITY_WEIGHTS,
@@ -84,6 +88,7 @@ __all__ = [
     "parse_status",
     "parse_work_item_datetime",
     "prioritize_work_items",
+    "resolve_work_item_datetime",
     "resolve_work_item_selector",
     "score_work_item",
     "set_work_item_last_reminded",

--- a/core/domain/work_items/schedule.py
+++ b/core/domain/work_items/schedule.py
@@ -6,10 +6,6 @@ from datetime import UTC, datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
-class InvalidWorkItemLocalTime(ValueError):
-    """Raised when a reminder names a nonexistent local wall time."""
-
-
 def parse_work_item_datetime(value: str) -> datetime | None:
     text = value.strip()
     if not text:
@@ -41,7 +37,7 @@ def resolve_work_item_datetime(value: str, timezone: str) -> datetime | None:
         round_trip = candidate.astimezone(UTC).astimezone(zone)
         if round_trip.replace(tzinfo=None) == parsed:
             return candidate
-    raise InvalidWorkItemLocalTime(f"invalid local time {value!r} in timezone {timezone!r}")
+    return None
 
 
 def cron_from_datetime(value: datetime) -> str:
@@ -49,7 +45,6 @@ def cron_from_datetime(value: datetime) -> str:
 
 
 __all__ = [
-    "InvalidWorkItemLocalTime",
     "cron_from_datetime",
     "parse_work_item_datetime",
     "resolve_work_item_datetime",

--- a/core/domain/work_items/schedule.py
+++ b/core/domain/work_items/schedule.py
@@ -6,6 +6,10 @@ from datetime import UTC, datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
+class InvalidWorkItemLocalTime(ValueError):
+    """Raised when a reminder names a nonexistent local wall time."""
+
+
 def parse_work_item_datetime(value: str) -> datetime | None:
     text = value.strip()
     if not text:
@@ -37,7 +41,7 @@ def resolve_work_item_datetime(value: str, timezone: str) -> datetime | None:
         round_trip = candidate.astimezone(UTC).astimezone(zone)
         if round_trip.replace(tzinfo=None) == parsed:
             return candidate
-    raise ValueError(f"invalid local time {value!r} in timezone {timezone!r}")
+    raise InvalidWorkItemLocalTime(f"invalid local time {value!r} in timezone {timezone!r}")
 
 
 def cron_from_datetime(value: datetime) -> str:
@@ -45,6 +49,7 @@ def cron_from_datetime(value: datetime) -> str:
 
 
 __all__ = [
+    "InvalidWorkItemLocalTime",
     "cron_from_datetime",
     "parse_work_item_datetime",
     "resolve_work_item_datetime",

--- a/core/domain/work_items/schedule.py
+++ b/core/domain/work_items/schedule.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 def parse_work_item_datetime(value: str) -> datetime | None:
@@ -20,8 +21,26 @@ def parse_work_item_datetime(value: str) -> datetime | None:
     return parsed.astimezone(UTC)
 
 
+def resolve_work_item_datetime(value: str, timezone: str) -> datetime | None:
+    """Resolve a work-item datetime to an aware instant using its IANA timezone."""
+    parsed = parse_work_item_datetime(value)
+    if parsed is None:
+        return None
+    try:
+        zone = ZoneInfo(timezone.strip())
+    except (ValueError, ZoneInfoNotFoundError) as exc:
+        raise ValueError(f"invalid IANA timezone: {timezone!r}") from exc
+    if parsed.tzinfo is not None:
+        return parsed.astimezone(UTC)
+    return parsed.replace(tzinfo=zone)
+
+
 def cron_from_datetime(value: datetime) -> str:
     return f"{value.minute} {value.hour} {value.day} {value.month} *"
 
 
-__all__ = ["cron_from_datetime", "parse_work_item_datetime"]
+__all__ = [
+    "cron_from_datetime",
+    "parse_work_item_datetime",
+    "resolve_work_item_datetime",
+]

--- a/core/domain/work_items/schedule.py
+++ b/core/domain/work_items/schedule.py
@@ -32,7 +32,12 @@ def resolve_work_item_datetime(value: str, timezone: str) -> datetime | None:
         raise ValueError(f"invalid IANA timezone: {timezone!r}") from exc
     if parsed.tzinfo is not None:
         return parsed.astimezone(UTC)
-    return parsed.replace(tzinfo=zone)
+    for fold in (0, 1):
+        candidate = parsed.replace(tzinfo=zone, fold=fold)
+        round_trip = candidate.astimezone(UTC).astimezone(zone)
+        if round_trip.replace(tzinfo=None) == parsed:
+            return candidate
+    raise ValueError(f"invalid local time {value!r} in timezone {timezone!r}")
 
 
 def cron_from_datetime(value: datetime) -> str:

--- a/infrastructure/scheduling/scheduler/runner.py
+++ b/infrastructure/scheduling/scheduler/runner.py
@@ -1,6 +1,6 @@
 """APScheduler-backed blocking runner for scheduled tasks.
 
-Loads all enabled tasks from the store, creates CronTrigger jobs, and
+Loads all enabled tasks from the store, creates APScheduler jobs, and
 blocks until SIGINT/SIGTERM. Fire times for dedup are passed directly from the
 APScheduler executor to each callback (UTC, minute precision), not recovered
 from listener timing or wall-clock time inside the callback.
@@ -20,6 +20,7 @@ from config.constants.turn_concurrency import (
     DEFAULT_SCHEDULED_RUN_CONCURRENCY,
     OPENSRE_SCHEDULER_MAX_CONCURRENT_RUNS_ENV,
 )
+from config.constants.work_items import WORK_ITEM_REMINDER_RUN_AT_PARAM
 from infrastructure.scheduling.scheduler.executor import execute_task
 from infrastructure.scheduling.scheduler.operation_log import (
     record_scheduler_execution_operation,
@@ -43,7 +44,7 @@ from infrastructure.scheduling.scheduler.storage import (
     try_queue_run,
     update_task,
 )
-from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskStatus
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind, TaskStatus
 
 logger = logging.getLogger(__name__)
 TaskFilter = Callable[[ScheduledTask], bool]
@@ -53,10 +54,27 @@ _RECOVERY_INTERVAL_SECONDS = 60
 
 
 def _make_trigger(task: ScheduledTask) -> Any:
-    """Build an APScheduler CronTrigger from a task's cron expression and timezone.
+    """Build an APScheduler trigger from a task's schedule and timezone.
 
     Raises ValueError if the cron expression or timezone is invalid.
     """
+    if task.kind is TaskKind.WORK_ITEM_REMINDER:
+        run_at = task.params.get(WORK_ITEM_REMINDER_RUN_AT_PARAM, "").strip()
+        if run_at:
+            from apscheduler.triggers.date import DateTrigger
+
+            try:
+                run_date = datetime.fromisoformat(run_at)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid work-item reminder run_at for task {task.id}: {run_at!r}"
+                ) from exc
+            if run_date.tzinfo is None:
+                raise ValueError(
+                    f"Invalid work-item reminder run_at for task {task.id}: timezone missing"
+                )
+            return DateTrigger(run_date=run_date)
+
     from apscheduler.triggers.cron import CronTrigger
 
     parts = task.cron.split()
@@ -82,7 +100,7 @@ def _next_run_from_trigger(trigger: Any, now: datetime | None = None) -> str | N
 
 
 def compute_next_run(task: ScheduledTask, now: datetime | None = None) -> str | None:
-    """Return the task's next UTC cron fire time, or raise for invalid schedules."""
+    """Return the task's next UTC fire time, or raise for an invalid schedule."""
     return _next_run_from_trigger(_make_trigger(task), now)
 
 

--- a/infrastructure/scheduling/scheduler/storage/legacy_task_migration.py
+++ b/infrastructure/scheduling/scheduler/storage/legacy_task_migration.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from pathlib import Path
 
+from filelock import Timeout
+
 from config.constants.work_items import WORK_ITEM_REMINDER_RUN_AT_PARAM
 from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_LEGACY_TASK_KIND_PARAM,
@@ -79,14 +81,18 @@ def _migrate_legacy_work_item_reminder(entry: dict[str, object]) -> bool:
     if not isinstance(timezone, str) or not timezone.strip():
         return False
 
-    from core.domain.work_items import get_work_item, resolve_work_item_datetime
+    from core.domain.work_items import (
+        WorkItemStoreError,
+        get_work_item,
+        resolve_work_item_datetime,
+    )
 
-    item = get_work_item(item_id, store_path=Path(store_path).expanduser())
-    if item is None:
-        return False
     try:
+        item = get_work_item(item_id, store_path=Path(store_path).expanduser())
+        if item is None:
+            return False
         resolved = resolve_work_item_datetime(item.remind_at, timezone)
-    except ValueError:
+    except (OSError, Timeout, ValueError, WorkItemStoreError):
         return False
     if resolved is None:
         return False

--- a/infrastructure/scheduling/scheduler/storage/legacy_task_migration.py
+++ b/infrastructure/scheduling/scheduler/storage/legacy_task_migration.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from pathlib import Path
 
+from config.constants.work_items import WORK_ITEM_REMINDER_RUN_AT_PARAM
 from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_LEGACY_TASK_KIND_PARAM,
     LOOP_MIGRATION_NOTICE_PARAM,
@@ -29,6 +31,8 @@ def migrate_legacy_task_entries(entries: Iterable[object]) -> bool:
     for entry in entries:
         if not isinstance(entry, dict):
             continue
+        if _migrate_legacy_work_item_reminder(entry):
+            changed = True
         legacy_kind = entry.get("kind")
         if legacy_kind not in _RETIRED_TASK_KINDS:
             continue
@@ -53,6 +57,41 @@ def migrate_legacy_task_entries(entries: Iterable[object]) -> bool:
             f"--prompt <instruction> ...', then remove this task with 'opensre cron remove {task_id}'."
         )
     return changed
+
+
+def _migrate_legacy_work_item_reminder(entry: dict[str, object]) -> bool:
+    """Add an absolute fire time to one legacy work-item reminder entry."""
+    if entry.get("kind") != TaskKind.WORK_ITEM_REMINDER.value:
+        return False
+    params = entry.get("params")
+    if not isinstance(params, dict):
+        return False
+    run_at = params.get(WORK_ITEM_REMINDER_RUN_AT_PARAM)
+    if isinstance(run_at, str) and run_at.strip():
+        return False
+    item_id = params.get("work_item_id")
+    store_path = params.get("store_path")
+    timezone = entry.get("timezone")
+    if not isinstance(item_id, str) or not item_id.strip():
+        return False
+    if not isinstance(store_path, str) or not store_path.strip():
+        return False
+    if not isinstance(timezone, str) or not timezone.strip():
+        return False
+
+    from core.domain.work_items import get_work_item, resolve_work_item_datetime
+
+    item = get_work_item(item_id, store_path=Path(store_path).expanduser())
+    if item is None:
+        return False
+    try:
+        resolved = resolve_work_item_datetime(item.remind_at, timezone)
+    except ValueError:
+        return False
+    if resolved is None:
+        return False
+    params[WORK_ITEM_REMINDER_RUN_AT_PARAM] = resolved.isoformat()
+    return True
 
 
 __all__ = ["migrate_legacy_task_entries"]

--- a/surfaces/cli/commands/work.py
+++ b/surfaces/cli/commands/work.py
@@ -9,15 +9,16 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from config.constants.work_items import WORK_ITEM_REMINDER_RUN_AT_PARAM
 from core.domain.work_items import (
     WORK_ITEM_PRIORITIES,
     WorkItemChannelTarget,
     add_work_item,
     complete_work_items,
-    cron_from_datetime,
     list_work_items,
     parse_work_item_datetime,
     prioritize_work_items,
+    resolve_work_item_datetime,
     work_items_path,
 )
 from infrastructure.scheduling.scheduler.storage import add_task as add_scheduled_task
@@ -107,6 +108,14 @@ def work_add(
     title_text = " ".join(title).strip()
     _validate_datetime("due-at", due_at)
     _validate_datetime("remind-at", remind_at)
+    reminder_timezone = timezone.strip() or "UTC"
+    if remind_at:
+        try:
+            resolve_work_item_datetime(remind_at, reminder_timezone)
+        except ValueError:
+            raise click.BadParameter(
+                "timezone must be a valid IANA timezone", param_hint="--tz"
+            ) from None
     delivery_targets = _parse_delivery_targets(provider, chat_id, targets)
     item = add_work_item(
         title=title_text,
@@ -125,14 +134,15 @@ def work_add(
     if remind_at:
         if not delivery_targets:
             raise click.BadParameter("--remind-at requires --target or --provider/--chat-id")
-        remind_dt = parse_work_item_datetime(remind_at)
-        if remind_dt is not None:
+        parsed_remind_at = parse_work_item_datetime(remind_at)
+        remind_dt = resolve_work_item_datetime(remind_at, reminder_timezone)
+        if remind_dt is not None and parsed_remind_at is not None:
             primary = delivery_targets[0]
-            schedule_timezone = "UTC" if remind_dt.tzinfo is not None else timezone
+            schedule_timezone = "UTC" if parsed_remind_at.tzinfo is not None else reminder_timezone
             scheduled = add_scheduled_task(
                 ScheduledTask(
                     kind=TaskKind.WORK_ITEM_REMINDER,
-                    cron=cron_from_datetime(remind_dt),
+                    cron="",
                     timezone=schedule_timezone,
                     provider=Provider(primary.provider),
                     chat_id=primary.chat_id,
@@ -140,6 +150,7 @@ def work_add(
                         "work_item_id": item.id,
                         "store_path": str(work_items_path()),
                         "disable_after_success": "true",
+                        WORK_ITEM_REMINDER_RUN_AT_PARAM: remind_dt.isoformat(),
                         "delivery_targets": json.dumps(
                             [target.to_dict() for target in delivery_targets],
                             separators=(",", ":"),

--- a/surfaces/cli/commands/work.py
+++ b/surfaces/cli/commands/work.py
@@ -12,6 +12,7 @@ from rich.table import Table
 from config.constants.work_items import WORK_ITEM_REMINDER_RUN_AT_PARAM
 from core.domain.work_items import (
     WORK_ITEM_PRIORITIES,
+    InvalidWorkItemLocalTime,
     WorkItemChannelTarget,
     add_work_item,
     complete_work_items,
@@ -112,6 +113,11 @@ def work_add(
     if remind_at:
         try:
             resolve_work_item_datetime(remind_at, reminder_timezone)
+        except InvalidWorkItemLocalTime:
+            raise click.BadParameter(
+                "remind-at does not exist in the selected timezone",
+                param_hint="--remind-at",
+            ) from None
         except ValueError:
             raise click.BadParameter(
                 "timezone must be a valid IANA timezone", param_hint="--tz"

--- a/surfaces/cli/commands/work.py
+++ b/surfaces/cli/commands/work.py
@@ -12,7 +12,6 @@ from rich.table import Table
 from config.constants.work_items import WORK_ITEM_REMINDER_RUN_AT_PARAM
 from core.domain.work_items import (
     WORK_ITEM_PRIORITIES,
-    InvalidWorkItemLocalTime,
     WorkItemChannelTarget,
     add_work_item,
     complete_work_items,
@@ -112,12 +111,11 @@ def work_add(
     reminder_timezone = timezone.strip() or "UTC"
     if remind_at:
         try:
-            resolve_work_item_datetime(remind_at, reminder_timezone)
-        except InvalidWorkItemLocalTime:
-            raise click.BadParameter(
-                "remind-at does not exist in the selected timezone",
-                param_hint="--remind-at",
-            ) from None
+            if resolve_work_item_datetime(remind_at, reminder_timezone) is None:
+                raise click.BadParameter(
+                    "remind-at does not exist in the selected timezone",
+                    param_hint="--remind-at",
+                )
         except ValueError:
             raise click.BadParameter(
                 "timezone must be a valid IANA timezone", param_hint="--tz"

--- a/tests/scheduler/test_runner.py
+++ b/tests/scheduler/test_runner.py
@@ -369,6 +369,24 @@ class TestComputeNextRun:
 
         assert result == "2026-08-05T08:00:00+00:00"
 
+    def test_work_item_reminder_uses_exact_year(self) -> None:
+        from datetime import UTC, datetime
+
+        task = ScheduledTask(
+            kind=TaskKind.WORK_ITEM_REMINDER,
+            cron="",
+            timezone="UTC",
+            provider=Provider.SLACK,
+            params={
+                "work_item_id": "item-1",
+                "run_at": "2027-09-12T09:00:00+00:00",
+            },
+        )
+
+        result = compute_next_run(task, datetime(2026, 1, 1, tzinfo=UTC))
+
+        assert result == "2027-09-12T09:00:00+00:00"
+
 
 class TestRegisterJobs:
     def test_real_scheduler_registers_and_passes_fire_time(

--- a/tests/scheduler/test_task_store.py
+++ b/tests/scheduler/test_task_store.py
@@ -474,6 +474,28 @@ class TestStoreSurvivesTornWrites:
 
 
 class TestLegacyTaskMigration:
+    def test_unreadable_work_item_store_does_not_abort_task_loading(
+        self, store_path: Path, tmp_path: Path
+    ) -> None:
+        work_items_store = tmp_path / "work_items.json"
+        work_items_store.write_text("{not-json", encoding="utf-8")
+        legacy_task = ScheduledTask(
+            kind=TaskKind.WORK_ITEM_REMINDER,
+            cron="0 9 12 9 *",
+            timezone="UTC",
+            provider=Provider.SLACK,
+            params={
+                "work_item_id": "item-1",
+                "store_path": str(work_items_store),
+            },
+        )
+        add_task(legacy_task, store_path)
+
+        loaded = get_task(legacy_task.id, store_path)
+
+        assert loaded is not None
+        assert WORK_ITEM_REMINDER_RUN_AT_PARAM not in loaded.params
+
     def test_legacy_work_item_reminder_is_migrated_to_an_absolute_run_at(
         self, store_path: Path, tmp_path: Path
     ) -> None:

--- a/tests/scheduler/test_task_store.py
+++ b/tests/scheduler/test_task_store.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from config.constants.work_items import WORK_ITEM_REMINDER_RUN_AT_PARAM
+from core.domain.work_items import add_work_item
 from infrastructure.scheduling.scheduler.storage.run_store import get_runs, try_claim
 from infrastructure.scheduling.scheduler.storage.task_store import (
     _quarantine_unreadable,
@@ -472,6 +474,36 @@ class TestStoreSurvivesTornWrites:
 
 
 class TestLegacyTaskMigration:
+    def test_legacy_work_item_reminder_is_migrated_to_an_absolute_run_at(
+        self, store_path: Path, tmp_path: Path
+    ) -> None:
+        work_items_store = tmp_path / "work_items.json"
+        item = add_work_item(
+            title="Check clusters",
+            remind_at="2027-09-12T09:00",
+            store_path=work_items_store,
+        )
+        legacy_task = ScheduledTask(
+            kind=TaskKind.WORK_ITEM_REMINDER,
+            cron="0 9 12 9 *",
+            timezone="Asia/Kolkata",
+            provider=Provider.SLACK,
+            params={
+                "work_item_id": item.id,
+                "store_path": str(work_items_store),
+                "disable_after_success": "true",
+            },
+        )
+        add_task(legacy_task, store_path)
+
+        migrated = get_task(legacy_task.id, store_path)
+
+        assert migrated is not None
+        assert migrated.params[WORK_ITEM_REMINDER_RUN_AT_PARAM] == "2027-09-12T09:00:00+05:30"
+        persisted = store_path.read_text(encoding="utf-8")
+        assert get_task(legacy_task.id, store_path) is not None
+        assert store_path.read_text(encoding="utf-8") == persisted
+
     @staticmethod
     def _copy_fixture(store_path: Path) -> None:
         fixture = Path(__file__).parents[1] / "fixtures" / "scheduler" / "pre_5981_tasks.json"

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -89,10 +89,11 @@ def test_the_next_run_is_shown_in_the_schedule_timezone(store_path: Path) -> Non
 
     # Act
     schedule_line = ci_loop.loop_card(scheduled).details[0]
+    next_run = schedule_line.split("next ", 1)[1]
 
     # Assert
-    assert "T" not in schedule_line.split("next ")[1]
-    assert schedule_line.endswith("08:00")
+    assert len(next_run.split()) == 4
+    assert next_run.endswith("08:00")
 
 
 def test_unparseable_time_raises_before_anything_is_stored(store_path: Path) -> None:

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -12,6 +12,7 @@ from core.domain.work_items import (
     WorkItemChannelTarget,
     WorkItemPriority,
     make_work_item,
+    resolve_work_item_datetime,
 )
 from infrastructure.scheduling.scheduler.storage import list_tasks
 from infrastructure.scheduling.scheduler.types import Provider
@@ -195,6 +196,11 @@ def test_reminder_scheduling_resolves_naive_datetime_in_requested_timezone(
     task = list_tasks()[0]
     assert task.timezone == "Asia/Kolkata"
     assert task.params["run_at"] == "2027-09-12T09:00:00+05:30"
+
+
+def test_reminder_scheduling_rejects_dst_gap() -> None:
+    with pytest.raises(ValueError, match="invalid local time"):
+        resolve_work_item_datetime("2027-03-14T02:30", "America/New_York")
 
 
 def test_work_task_add_rejects_invalid_timezone_before_persistence(

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -8,7 +8,12 @@ from typing import Any
 
 import pytest
 
-from core.domain.work_items import WorkItemChannelTarget, WorkItemPriority, make_work_item
+from core.domain.work_items import (
+    WorkItemChannelTarget,
+    WorkItemPriority,
+    make_work_item,
+)
+from infrastructure.scheduling.scheduler.storage import list_tasks
 from infrastructure.scheduling.scheduler.types import Provider
 from tools.system.work_items._evidence import map_work_task_list, map_work_task_prioritize
 from tools.system.work_items.delivery import (
@@ -147,14 +152,15 @@ def test_reminder_scheduling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
         remind_at="2026-08-24T10:00:00Z",
     )
     targets = [WorkItemChannelTarget(provider="slack", chat_id="C999")]
-    scheduled = schedule_item_reminder(item, targets=targets, timezone="UTC")
+    scheduled = schedule_item_reminder(item, targets=targets, timezone="Asia/Kolkata")
     assert scheduled is not None
-
-    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
 
     tasks = list_tasks()
     assert len(tasks) == 1
     assert tasks[0].enabled is True
+    assert tasks[0].cron == ""
+    assert tasks[0].timezone == "UTC"
+    assert tasks[0].params["run_at"] == "2026-08-24T10:00:00+00:00"
 
     # Rescheduling with a new reminder time disables the prior reminder
     updated_item = dataclasses.replace(item, remind_at="2026-08-24T14:00:00Z")
@@ -165,6 +171,60 @@ def test_reminder_scheduling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert len(tasks) == 2
     assert tasks[0].enabled is False
     assert tasks[1].enabled is True
+
+
+def test_reminder_scheduling_resolves_naive_datetime_in_requested_timezone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.storage.task_store.default_task_store_path",
+        lambda: tmp_path / "scheduler_tasks.json",
+    )
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.reload_signal.request_scheduler_reload",
+        lambda: None,
+    )
+
+    item = make_work_item(
+        title="Check clusters",
+        remind_at="2027-09-12T09:00",
+    )
+    targets = [WorkItemChannelTarget(provider="slack", chat_id="C999")]
+    schedule_item_reminder(item, targets=targets, timezone="Asia/Kolkata")
+
+    task = list_tasks()[0]
+    assert task.timezone == "Asia/Kolkata"
+    assert task.params["run_at"] == "2027-09-12T09:00:00+05:30"
+
+
+def test_work_task_add_rejects_invalid_timezone_before_persistence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_items_file = tmp_path / "work_items.json"
+    scheduler_file = tmp_path / "scheduler_tasks.json"
+    monkeypatch.setattr("core.domain.work_items.store.work_items_path", lambda: work_items_file)
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.storage.task_store.default_task_store_path",
+        lambda: scheduler_file,
+    )
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.reload_signal.request_scheduler_reload",
+        lambda: None,
+    )
+
+    response = work_task_add(
+        title="Check clusters",
+        remind_at="2027-09-12T09:00",
+        channel_provider="slack",
+        timezone="Invalid/Timezone",
+    )
+
+    assert response == {
+        "error": "invalid_timezone",
+        "detail": "timezone must be a valid IANA timezone",
+    }
+    assert not work_items_file.exists()
+    assert list_tasks(scheduler_file) == []
 
 
 def test_work_task_tools_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -9,11 +9,9 @@ from typing import Any
 import pytest
 
 from core.domain.work_items import (
-    InvalidWorkItemLocalTime,
     WorkItemChannelTarget,
     WorkItemPriority,
     make_work_item,
-    resolve_work_item_datetime,
 )
 from infrastructure.scheduling.scheduler.storage import list_tasks
 from infrastructure.scheduling.scheduler.types import Provider
@@ -197,11 +195,6 @@ def test_reminder_scheduling_resolves_naive_datetime_in_requested_timezone(
     task = list_tasks()[0]
     assert task.timezone == "Asia/Kolkata"
     assert task.params["run_at"] == "2027-09-12T09:00:00+05:30"
-
-
-def test_reminder_scheduling_rejects_dst_gap() -> None:
-    with pytest.raises(InvalidWorkItemLocalTime, match="invalid local time"):
-        resolve_work_item_datetime("2027-03-14T02:30", "America/New_York")
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from core.domain.work_items import (
+    InvalidWorkItemLocalTime,
     WorkItemChannelTarget,
     WorkItemPriority,
     make_work_item,
@@ -199,12 +200,37 @@ def test_reminder_scheduling_resolves_naive_datetime_in_requested_timezone(
 
 
 def test_reminder_scheduling_rejects_dst_gap() -> None:
-    with pytest.raises(ValueError, match="invalid local time"):
+    with pytest.raises(InvalidWorkItemLocalTime, match="invalid local time"):
         resolve_work_item_datetime("2027-03-14T02:30", "America/New_York")
 
 
-def test_work_task_add_rejects_invalid_timezone_before_persistence(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("remind_at", "timezone", "expected"),
+    [
+        (
+            "2027-09-12T09:00",
+            "Invalid/Timezone",
+            {
+                "error": "invalid_timezone",
+                "detail": "timezone must be a valid IANA timezone",
+            },
+        ),
+        (
+            "2027-03-14T02:30",
+            "America/New_York",
+            {
+                "error": "invalid_remind_at",
+                "detail": "remind_at does not exist in the specified timezone",
+            },
+        ),
+    ],
+)
+def test_work_task_add_rejects_invalid_reminder_before_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    remind_at: str,
+    timezone: str,
+    expected: dict[str, str],
 ) -> None:
     work_items_file = tmp_path / "work_items.json"
     scheduler_file = tmp_path / "scheduler_tasks.json"
@@ -220,15 +246,12 @@ def test_work_task_add_rejects_invalid_timezone_before_persistence(
 
     response = work_task_add(
         title="Check clusters",
-        remind_at="2027-09-12T09:00",
+        remind_at=remind_at,
         channel_provider="slack",
-        timezone="Invalid/Timezone",
+        timezone=timezone,
     )
 
-    assert response == {
-        "error": "invalid_timezone",
-        "detail": "timezone must be a valid IANA timezone",
-    }
+    assert response == expected
     assert not work_items_file.exists()
     assert list_tasks(scheduler_file) == []
 

--- a/tools/system/work_items/reminders.py
+++ b/tools/system/work_items/reminders.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 
+from config.constants.work_items import WORK_ITEM_REMINDER_RUN_AT_PARAM
 from core.domain.work_items import (
     WorkItem,
     WorkItemChannelTarget,
-    cron_from_datetime,
     parse_work_item_datetime,
+    resolve_work_item_datetime,
     work_items_path,
 )
 from infrastructure.scheduling.scheduler.storage import add_task as add_scheduled_task
@@ -42,9 +43,13 @@ def schedule_item_reminder(
     """Schedule or replace a one-shot work item reminder task."""
     if not item.remind_at:
         return None
-    remind_at = parse_work_item_datetime(item.remind_at)
+    schedule_timezone = timezone.strip() or "UTC"
+    parsed_remind_at = parse_work_item_datetime(item.remind_at)
+    remind_at = resolve_work_item_datetime(item.remind_at, schedule_timezone)
     if remind_at is None:
         return None
+    if parsed_remind_at is not None and parsed_remind_at.tzinfo is not None:
+        schedule_timezone = "UTC"
     valid_targets = [target for target in targets if validate_provider(target.provider) is not None]
     if not valid_targets:
         return None
@@ -52,10 +57,9 @@ def schedule_item_reminder(
     disable_existing_item_reminders(item.id)
     primary = valid_targets[0]
     parsed_provider = Provider(primary.provider)
-    schedule_timezone = "UTC" if remind_at.tzinfo is not None else timezone
     task = ScheduledTask(
         kind=TaskKind.WORK_ITEM_REMINDER,
-        cron=cron_from_datetime(remind_at),
+        cron="",
         timezone=schedule_timezone,
         provider=parsed_provider,
         chat_id=primary.chat_id,
@@ -63,6 +67,7 @@ def schedule_item_reminder(
             "work_item_id": item.id,
             "store_path": str(work_items_path()),
             "disable_after_success": "true",
+            WORK_ITEM_REMINDER_RUN_AT_PARAM: remind_at.isoformat(),
             "delivery_targets": json.dumps(
                 [target.to_dict() for target in valid_targets], separators=(",", ":")
             ),

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -9,7 +9,6 @@ from core.domain.types.tools import ToolSurface
 from core.domain.work_items import (
     WORK_ITEM_PRIORITIES,
     WORK_ITEM_STATUSES,
-    InvalidWorkItemLocalTime,
     WorkItemChannelTarget,
     WorkItemPriority,
     WorkItemUpdates,
@@ -173,12 +172,11 @@ def work_task_add(
         }
     if remind_at:
         try:
-            resolve_work_item_datetime(remind_at, timezone.strip() or "UTC")
-        except InvalidWorkItemLocalTime:
-            return {
-                "error": "invalid_remind_at",
-                "detail": "remind_at does not exist in the specified timezone",
-            }
+            if resolve_work_item_datetime(remind_at, timezone.strip() or "UTC") is None:
+                return {
+                    "error": "invalid_remind_at",
+                    "detail": "remind_at does not exist in the specified timezone",
+                }
         except ValueError:
             return {
                 "error": "invalid_timezone",
@@ -378,12 +376,11 @@ def work_task_update(
             return error
     if remind_at:
         try:
-            resolve_work_item_datetime(remind_at, timezone.strip() or "UTC")
-        except InvalidWorkItemLocalTime:
-            return {
-                "error": "invalid_remind_at",
-                "detail": "remind_at does not exist in the specified timezone",
-            }
+            if resolve_work_item_datetime(remind_at, timezone.strip() or "UTC") is None:
+                return {
+                    "error": "invalid_remind_at",
+                    "detail": "remind_at does not exist in the specified timezone",
+                }
         except ValueError:
             return {
                 "error": "invalid_timezone",

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -17,6 +17,7 @@ from core.domain.work_items import (
     list_work_items,
     make_work_item,
     prioritize_work_items,
+    resolve_work_item_datetime,
     resolve_work_item_selector,
     update_work_item,
     work_items_path,
@@ -169,6 +170,14 @@ def work_task_add(
                 "a gateway chat with an active channel"
             ),
         }
+    if remind_at:
+        try:
+            resolve_work_item_datetime(remind_at, timezone.strip() or "UTC")
+        except ValueError:
+            return {
+                "error": "invalid_timezone",
+                "detail": "timezone must be a valid IANA timezone",
+            }
     item = add_work_item(
         title=title,
         priority=parsed_priority,
@@ -361,6 +370,14 @@ def work_task_update(
         error = validate_datetime_arg(value, field=field_name)
         if error is not None:
             return error
+    if remind_at:
+        try:
+            resolve_work_item_datetime(remind_at, timezone.strip() or "UTC")
+        except ValueError:
+            return {
+                "error": "invalid_timezone",
+                "detail": "timezone must be a valid IANA timezone",
+            }
     explicit_targets = delivery_targets(
         provider=channel_provider,
         chat_id=channel_id,

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -9,6 +9,7 @@ from core.domain.types.tools import ToolSurface
 from core.domain.work_items import (
     WORK_ITEM_PRIORITIES,
     WORK_ITEM_STATUSES,
+    InvalidWorkItemLocalTime,
     WorkItemChannelTarget,
     WorkItemPriority,
     WorkItemUpdates,
@@ -173,6 +174,11 @@ def work_task_add(
     if remind_at:
         try:
             resolve_work_item_datetime(remind_at, timezone.strip() or "UTC")
+        except InvalidWorkItemLocalTime:
+            return {
+                "error": "invalid_remind_at",
+                "detail": "remind_at does not exist in the specified timezone",
+            }
         except ValueError:
             return {
                 "error": "invalid_timezone",
@@ -373,6 +379,11 @@ def work_task_update(
     if remind_at:
         try:
             resolve_work_item_datetime(remind_at, timezone.strip() or "UTC")
+        except InvalidWorkItemLocalTime:
+            return {
+                "error": "invalid_remind_at",
+                "detail": "remind_at does not exist in the specified timezone",
+            }
         except ValueError:
             return {
                 "error": "invalid_timezone",


### PR DESCRIPTION
  Fixes #6197

  #### Describe the changes you have made in this PR -

  - Store the resolved reminder instant instead of encoding one-shot reminders as recurring five-field cron expressions.
  - Use APScheduler `DateTrigger` so reminders preserve the requested year and exact time.
  - Resolve naive datetimes using the requested IANA timezone.
  - Reject invalid timezones before persisting work items or schedules.
  - Add regressions for future-year reminders, timezone handling, and invalid timezone input.

  **Explain your implementation approach:**

  The existing implementation converted one-shot reminders into five-field cron expressions, which omitted the year and could schedule a future reminder in the current year. The fix stores the resolved absolute timestamp in the task parameters and uses a date trigger for work-item reminders. Existing recurring cron tasks continue using the existing cron path.

Invalid IANA timezones are validated before work-item creation or schedule persistence. Tests cover future-year reminders, naive and offset-aware datetime behavior, and invalid timezone rejection.