### PR TITLE
fix: clear task plans when skill menus are cancelled

### DIFF
--- a/core/agent_harness/session_goal/goal.py
+++ b/core/agent_harness/session_goal/goal.py
@@ -31,6 +31,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from typing import Any
 
+from core.agent_harness.task_plan.discard import discard_task_plan
 from infrastructure.evidence.evidence_compaction import truncate_message
 
 
@@ -446,19 +447,13 @@ def attach_session_goal(session: Any, goal: SessionGoal) -> SessionGoal:
         goal = mark_session_goal_started(goal, session=session)
     session.session_goal = goal
     if new_identity:
-        _discard_session_task_plan(session)
+        discard_task_plan(session)
     return goal
 
 
 def clear_session_goal(session: Any) -> None:
     session.session_goal = None
-    _discard_session_task_plan(session)
-
-
-def _discard_session_task_plan(session: Any) -> None:
-    """Drop the live plan so a later goal cannot inherit completed steps."""
-    if hasattr(session, "task_plan"):
-        session.task_plan = None
+    discard_task_plan(session)
 
 
 def session_goal_elapsed_seconds(

--- a/core/agent_harness/spi/task_plan.py
+++ b/core/agent_harness/spi/task_plan.py
@@ -6,6 +6,7 @@ checklist and parses an ``update_plan`` payload through :func:`parse_task_plan`.
 
 from __future__ import annotations
 
+from core.agent_harness.task_plan.discard import discard_task_plan
 from core.agent_harness.task_plan.display import (
     ensure_active_step,
     is_plan_diagnosis_prose,
@@ -46,6 +47,7 @@ __all__ = [
     "apply_update_plan_host_policy",
     "apply_update_plan_session",
     "demote_unevidenced_completions",
+    "discard_task_plan",
     "ensure_active_step",
     "format_plan_header",
     "format_task_plan_plain",

--- a/core/agent_harness/task_plan/__init__.py
+++ b/core/agent_harness/task_plan/__init__.py
@@ -11,6 +11,7 @@ Leaves:
 
 from __future__ import annotations
 
+from core.agent_harness.task_plan.discard import discard_task_plan
 from core.agent_harness.task_plan.plan import (
     PlanStep,
     PlanStepStatus,
@@ -30,6 +31,7 @@ __all__ = [
     "PlanStep",
     "PlanStepStatus",
     "TaskPlan",
+    "discard_task_plan",
     "format_plan_header",
     "format_task_plan_plain",
     "parse_task_plan",

--- a/core/agent_harness/task_plan/discard.py
+++ b/core/agent_harness/task_plan/discard.py
@@ -1,0 +1,17 @@
+"""Discard the live task plan and its derived session state."""
+
+from typing import Any
+
+
+def discard_task_plan(session: Any) -> None:
+    """Drop the live checklist and every field derived from it, when present."""
+    if hasattr(session, "task_plan"):
+        session.task_plan = None
+    if hasattr(session, "task_plan_work"):
+        session.task_plan_work = []
+    if hasattr(session, "task_plan_work_step_texts"):
+        session.task_plan_work_step_texts = None
+    if hasattr(session, "task_plan_breakdown_emitted"):
+        session.task_plan_breakdown_emitted = False
+    if hasattr(session, "plan_only_until_authorized"):
+        session.plan_only_until_authorized = False

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -20,6 +20,7 @@ from core.agent_harness.spi.handoff import (
     format_ask_user_answers,
     question_key,
 )
+from core.agent_harness.spi.task_plan import discard_task_plan
 from infrastructure.terminal import theme as ui_theme
 from infrastructure.terminal.notify import NotifyEvent, play_notification
 from surfaces.interactive_shell.command_registry.types import SlashCommand
@@ -68,6 +69,7 @@ def _leave_menu(session: Session, console: Console, note: str) -> None:
     session.terminal.awaiting_handoff_answer = False
     if session.active_skill is not None:
         session.skills_already_prompted.discard(session.active_skill)
+        discard_task_plan(session)
     session.active_skill = None
     session.active_skill_tools = ()
     session.skill_hooks_fired = set()

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -12,6 +12,7 @@ from prompt_toolkit import PromptSession
 from rich.console import Console
 
 from config.repl_config import ReplConfig
+from core.agent_harness.spi.task_plan import discard_task_plan
 from core.domain.alerts import inbox as _alert_inbox
 from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskPool
 from surfaces.interactive_shell.runtime.ci_fix_status import bind_ci_fix_status
@@ -291,7 +292,7 @@ class InteractiveShellController:
                         and plan.all_completed
                         and not self.state.is_dispatch_running()
                     ):
-                        self.session.task_plan = None
+                        discard_task_plan(self.session)
                 # Only exclusive-stdin commands hold the next prompt. A ``/goal``
                 # work turn keeps it open: the prompt row is where the spinner,
                 # the live tool name and the Auto line are painted, so

--- a/tests/core/agent_harness/task_plan/test_discard.py
+++ b/tests/core/agent_harness/task_plan/test_discard.py
@@ -1,0 +1,43 @@
+"""Discarding a plan clears state that could leak into a later checklist."""
+
+from types import SimpleNamespace
+
+from core.agent_harness.task_plan import PlanStep, PlanStepStatus, TaskPlan, discard_task_plan
+from core.agent_harness.task_plan.work_log import sync_task_plan_work_for_plan
+
+
+def test_discard_resets_the_plan_and_every_derived_field() -> None:
+    plan = TaskPlan(
+        steps=(
+            PlanStep("Inspect CI failures", PlanStepStatus.IN_PROGRESS),
+            PlanStep("Schedule CI fixes", PlanStepStatus.PENDING),
+        )
+    )
+    session = SimpleNamespace(
+        task_plan=plan,
+        task_plan_work=[["GitHub CLI · inspect checks"], []],
+        task_plan_work_step_texts=tuple(item.step for item in plan.steps),
+        task_plan_breakdown_emitted=True,
+        plan_only_until_authorized=True,
+    )
+
+    discard_task_plan(session)
+
+    assert session.task_plan is None
+    assert session.task_plan_work == []
+    assert session.task_plan_work_step_texts is None
+    assert session.task_plan_breakdown_emitted is False
+    assert session.plan_only_until_authorized is False
+
+    # Re-entering the same skill must start a fresh log even with identical steps.
+    session.task_plan = plan
+    sync_task_plan_work_for_plan(session, plan)
+    assert session.task_plan_work == [[], []]
+
+
+def test_discard_does_not_add_fields_to_a_session_without_plan_state() -> None:
+    session = SimpleNamespace()
+
+    discard_task_plan(session)
+
+    assert vars(session) == {}

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -179,6 +179,7 @@ SPI_ROLE_NAMES: dict[str, frozenset[str]] = {
             "apply_update_plan_host_policy",
             "apply_update_plan_session",
             "demote_unevidenced_completions",
+            "discard_task_plan",
             "ensure_active_step",
             "format_plan_header",
             "format_task_plan_plain",

--- a/tests/interactive_shell/runtime/test_controller_input_actions.py
+++ b/tests/interactive_shell/runtime/test_controller_input_actions.py
@@ -169,11 +169,45 @@ async def test_idle_new_turn_clears_a_completed_plan() -> None:
     """A finished plan must not linger over the next unrelated typed turn."""
     controller = _controller()
     controller.session.task_plan = _plan("completed", "completed")
+    controller.session.task_plan_work = [["Prior work"], []]
+    controller.session.task_plan_work_step_texts = ("Step 1", "Step 2")
+    controller.session.plan_only_until_authorized = True
 
     kept = await controller._handle_input_action(SubmitTurn(text="new question"))
 
     assert kept is True
     assert controller.session.task_plan is None
+    assert controller.session.task_plan_work == []
+    assert controller.session.task_plan_work_step_texts is None
+    assert controller.session.plan_only_until_authorized is False
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_running_turn_keeps_its_skill_and_plan() -> None:
+    import asyncio
+    import threading
+
+    controller = _controller()
+    plan = _plan("in_progress", "pending")
+    controller.session.task_plan = plan
+    controller.session.active_skill = "scheduling-github-ci-fixes"
+    cancel_event = threading.Event()
+
+    async def _hold() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_hold())
+    controller.state.start_dispatch(task=task, cancel_event=cancel_event)
+    try:
+        kept = await controller._handle_input_action(CancelTurn())
+
+        assert kept is True
+        assert cancel_event.is_set()
+        assert controller.session.task_plan is plan
+        assert controller.session.active_skill == "scheduling-github-ci-fixes"
+    finally:
+        task.cancel()
+        _ = await asyncio.gather(task, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -13,8 +13,12 @@ from core.agent_harness.session.pending_choice import (
     PendingUserChoice,
     format_ask_user_answers,
 )
+from core.agent_harness.task_plan import PlanStep, PlanStepStatus, TaskPlan
+from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.ask_user import CUSTOM_OPTION
+from surfaces.interactive_shell.ui.input_prompt.rendering import resolve_prompt_placeholder
+from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
 
 _CHOICE = PendingUserChoice(
     title="How should I handle the uncommitted changes?",
@@ -80,6 +84,64 @@ def test_cancelled_menu_leaves_prompt_free(monkeypatch: pytest.MonkeyPatch) -> N
     assert session.terminal.pending_prompt_default is None
     assert session.terminal.pending_prompt_autosubmit is False
     assert "cancelled" in buf.getvalue().lower()
+
+
+@pytest.mark.parametrize("plan_only", [False, True])
+def test_cancelling_a_skill_menu_drops_the_skill_plan(
+    monkeypatch: pytest.MonkeyPatch, plan_only: bool
+) -> None:
+    session = Session()
+    plain_placeholder = resolve_prompt_placeholder(session)
+    session.pending_user_choice = _CHOICE
+    session.active_skill = "scheduling-github-ci-fixes"
+    session.skills_already_prompted.add(session.active_skill)
+    session.task_plan = TaskPlan(
+        steps=(
+            PlanStep(
+                "Inspect CI failures",
+                PlanStepStatus.PENDING if plan_only else PlanStepStatus.IN_PROGRESS,
+            ),
+            PlanStep("Schedule CI fixes", PlanStepStatus.PENDING),
+        )
+    )
+    session.plan_only_until_authorized = plan_only
+    state, spinner = ReplState(), SpinnerState()
+    assert "Plan" in render_prompt_region(session, state, spinner).value
+    assert resolve_prompt_placeholder(session) != plain_placeholder
+    console, _buf = _console()
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(choice_prompt, "repl_choose_one", lambda **_kw: None)
+
+    assert _handler(session, console) is True
+
+    assert session.active_skill is None
+    assert "scheduling-github-ci-fixes" not in session.skills_already_prompted
+    assert session.task_plan is None
+    assert session.plan_only_until_authorized is False
+    assert "Plan" not in render_prompt_region(session, state, spinner).value
+    assert resolve_prompt_placeholder(session) == plain_placeholder
+
+
+def test_cancelling_a_menu_without_a_skill_keeps_the_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = Session()
+    session.pending_user_choice = _CHOICE
+    plan = TaskPlan(
+        steps=(
+            PlanStep("Inspect CI failures", PlanStepStatus.IN_PROGRESS),
+            PlanStep("Schedule CI fixes", PlanStepStatus.PENDING),
+        )
+    )
+    session.task_plan = plan
+    session.plan_only_until_authorized = True
+    console, _buf = _console()
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(choice_prompt, "repl_choose_one", lambda **_kw: None)
+
+    assert _handler(session, console) is True
+
+    assert session.active_skill is None
+    assert session.task_plan is plan
+    assert session.plan_only_until_authorized is True
 
 
 def test_no_pending_choice_prints_notice() -> None:


### PR DESCRIPTION
Issue: reported directly; no linked issue.

#### Describe the changes you have made in this PR -

Cancelling an Ask User menu during an active skill ended the skill but left its unfinished checklist pinned above subsequent requests. Esc now discards that checklist and its derived work-log state and authorization latch when the shell ends the skill. Skip-demo and repository-picker cancellation use the same cleanup path.

The shared `discard_task_plan` helper also handles goal replacement/clearing and completed-plan dismissal. It is exposed through the harness task-plan API and tolerates sessions without plan fields. Cancelling a menu without an active skill and interrupting a running turn still preserve the plan.

Cancellation policy: leaving an active skill ends the current workflow and discards the session's live checklist, including a checklist that predates opening `/demo`. This is intentional. Plan preservation applies when no skill is active or when a running turn is interrupted. The shell does not track or restore separate plan ownership.

### Demo/Screenshot for feature changes and bug fixes -

Terminal smoke check using the real picker and prompt controller with a seeded seven-step CI-fix demo plan:

```text
Before Esc:
Plan · 1/7
> continue the plan, or type a message

After Esc in /choose:
Selection cancelled — type a reply instead.
Auto (High) · Allow all
> Ask about an alert

PASS: Esc closed the real menu, removed the plan and continuation hint,
and resumed editable input.
```

No extra prompt notification was needed. The complete model-driven demo was not run; the smoke check seeded the state present when its menu opens.

Validation:

- Reproduced the failure before the fix with the new skill-menu cancellation regression.
- `make lint`, `make format-check`, and `make typecheck` passed.
- 372 focused tests passed:

```bash
uv run python -m pytest \
  tests/interactive_shell/test_choice_prompt.py \
  tests/interactive_shell/command_registry/ \
  tests/interactive_shell/runtime/test_controller_input_actions.py \
  tests/core/agent_harness/task_plan \
  tests/core/agent_harness/session_goal \
  tests/interactive_shell/ui/test_task_plan.py \
  tests/interactive_shell/ui/test_input_prompt.py \
  tests/interactive_shell/runtime/test_prompt_builder.py \
  tests/interactive_shell/test_harness_api_border.py \
  tests/core/agent_harness/test_harness_api.py -q
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

Implementation and self-review were performed by Codex. These checks do not assert a human review.

**Explain your implementation approach:**

A guarded helper in the task-plan package clears the plan, work entries, step-text identity, breakdown marker, and plan-only latch together. Resetting the identity prevents a later run with identical steps from inheriting old work. The shell invokes it only when leaving an active skill; the controller retains its existing conditions for dismissing completed plans. Existing goal cleanup delegates to the same helper. Regression tests cover cancellation with and without a skill, plan-only and executing overlays, repeated plan identities, minimal sessions, and interruption of a running turn.

---

## Checklist before requesting a review
- [x] I have added a proper PR title; this directly reported bug has no linked issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
