### PR TITLE
fix(loops): do not list the opened run again under its own report

### DIFF
--- a/surfaces/interactive_shell/command_registry/loop_show.py
+++ b/surfaces/interactive_shell/command_registry/loop_show.py
@@ -58,7 +58,8 @@ def show_loop(session: Session, console: Console, args: list[str]) -> bool:
             console.print(Text(f"Run {run_id} was not found for this loop.", style=ERROR))
             return True
         runs = restore_legacy_reports([selected, *runs])
-        selected, runs = runs[0], runs[1:]
+        selected = runs[0]
+        runs = [run for run in runs[1:] if run.run_id != selected.run_id]
     else:
         runs = restore_legacy_reports(runs)
         selected = runs[0] if runs else None

--- a/tests/interactive_shell/test_loop_results.py
+++ b/tests/interactive_shell/test_loop_results.py
@@ -177,6 +177,12 @@ def test_commands_show_latest_failure_and_allow_opening_the_earlier_full_report(
     assert (
         "Provider unavailable" not in text
     )  # Selected run's details, not another attempt's error.
+    # The opened attempt is recent enough to be in the history query; it must
+    # not be listed again under its own report.
+    recent = text[text.index("Recent runs") : text.index("Configuration")]
+    assert f" {prior_id} │" not in recent
+    assert f" {get_runs(task.id)[0].run_id} │" in recent
+    assert f"Run {prior_id} " in text
 
 
 @pytest.mark.usefixtures("loop_stores")


### PR DESCRIPTION
Fixes #

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Follow-up to #6222, addressing the open Greptile P2 thread on `surfaces/interactive_shell/command_registry/loop_show.py` (the PR merged before the fix landed on its branch).

`/loops show <loop> --run <id>` prepends the requested attempt to the 20-row recent-history query. When that attempt is itself among the recent rows, it was rendered twice: once as the opened report and again in the **Recent runs** table. The selected run is now dropped from the table by `run_id` after legacy-report restoration.

`test_commands_show_latest_failure_and_allow_opening_the_earlier_full_report` now also asserts the opened run is absent from the table row list while the other attempt remains; it failed before the change (the prior run appeared as a table row) and passes after.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest -q tests/interactive_shell/test_loop_results.py::test_commands_show_latest_failure_and_allow_opening_the_earlier_full_report
1 passed in 0.46s
```

Before the fix the same test fails with the prior run listed in the table:

```
E   assert ' 1 │' not in 'Recent runs Run │ Started │ Result … 1 │ 2026-09-12 … │ Done · 1 workflow fixed …'
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`get_group_runs` returns the newest 20 attempts and `get_group_run` resolves the explicitly requested one. Both lists go through `restore_legacy_reports` together so a legacy report is restored once. The selected run is `runs[0]` afterwards; the table gets `runs[1:]` minus any row sharing its `run_id`. Filtering by id (not identity) is required because `restore_legacy_reports` may return `model_copy` instances. The default path (no `--run`) is unchanged: it opens the newest attempt and lists the full history.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
