### PR TITLE
fix(account): fall back from stale hosted LLM sessions

### DIFF
--- a/config/account.py
+++ b/config/account.py
@@ -240,6 +240,8 @@ def _validated_account_llm_route(record: AccountRecord, token: str) -> AccountLL
 
 def account_llm_route() -> AccountLLMRoute | None:
     """Return the hosted route only while the stored account session validates."""
+    global _account_route_cache
+
     record = load_account_record()
     token = resolve_account_token()
     if record is None or record.llm_provider != "openai" or not token:
@@ -257,7 +259,7 @@ def account_llm_route() -> AccountLLMRoute | None:
         return cached.route
 
     route = _validated_account_llm_route(record, token)
-    globals()["_account_route_cache"] = _AccountRouteCacheEntry(
+    _account_route_cache = _AccountRouteCacheEntry(
         key=key,
         checked_at=now,
         route=route,

--- a/config/account.py
+++ b/config/account.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from threading import Lock
 from time import monotonic
 from urllib.parse import urlsplit, urlunsplit
 
@@ -69,6 +70,7 @@ class _AccountRouteCacheEntry:
 
 
 _account_route_cache: _AccountRouteCacheEntry | None = None
+_account_route_validation_lock = Lock()
 
 
 def normalize_account_app_url(value: str | None = None) -> str:
@@ -160,7 +162,8 @@ def _parse_record(value: object) -> AccountRecord | None:
 
 def _clear_account_route_validation_cache() -> None:
     global _account_route_cache
-    _account_route_cache = None
+    with _account_route_validation_lock:
+        _account_route_cache = None
 
 
 def save_account_record(record: AccountRecord) -> None:
@@ -238,6 +241,23 @@ def _validated_account_llm_route(record: AccountRecord, token: str) -> AccountLL
     )
 
 
+def _account_route_key(record: AccountRecord, token: str) -> tuple[AccountRecord, bytes]:
+    return (record, hashlib.sha256(token.encode("utf-8")).digest())
+
+
+def _cached_account_route(
+    key: tuple[AccountRecord, bytes], now: float
+) -> _AccountRouteCacheEntry | None:
+    cached = _account_route_cache
+    if (
+        cached is not None
+        and cached.key == key
+        and now - cached.checked_at < _ACCOUNT_ROUTE_VALIDATION_TTL_SECONDS
+    ):
+        return cached
+    return None
+
+
 def account_llm_route() -> AccountLLMRoute | None:
     """Return the hosted route only while the stored account session validates."""
     global _account_route_cache
@@ -247,24 +267,30 @@ def account_llm_route() -> AccountLLMRoute | None:
     if record is None or record.llm_provider != "openai" or not token:
         return None
 
-    token_fingerprint = hashlib.sha256(token.encode("utf-8")).digest()
-    key = (record, token_fingerprint)
-    now = monotonic()
-    cached = _account_route_cache
-    if (
-        cached is not None
-        and cached.key == key
-        and now - cached.checked_at < _ACCOUNT_ROUTE_VALIDATION_TTL_SECONDS
-    ):
+    key = _account_route_key(record, token)
+    if (cached := _cached_account_route(key, monotonic())) is not None:
         return cached.route
 
-    route = _validated_account_llm_route(record, token)
-    _account_route_cache = _AccountRouteCacheEntry(
-        key=key,
-        checked_at=now,
-        route=route,
-    )
-    return route
+    with _account_route_validation_lock:
+        # Re-read account state after waiting for another validation or a local
+        # account mutation, then double-check the cache before issuing HTTP.
+        record = load_account_record()
+        token = resolve_account_token()
+        if record is None or record.llm_provider != "openai" or not token:
+            return None
+
+        key = _account_route_key(record, token)
+        now = monotonic()
+        if (cached := _cached_account_route(key, now)) is not None:
+            return cached.route
+
+        route = _validated_account_llm_route(record, token)
+        _account_route_cache = _AccountRouteCacheEntry(
+            key=key,
+            checked_at=now,
+            route=route,
+        )
+        return route
 
 
 __all__ = [

--- a/config/account.py
+++ b/config/account.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import tempfile
@@ -9,10 +10,12 @@ from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from time import monotonic
 from urllib.parse import urlsplit, urlunsplit
 
 from filelock import FileLock
 
+from config.account_validation import AccountValidationState, validate_account_session
 from config.constants.account import (
     OPENSRE_ACCOUNT_FILENAME,
     OPENSRE_ACCOUNT_LLM_BASE_PATH,
@@ -31,6 +34,7 @@ from config.secrets.store import (
 
 _VERSION = 1
 _LOCK_TIMEOUT_SECONDS = 10.0
+_ACCOUNT_ROUTE_VALIDATION_TTL_SECONDS = 60.0
 
 
 @dataclass(frozen=True)
@@ -53,6 +57,18 @@ class AccountLLMRoute:
 
     base_url: str
     model: str
+
+
+@dataclass(frozen=True)
+class _AccountRouteCacheEntry:
+    """Short-lived result of validating the hosted LLM route."""
+
+    key: tuple[AccountRecord, bytes]
+    checked_at: float
+    route: AccountLLMRoute | None
+
+
+_account_route_cache: _AccountRouteCacheEntry | None = None
 
 
 def normalize_account_app_url(value: str | None = None) -> str:
@@ -142,12 +158,18 @@ def _parse_record(value: object) -> AccountRecord | None:
     )
 
 
+def _clear_account_route_validation_cache() -> None:
+    global _account_route_cache
+    _account_route_cache = None
+
+
 def save_account_record(record: AccountRecord) -> None:
     """Atomically persist non-secret account metadata with mode ``0600``."""
     path = account_metadata_path()
     _ensure_parent(path)
     with FileLock(str(_lock_path(path)), timeout=_LOCK_TIMEOUT_SECONDS):
         _write_record(path, record)
+    _clear_account_route_validation_cache()
 
 
 def load_account_record() -> AccountRecord | None:
@@ -168,10 +190,10 @@ def load_account_record() -> AccountRecord | None:
 def delete_account_record() -> None:
     """Delete the local non-secret account record when present."""
     path = account_metadata_path()
-    if not path.exists():
-        return
-    with FileLock(str(_lock_path(path)), timeout=_LOCK_TIMEOUT_SECONDS):
-        path.unlink(missing_ok=True)
+    if path.exists():
+        with FileLock(str(_lock_path(path)), timeout=_LOCK_TIMEOUT_SECONDS):
+            path.unlink(missing_ok=True)
+    _clear_account_route_validation_cache()
 
 
 def resolve_account_token() -> str:
@@ -187,22 +209,60 @@ def stored_account_token() -> str:
 def save_account_token(value: str) -> None:
     """Persist the OpenSRE account bearer token in owner-only credential storage."""
     save_secret(OPENSRE_ACCOUNT_TOKEN_ENV, value)
+    _clear_account_route_validation_cache()
 
 
 def delete_account_token() -> None:
     """Delete the locally persisted OpenSRE account bearer token."""
     delete_secret(OPENSRE_ACCOUNT_TOKEN_ENV)
+    _clear_account_route_validation_cache()
+
+
+def _validated_account_llm_route(record: AccountRecord, token: str) -> AccountLLMRoute | None:
+    try:
+        app_url = normalize_account_app_url(record.app_url)
+    except ValueError:
+        return None
+
+    validation = validate_account_session(
+        app_url=app_url,
+        token=token,
+        expected_user_id=record.user_id,
+        expected_organization_id=record.organization_id,
+    )
+    if validation.state is not AccountValidationState.ACTIVE or validation.llm_model is None:
+        return None
+    return AccountLLMRoute(
+        base_url=f"{app_url}{OPENSRE_ACCOUNT_LLM_BASE_PATH}",
+        model=validation.llm_model,
+    )
 
 
 def account_llm_route() -> AccountLLMRoute | None:
-    """Return the hosted OpenAI route only when account metadata and token exist."""
+    """Return the hosted route only while the stored account session validates."""
     record = load_account_record()
-    if record is None or record.llm_provider != "openai" or not resolve_account_token():
+    token = resolve_account_token()
+    if record is None or record.llm_provider != "openai" or not token:
         return None
-    return AccountLLMRoute(
-        base_url=f"{record.app_url.rstrip('/')}{OPENSRE_ACCOUNT_LLM_BASE_PATH}",
-        model=record.llm_model,
+
+    token_fingerprint = hashlib.sha256(token.encode("utf-8")).digest()
+    key = (record, token_fingerprint)
+    now = monotonic()
+    cached = _account_route_cache
+    if (
+        cached is not None
+        and cached.key == key
+        and now - cached.checked_at < _ACCOUNT_ROUTE_VALIDATION_TTL_SECONDS
+    ):
+        return cached.route
+
+    route = _validated_account_llm_route(record, token)
+    globals()["_account_route_cache"] = _AccountRouteCacheEntry(
+        key=key,
+        checked_at=now,
+        route=route,
     )
+    return route
 
 
 __all__ = [

--- a/config/account_validation.py
+++ b/config/account_validation.py
@@ -1,0 +1,128 @@
+"""Remote validation for locally stored OpenSRE account sessions."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from http import HTTPStatus
+
+import httpx
+
+from config.constants.account import (
+    OPENSRE_ACCOUNT_HTTP_TIMEOUT_SECONDS,
+    OPENSRE_ACCOUNT_SESSION_PATH,
+)
+
+
+class AccountValidationState(StrEnum):
+    """Remote validation states for a complete local account session."""
+
+    ACTIVE = "active"
+    INVALID = "invalid"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class AccountValidation:
+    """Validated hosted-account state returned by the OpenSRE web app."""
+
+    state: AccountValidationState
+    detail: str
+    llm_provider: str | None = None
+    llm_model: str | None = None
+    expires_at: str | None = None
+
+    @property
+    def active(self) -> bool:
+        """Whether the validated session may use the hosted LLM route."""
+        return self.state is AccountValidationState.ACTIVE
+
+
+def _mapping(value: object, key: str) -> Mapping[str, object] | None:
+    if not isinstance(value, Mapping):
+        return None
+    nested = value.get(key)
+    return nested if isinstance(nested, Mapping) else None
+
+
+def validate_account_session(
+    *,
+    app_url: str,
+    token: str,
+    expected_user_id: str,
+    expected_organization_id: str,
+) -> AccountValidation:
+    """Validate a complete local account session against the OpenSRE web app."""
+    try:
+        response = httpx.get(
+            f"{app_url.rstrip('/')}{OPENSRE_ACCOUNT_SESSION_PATH}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=OPENSRE_ACCOUNT_HTTP_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError:
+        return AccountValidation(
+            AccountValidationState.UNAVAILABLE,
+            "The OpenSRE app could not be reached to validate this login.",
+        )
+
+    if response.status_code == HTTPStatus.UNAUTHORIZED:
+        return AccountValidation(
+            AccountValidationState.INVALID,
+            "The stored OpenSRE login has expired or was revoked.",
+        )
+    if response.status_code != HTTPStatus.OK:
+        return AccountValidation(
+            AccountValidationState.UNAVAILABLE,
+            "The OpenSRE app could not validate this login.",
+        )
+
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        payload = None
+
+    user = _mapping(payload, "user")
+    organization = _mapping(payload, "organization")
+    llm = _mapping(payload, "llm")
+    if user is None or organization is None or llm is None or not isinstance(payload, Mapping):
+        return AccountValidation(
+            AccountValidationState.INVALID,
+            "The OpenSRE app returned account or hosted-model state that does not match this login.",
+        )
+
+    user_id = user.get("id")
+    organization_id = organization.get("id")
+    provider = llm.get("provider")
+    model = llm.get("model")
+    expires_at = payload.get("expires_at")
+    if (
+        user_id != expected_user_id
+        or organization_id != expected_organization_id
+        or provider != "openai"
+        or not isinstance(model, str)
+        or not model.strip()
+        or not isinstance(expires_at, str)
+        or not expires_at
+    ):
+        return AccountValidation(
+            AccountValidationState.INVALID,
+            "The OpenSRE app returned account or hosted-model state that does not match this login.",
+        )
+
+    normalized_model = model.strip()
+    return AccountValidation(
+        AccountValidationState.ACTIVE,
+        f"Authenticated with OpenSRE; LLM provider: openai ({normalized_model}).",
+        llm_provider="openai",
+        llm_model=normalized_model,
+        expires_at=expires_at,
+    )
+
+
+__all__ = [
+    "AccountValidation",
+    "AccountValidationState",
+    "validate_account_session",
+]

--- a/surfaces/shared/account_session.py
+++ b/surfaces/shared/account_session.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from enum import StrEnum
-from http import HTTPStatus
-
-import httpx
 
 from config.account import (
     AccountRecord,
@@ -17,10 +12,7 @@ from config.account import (
     resolve_account_token,
     save_account_record,
 )
-from config.constants.account import (
-    OPENSRE_ACCOUNT_HTTP_TIMEOUT_SECONDS,
-    OPENSRE_ACCOUNT_SESSION_PATH,
-)
+from config.account_validation import AccountValidationState, validate_account_session
 
 
 class AccountSessionState(StrEnum):
@@ -45,47 +37,6 @@ class AccountStatus:
     def authenticated(self) -> bool:
         """Whether this state may enter the interactive shell."""
         return self.state is AccountSessionState.ACTIVE and self.record is not None
-
-
-def _mapping(value: object, key: str) -> Mapping[str, object] | None:
-    if not isinstance(value, Mapping):
-        return None
-    nested = value.get(key)
-    return nested if isinstance(nested, Mapping) else None
-
-
-def _refreshed_record(payload: object, record: AccountRecord) -> AccountRecord | None:
-    """Return current server-owned account metadata when the response is usable."""
-    user = _mapping(payload, "user")
-    organization = _mapping(payload, "organization")
-    llm = _mapping(payload, "llm")
-    if user is None or organization is None or llm is None or not isinstance(payload, Mapping):
-        return None
-    user_id = user.get("id")
-    organization_id = organization.get("id")
-    provider = llm.get("provider")
-    model = llm.get("model")
-    expires_at = payload.get("expires_at")
-    if (
-        not isinstance(user_id, str)
-        or not user_id
-        or not isinstance(organization_id, str)
-        or not organization_id
-        or provider != "openai"
-        or not isinstance(model, str)
-        or not model.strip()
-        or not isinstance(expires_at, str)
-        or not expires_at
-    ):
-        return None
-    if user_id != record.user_id or organization_id != record.organization_id:
-        return None
-    return replace(
-        record,
-        token_expires_at=expires_at,
-        llm_provider=provider,
-        llm_model=model.strip(),
-    )
 
 
 def account_status(*, app_url: str | None = None) -> AccountStatus:
@@ -119,40 +70,33 @@ def account_status(*, app_url: str | None = None) -> AccountStatus:
             record,
             "The stored OpenSRE app URL is invalid.",
         )
-    try:
-        response = httpx.get(
-            f"{resolved_app_url}{OPENSRE_ACCOUNT_SESSION_PATH}",
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=OPENSRE_ACCOUNT_HTTP_TIMEOUT_SECONDS,
-        )
-    except httpx.HTTPError:
-        return AccountStatus(
-            AccountSessionState.UNAVAILABLE,
-            record,
-            "The OpenSRE app could not be reached to validate this login.",
-        )
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        return AccountStatus(
-            AccountSessionState.INVALID,
-            record,
-            "The stored OpenSRE login has expired or was revoked.",
-        )
-    if response.status_code != HTTPStatus.OK:
-        return AccountStatus(
-            AccountSessionState.UNAVAILABLE,
-            record,
-            "The OpenSRE app could not validate this login.",
-        )
-    try:
-        refreshed_record = _refreshed_record(response.json(), record)
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        refreshed_record = None
-    if refreshed_record is None:
+
+    validation = validate_account_session(
+        app_url=resolved_app_url,
+        token=token,
+        expected_user_id=record.user_id,
+        expected_organization_id=record.organization_id,
+    )
+    state = AccountSessionState(validation.state.value)
+    if validation.state is not AccountValidationState.ACTIVE:
+        return AccountStatus(state, record, validation.detail)
+    if (
+        validation.llm_provider is None
+        or validation.llm_model is None
+        or validation.expires_at is None
+    ):
         return AccountStatus(
             AccountSessionState.INVALID,
             record,
             "The OpenSRE app returned account or hosted-model state that does not match this login.",
         )
+
+    refreshed_record = replace(
+        record,
+        token_expires_at=validation.expires_at,
+        llm_provider=validation.llm_provider,
+        llm_model=validation.llm_model,
+    )
     if refreshed_record != record:
         try:
             save_account_record(refreshed_record)
@@ -162,11 +106,10 @@ def account_status(*, app_url: str | None = None) -> AccountStatus:
                 record,
                 "OpenSRE could not save the current hosted-model state.",
             )
-    provider = f"{refreshed_record.llm_provider} ({refreshed_record.llm_model})"
     return AccountStatus(
         AccountSessionState.ACTIVE,
         refreshed_record,
-        f"Authenticated with OpenSRE; LLM provider: {provider}.",
+        validation.detail,
     )
 
 

--- a/tests/config/test_account_route.py
+++ b/tests/config/test_account_route.py
@@ -1,0 +1,86 @@
+"""Hosted account routing falls back when the stored session is stale."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from config import account
+from config.account import AccountLLMRoute, AccountRecord
+from config.account_validation import AccountValidation, AccountValidationState
+
+
+def _record() -> AccountRecord:
+    return AccountRecord(
+        user_id="user_123",
+        organization_id="org_123",
+        email=None,
+        app_url="https://app.opensre.com",
+        signed_in_at="2026-09-01T10:00:00+00:00",
+        token_expires_at="2026-12-01T10:00:00+00:00",
+        llm_model="gpt-5.4-mini",
+    )
+
+
+def test_stale_hosted_route_falls_back_until_validation_cache_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    validations = iter(
+        [
+            AccountValidation(
+                AccountValidationState.UNAVAILABLE,
+                "The OpenSRE app could not be reached to validate this login.",
+            ),
+            AccountValidation(
+                AccountValidationState.ACTIVE,
+                "Authenticated with OpenSRE; LLM provider: openai (gpt-5.5).",
+                llm_provider="openai",
+                llm_model="gpt-5.5",
+                expires_at="2026-12-01T10:00:00+00:00",
+            ),
+        ]
+    )
+    calls = 0
+
+    def _validate(**_kwargs: object) -> AccountValidation:
+        nonlocal calls
+        calls += 1
+        return next(validations)
+
+    times: Iterator[float] = iter((100.0, 130.0, 161.0))
+    monkeypatch.setattr(account, "load_account_record", _record)
+    monkeypatch.setattr(account, "resolve_account_token", lambda: "token")
+    monkeypatch.setattr(account, "validate_account_session", _validate)
+    monkeypatch.setattr(account, "monotonic", lambda: next(times))
+    monkeypatch.setattr(account, "_account_route_cache", None)
+
+    assert account.account_llm_route() is None
+    assert account.account_llm_route() is None
+    assert account.account_llm_route() == AccountLLMRoute(
+        base_url="https://app.opensre.com/api/llm/v1",
+        model="gpt-5.5",
+    )
+    assert calls == 2
+
+
+def test_account_route_cache_does_not_retain_raw_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(account, "load_account_record", _record)
+    monkeypatch.setattr(account, "resolve_account_token", lambda: "sensitive-token")
+    monkeypatch.setattr(
+        account,
+        "validate_account_session",
+        lambda **_kwargs: AccountValidation(
+            AccountValidationState.UNAVAILABLE,
+            "offline",
+        ),
+    )
+    monkeypatch.setattr(account, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(account, "_account_route_cache", None)
+
+    assert account.account_llm_route() is None
+    cached = account._account_route_cache
+    assert cached is not None
+    assert b"sensitive-token" not in cached.key[1]

--- a/tests/config/test_account_route.py
+++ b/tests/config/test_account_route.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Lock, local
 
 import pytest
 
@@ -48,7 +50,7 @@ def test_stale_hosted_route_falls_back_until_validation_cache_expires(
         calls += 1
         return next(validations)
 
-    times: Iterator[float] = iter((100.0, 130.0, 161.0))
+    times: Iterator[float] = iter((100.0, 100.0, 130.0, 161.0, 161.0))
     monkeypatch.setattr(account, "load_account_record", _record)
     monkeypatch.setattr(account, "resolve_account_token", lambda: "token")
     monkeypatch.setattr(account, "validate_account_session", _validate)
@@ -62,6 +64,47 @@ def test_stale_hosted_route_falls_back_until_validation_cache_expires(
         model="gpt-5.5",
     )
     assert calls == 2
+
+
+def test_concurrent_cache_misses_share_one_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workers = 4
+    outer_lookup_barrier = Barrier(workers)
+    thread_state = local()
+    calls = 0
+    calls_lock = Lock()
+    original_cache_lookup = account._cached_account_route
+
+    def _synchronized_cache_lookup(
+        key: tuple[AccountRecord, bytes], now: float
+    ) -> account._AccountRouteCacheEntry | None:
+        if not getattr(thread_state, "outer_lookup_complete", False):
+            thread_state.outer_lookup_complete = True
+            cached = original_cache_lookup(key, now)
+            assert cached is None
+            outer_lookup_barrier.wait(timeout=2)
+            return cached
+        return original_cache_lookup(key, now)
+
+    def _validate(**_kwargs: object) -> AccountValidation:
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        return AccountValidation(AccountValidationState.UNAVAILABLE, "offline")
+
+    monkeypatch.setattr(account, "load_account_record", _record)
+    monkeypatch.setattr(account, "resolve_account_token", lambda: "token")
+    monkeypatch.setattr(account, "validate_account_session", _validate)
+    monkeypatch.setattr(account, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(account, "_cached_account_route", _synchronized_cache_lookup)
+    monkeypatch.setattr(account, "_account_route_cache", None)
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(lambda _index: account.account_llm_route(), range(workers)))
+
+    assert results == [None] * workers
+    assert calls == 1
 
 
 def test_account_route_cache_does_not_retain_raw_token(

--- a/tests/shared/test_account_session.py
+++ b/tests/shared/test_account_session.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 import httpx
 import pytest
 
+from config import account_validation
 from config.account import AccountRecord
 from surfaces.shared import account_session
 from surfaces.shared.account_session import AccountSessionState
@@ -63,7 +64,7 @@ def test_webapp_validation_activates_account_and_hosted_model(
     monkeypatch.setattr(account_session, "load_account_record", _record)
     monkeypatch.setattr(account_session, "resolve_account_token", lambda: "token")
     monkeypatch.setattr(
-        account_session.httpx,
+        account_validation.httpx,
         "get",
         lambda *_args, **_kwargs: httpx.Response(
             HTTPStatus.OK,
@@ -86,7 +87,7 @@ def test_webapp_model_change_updates_the_route_before_shell_start(
     monkeypatch.setattr(account_session, "resolve_account_token", lambda: "token")
     monkeypatch.setattr(account_session, "save_account_record", saved.append)
     monkeypatch.setattr(
-        account_session.httpx,
+        account_validation.httpx,
         "get",
         lambda *_args, **_kwargs: httpx.Response(
             HTTPStatus.OK,
@@ -110,7 +111,7 @@ def test_webapp_identity_mismatch_never_authenticates(
     monkeypatch.setattr(account_session, "load_account_record", _record)
     monkeypatch.setattr(account_session, "resolve_account_token", lambda: "token")
     monkeypatch.setattr(
-        account_session.httpx,
+        account_validation.httpx,
         "get",
         lambda *_args, **_kwargs: httpx.Response(HTTPStatus.OK, json=payload),
     )
@@ -134,7 +135,7 @@ def test_invalid_stored_app_url_fails_before_sending_the_token(
     def _unexpected_request(*_args: object, **_kwargs: object) -> httpx.Response:
         raise AssertionError("invalid account URL must not receive the bearer token")
 
-    monkeypatch.setattr(account_session.httpx, "get", _unexpected_request)
+    monkeypatch.setattr(account_validation.httpx, "get", _unexpected_request)
 
     status = account_session.account_status()
 
@@ -148,7 +149,7 @@ def test_revoked_or_unreachable_session_fails_closed(
     monkeypatch.setattr(account_session, "load_account_record", _record)
     monkeypatch.setattr(account_session, "resolve_account_token", lambda: "token")
     monkeypatch.setattr(
-        account_session.httpx,
+        account_validation.httpx,
         "get",
         lambda *_args, **_kwargs: httpx.Response(HTTPStatus.UNAUTHORIZED),
     )
@@ -157,7 +158,7 @@ def test_revoked_or_unreachable_session_fails_closed(
     def _unreachable(*_args: object, **_kwargs: object) -> httpx.Response:
         raise httpx.ConnectError("offline")
 
-    monkeypatch.setattr(account_session.httpx, "get", _unreachable)
+    monkeypatch.setattr(account_validation.httpx, "get", _unreachable)
     status = account_session.account_status()
     assert status.state is AccountSessionState.UNAVAILABLE
     assert status.authenticated is False


### PR DESCRIPTION
Fixes #6223

#### Describe the changes you have made in this PR -

- Validate the stored OpenSRE account session before returning the hosted OpenAI LLM route, so a revoked or unreachable account session no longer overrides a working locally configured provider.
- Cache the validation result for 60 seconds to keep route resolution off the per-turn HTTP hot path. The cache key stores only a SHA-256 token fingerprint and is cleared when account metadata or credentials change.
- Coordinate cache misses behind a process-local single-flight lock. Waiting callers re-read account state and double-check the cache before issuing HTTP, so an account-service outage cannot fan out duplicate validation requests across bounded turn workers.
- Move the remote session check into a small config-level validation module and reuse it from `account status`, so hosted-route selection and the user-facing account state cannot drift.
- Add regression coverage for stale-route fallback, validation-cache expiry/recovery, token handling, concurrent misses, and the existing active/invalid/unavailable account states.

### Demo/Screenshot for feature changes and bug fixes -

Regression behavior covered by `tests/config/test_account_route.py`:

```text
stale/unreachable hosted session + configured local provider
    -> account_llm_route() returns None
    -> repeated route lookup inside the 60s TTL does not repeat HTTP validation
    -> four concurrent cache misses share one validation request
    -> after TTL, a recovered session is revalidated and the hosted route returns
```

GitHub Actions verification on head `2486b2d`:

```text
CI run #12554: success
quality-static: lint, format-check, registry checks, import graph/boundaries passed
quality-typecheck: typecheck + typed-tool-contract verification passed
package-preflight: build/validation + installed-wheel smoke passed
all required test shards and final CI Gate completed successfully
```

Greptile re-review on `2486b2d`:

```text
Confidence Score: 5/5
previous concurrent-validation P1: resolved/outdated
new actionable defects: none
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The failure happens because local account metadata was treated as sufficient proof that the hosted LLM route was usable. `account status` already performed a real webapp session check, but `account_llm_route()` only checked for a record and token, so non-shell surfaces could keep selecting a dead hosted route.

I kept `account_llm_route()` as the single routing decision instead of adding fallback branches to every LLM client builder. Remote validation is shared with the existing account-status surface, while a short-lived route cache prevents repeated network requests during one process/session. The cache is keyed by the immutable account record plus a token fingerprint, and account/token mutations clear it immediately.

Concurrent misses use one process-local validation lock. A caller that waits for another validation re-reads the account record and token after acquiring the lock, then checks the cache again before making an HTTP request. This preserves current account mutations while ensuring one expired cache entry does not fan out duplicate blocking validations.

A permanent cache was rejected because revoked sessions would remain trusted for the life of the process. A per-call validation was also rejected because route lookup is used by the LLM cache/factory and client builders and can occur repeatedly on the hot path. The 60-second TTL gives stale sessions a bounded lifetime while allowing recovered sessions to be retried without restarting OpenSRE.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of the code structure and diff scope
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Maintainer edits are enabled. CI and Greptile are green. This PR remains draft only because the contributor must personally review the AI-assisted changes and complete the two understanding attestations above.