### PR TITLE
fix(github): harden CI repair identity, recovery and packaged workers

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -223,6 +223,7 @@ if TYPE_CHECKING:
     from config.constants.ci_repair import CI_REPAIR_POLL_SECONDS as CI_REPAIR_POLL_SECONDS
     from config.constants.ci_repair import CI_REPAIR_REPORT_BUILDER as CI_REPAIR_REPORT_BUILDER
     from config.constants.ci_repair import CI_REPAIR_SECONDS as CI_REPAIR_SECONDS
+    from config.constants.ci_repair import CI_REPAIR_WORKER_COMMAND as CI_REPAIR_WORKER_COMMAND
     from config.constants.clerk import (
         CLERK_ISSUER_ENV as CLERK_ISSUER_ENV,
     )

--- a/config/constants/ci_repair.py
+++ b/config/constants/ci_repair.py
@@ -1,5 +1,6 @@
 """Limits and storage names for bounded GitHub CI repair loops."""
 
+CI_REPAIR_WORKER_COMMAND = "_ci-repair-worker"
 CI_REPAIR_SECONDS = 600
 CI_REPAIR_FINISH_RESERVE_SECONDS = 15
 CI_REPAIR_POLL_SECONDS = 1.0
@@ -14,4 +15,5 @@ __all__ = [
     "CI_REPAIR_POLL_SECONDS",
     "CI_REPAIR_REPORT_BUILDER",
     "CI_REPAIR_SECONDS",
+    "CI_REPAIR_WORKER_COMMAND",
 ]

--- a/config/constants/exports.py
+++ b/config/constants/exports.py
@@ -8,6 +8,7 @@ from config.package_exports import bind_package_exports
 # those modules; ``__getattr__`` loads one leaf the first time a name is used.
 EXPORTS: dict[str, str] = {
     "GITHUB_CI_DEMO_REPOSITORY": "github",
+    "CI_REPAIR_WORKER_COMMAND": "ci_repair",
     "CI_REPAIR_SECONDS": "ci_repair",
     "CI_REPAIR_FINISH_RESERVE_SECONDS": "ci_repair",
     "CI_REPAIR_POLL_SECONDS": "ci_repair",

--- a/infrastructure/process/entrypoint.py
+++ b/infrastructure/process/entrypoint.py
@@ -1,0 +1,13 @@
+"""Re-enter the current OpenSRE installation from Python or a frozen executable."""
+
+from __future__ import annotations
+
+import sys
+
+
+def opensre_command(*args: str) -> list[str]:
+    """Build a child command without sending Python module flags to a frozen binary."""
+    prefix = [sys.executable]
+    if not getattr(sys, "frozen", False):
+        prefix.extend(["-m", "surfaces.entrypoint"])
+    return [*prefix, *args]

--- a/infrastructure/scheduling/scheduler/background_service.py
+++ b/infrastructure/scheduling/scheduler/background_service.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from config.constants.paths import OPENSRE_HOME_DIR, OPENSRE_HOME_ENV
+from infrastructure.process.entrypoint import opensre_command
 
 SERVICE_LABEL = "com.opensre.scheduler"
 _LOGS_DIRNAME = "logs"
@@ -232,7 +233,7 @@ def ensure_background_service(
     state = check_background_service(home=home, system=system, run=run)
     if not state.supported:
         raise RuntimeError(state.summary)
-    command = [sys.executable, "-m", "surfaces.entrypoint", "cron", "start", "--service"]
+    command = opensre_command("cron", "start", "--service")
     matches = False
     if state.unit_path is not None:
         if state.platform == "Darwin":

--- a/integrations/github/__init__.py
+++ b/integrations/github/__init__.py
@@ -15,6 +15,7 @@ from integrations.github.client import GitHubApiError, GitHubRestClient, resolve
 
 #: Public name -> the submodule that defines it, imported on first access.
 _LAZY_EXPORTS: dict[str, str] = {
+    "run_ci_repair_worker": "integrations.github.tools.ci_repair_loop.worker",
     "count_ci_fixes": "integrations.github.tools.ci_fix.ledger",
     "get_ci_fix_counter": "integrations.github.tools.ci_fix.ledger",
     "github_creds": "integrations.github.helpers",
@@ -104,6 +105,7 @@ if TYPE_CHECKING:
     )
     from integrations.github.tools.ci_analytics.render import ci_report_headline
     from integrations.github.tools.ci_fix.ledger import count_ci_fixes, get_ci_fix_counter
+    from integrations.github.tools.ci_repair_loop.worker import run_ci_repair_worker
 
 
 __all__ = [
@@ -141,6 +143,7 @@ __all__ = [
     "report_looks_complete",
     "resolve_github_token",
     "resolve_repo_scope",
+    "run_ci_repair_worker",
     "saved_github_username",
     "schedule_ci_reliability_loop",
     "validate_github_mcp_config",

--- a/integrations/github/tools/ci_fix/verification.py
+++ b/integrations/github/tools/ci_fix/verification.py
@@ -148,7 +148,7 @@ def wait_for_pr_checks(
                     failing = tuple(
                         _check_name(check)
                         for check in checks
-                        if _check_failed(check, expected_skips=expected_skips)
+                        if check_failed(check, expected_skips=expected_skips)
                     )
                     return CheckVerification(
                         state=CheckState.FAILED if failing else CheckState.PASSED,
@@ -410,7 +410,8 @@ def _check_signature(checks: list[dict[str, Any]]) -> tuple[str, ...]:
     return tuple(sorted(signatures))
 
 
-def _check_failed(check: dict[str, Any], *, expected_skips: set[str]) -> bool:
+def check_failed(check: dict[str, Any], *, expected_skips: set[str]) -> bool:
+    """Classify a GitHub check or commit status, allowing only explicitly expected skips."""
     conclusion = str(check.get("conclusion") or "").strip().upper()
     state = str(check.get("state") or "").strip().upper()
     if conclusion == _SKIPPED_CONCLUSION:
@@ -433,6 +434,7 @@ def _check_is_terminal(check: dict[str, Any]) -> bool:
 __all__ = [
     "CheckState",
     "CheckVerification",
+    "check_failed",
     "DEFAULT_CHECK_WAIT_SECONDS",
     "DEFAULT_HEAD_PROPAGATION_SECONDS",
     "DEFAULT_POLL_INTERVAL_SECONDS",

--- a/integrations/github/tools/ci_repair_loop/credentials.py
+++ b/integrations/github/tools/ci_repair_loop/credentials.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from config.constants import GH_TOKEN_ENV, GITHUB_MCP_AUTH_TOKEN_ENV, GITHUB_TOKEN_ENV
 from config.llm_credentials import resolve_env_credential
 from integrations.catalog import resolve_effective_integrations
@@ -21,3 +23,11 @@ def configured_token(explicit: str | None = None) -> str:
         if token:
             return token
     raise ValueError("Configure GitHub with `opensre integrations setup github` before scheduling.")
+
+
+def account_id(user: Mapping[str, object]) -> int:
+    """Require the stable GitHub account ID before authorizing a durable run."""
+    value = user.get("id")
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError("GitHub did not return a valid account identity.")
+    return value

--- a/integrations/github/tools/ci_repair_loop/fixture.py
+++ b/integrations/github/tools/ci_repair_loop/fixture.py
@@ -12,6 +12,10 @@ from integrations.github.tools.ci_repair_loop.models import RepairRun
 from integrations.github.tools.ci_repair_loop.storage import RepairStore
 
 
+class DemoRepositoryMismatch(ValueError):
+    """The selected repository does not contain the owned, compatible demo baseline."""
+
+
 def baseline_files(base_branch: str) -> dict[str, str]:
     """The marker and small healthy fixture that a reusable repository must contain."""
     return {
@@ -71,7 +75,9 @@ def validate_baseline(client: GitHubRestClient, run: RepairRun) -> str:
             for name, content in baseline_files(run.base_branch).items()
         )
     ):
-        raise ValueError("The fixed repository name belongs to an unrecognized or modified demo.")
+        raise DemoRepositoryMismatch(
+            "The fixed repository name belongs to an unrecognized or modified demo."
+        )
     return sha
 
 

--- a/integrations/github/tools/ci_repair_loop/models.py
+++ b/integrations/github/tools/ci_repair_loop/models.py
@@ -35,6 +35,7 @@ class RepairRun(BaseModel):
     branch: str = ""
     repository_id: int = 0
     created_repository: bool = False
+    registered: bool = False
     initial_sha: str = ""
     fixed_sha: str = ""
     failed_run_url: str = ""

--- a/integrations/github/tools/ci_repair_loop/models.py
+++ b/integrations/github/tools/ci_repair_loop/models.py
@@ -23,6 +23,8 @@ class RepairRun(BaseModel):
     owner: str
     repo: str
     actor: str
+    # Legacy records remain readable locally but cannot authorize an account.
+    actor_id: int = Field(default=0, ge=0, strict=True)
     demo: bool
     started_at: float
     deadline: float
@@ -50,9 +52,9 @@ class RepairRun(BaseModel):
         return self.status not in {RepairStatus.QUEUED, RepairStatus.RUNNING}
 
     @property
-    def identity(self) -> tuple[str, str, str, int]:
+    def identity(self) -> tuple[int, str, str, int]:
         return (
-            self.actor.casefold(),
+            self.actor_id,
             self.owner.casefold(),
             self.repo.casefold(),
             (0 if self.demo else self.pr_number),

--- a/integrations/github/tools/ci_repair_loop/schedule.py
+++ b/integrations/github/tools/ci_repair_loop/schedule.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 import subprocess
 import time
@@ -29,6 +30,8 @@ from integrations.github.tools.ci_repair_loop.fixture import object_response
 from integrations.github.tools.ci_repair_loop.models import RepairRun, RepairStatus
 from integrations.github.tools.ci_repair_loop.storage import RepairStore
 from integrations.github.tools.ci_repair_loop.supervisor import finish_run
+
+logger = logging.getLogger(__name__)
 
 
 def _component(value: str) -> str:
@@ -76,9 +79,11 @@ def schedule_repair(
             )
         )
         existing = get_task(run.id)
-        if reused:
-            if existing is not None and existing.enabled:
-                return run, True, existing.next_run
+        if reused and existing is not None and existing.enabled:
+            return run, True, existing.next_run
+        if reused and (
+            existing is not None or run.registered or run.status is not RepairStatus.QUEUED
+        ):
             try:
                 with FileLock(str(store.directory(run.id)) + ".execution.lock", timeout=0):
                     run = store.get(run.id)
@@ -117,8 +122,13 @@ def schedule_repair(
                 )
                 task.next_run = compute_next_run(task)
                 existing = add_task(task)
-        except (ValueError, RuntimeError, OSError, subprocess.SubprocessError) as exc:
-            run.status, run.reason = RepairStatus.FAILED, str(exc)
+                run = store.mark_registered(run.id)
+        except (ValueError, RuntimeError, OSError, subprocess.SubprocessError):
+            logger.exception("CI repair registration failed")
+            run.status, run.reason = (
+                RepairStatus.FAILED,
+                "Could not register the background repair; check the local scheduler log.",
+            )
             finish_run(store, run)
             return run, reused, None
     return run, reused, existing.next_run

--- a/integrations/github/tools/ci_repair_loop/schedule.py
+++ b/integrations/github/tools/ci_repair_loop/schedule.py
@@ -25,7 +25,7 @@ from infrastructure.scheduling.scheduler.runner import compute_next_run
 from infrastructure.scheduling.scheduler.storage import add_task, get_task
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
 from integrations.github.client import GitHubRestClient
-from integrations.github.tools.ci_repair_loop.credentials import configured_token
+from integrations.github.tools.ci_repair_loop.credentials import account_id, configured_token
 from integrations.github.tools.ci_repair_loop.fixture import object_response
 from integrations.github.tools.ci_repair_loop.models import RepairRun, RepairStatus
 from integrations.github.tools.ci_repair_loop.storage import RepairStore
@@ -53,6 +53,7 @@ def schedule_repair(
     started = time.time()
     token = configured_token(github_token)
     user = object_response(GitHubRestClient(token).request("GET", "user"))
+    actor_id = account_id(user)
     actor = _component(str(user.get("login") or ""))
     owner = _component(owner.strip() or actor)
     if demo:
@@ -72,6 +73,7 @@ def schedule_repair(
                 owner=owner,
                 repo=repo,
                 actor=actor,
+                actor_id=actor_id,
                 demo=demo,
                 started_at=started,
                 deadline=started + CI_REPAIR_SECONDS,

--- a/integrations/github/tools/ci_repair_loop/storage.py
+++ b/integrations/github/tools/ci_repair_loop/storage.py
@@ -54,7 +54,7 @@ class RepairStore:
             runs = self._read()
             for run in runs.values():
                 if run.identity[1:] == candidate.identity[1:] and not run.terminal:
-                    if run.actor.casefold() != candidate.actor.casefold():
+                    if not run.actor_id or run.actor_id != candidate.actor_id:
                         raise ValueError(
                             "Another GitHub account already has an active repair for this target."
                         )

--- a/integrations/github/tools/ci_repair_loop/storage.py
+++ b/integrations/github/tools/ci_repair_loop/storage.py
@@ -63,6 +63,15 @@ class RepairStore:
             self._write(runs)
             return candidate, False
 
+    def mark_registered(self, run_id: str) -> RepairRun:
+        """Publish registration without overwriting a worker that has already started."""
+        with self.lock:
+            runs = self._read()
+            run = runs[run_id]
+            run.registered = True
+            self._write(runs)
+            return run
+
     def get(self, run_id: str) -> RepairRun:
         self.directory(run_id)
         with self.lock:

--- a/integrations/github/tools/ci_repair_loop/storage.py
+++ b/integrations/github/tools/ci_repair_loop/storage.py
@@ -6,13 +6,14 @@ import json
 import os
 import re
 import tempfile
+import time
 from pathlib import Path
 
-from filelock import FileLock
+from filelock import FileLock, Timeout
 
 from config.constants.ci_repair import CI_REPAIR_DIRECTORY
 from config.constants.paths import OPENSRE_HOME_DIR
-from integrations.github.tools.ci_repair_loop.models import RepairRun
+from integrations.github.tools.ci_repair_loop.models import RepairRun, RepairStatus
 
 
 class RepairStore:
@@ -54,7 +55,14 @@ class RepairStore:
             runs = self._read()
             for run in runs.values():
                 if run.identity[1:] == candidate.identity[1:] and not run.terminal:
-                    if not run.actor_id or run.actor_id != candidate.actor_id:
+                    if run.deadline <= time.time():
+                        self._expire(run, runs)
+                        continue
+                    if not run.actor_id:
+                        raise ValueError(
+                            "A legacy repair is still active; retry after its original deadline."
+                        )
+                    if run.actor_id != candidate.actor_id:
                         raise ValueError(
                             "Another GitHub account already has an active repair for this target."
                         )
@@ -62,6 +70,17 @@ class RepairStore:
             runs[candidate.id] = candidate
             self._write(runs)
             return candidate, False
+
+    def _expire(self, run: RepairRun, runs: dict[str, RepairRun]) -> None:
+        """Release expired scope only when its supervisor no longer owns execution."""
+        try:
+            with FileLock(str(self.directory(run.id)) + ".execution.lock", timeout=0):
+                run.status = RepairStatus.TIMED_OUT
+                run.finished_at = time.time()
+                run.reason = "The previous repair reached its time budget."
+                self._write(runs)
+        except Timeout as exc:
+            raise ValueError("The previous repair is stopping; try again shortly.") from exc
 
     def mark_registered(self, run_id: str) -> RepairRun:
         """Publish registration without overwriting a worker that has already started."""

--- a/integrations/github/tools/ci_repair_loop/supervisor.py
+++ b/integrations/github/tools/ci_repair_loop/supervisor.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 import time
 from collections.abc import Mapping
 
 from filelock import FileLock, Timeout
 
-from config.constants.ci_repair import CI_REPAIR_FINISH_RESERVE_SECONDS, CI_REPAIR_POLL_SECONDS
+from config.constants.ci_repair import (
+    CI_REPAIR_FINISH_RESERVE_SECONDS,
+    CI_REPAIR_POLL_SECONDS,
+    CI_REPAIR_WORKER_COMMAND,
+)
+from infrastructure.process.entrypoint import opensre_command
 from infrastructure.process.tree import stop_worker
 from infrastructure.scheduling.scheduler.storage import get_task
 from infrastructure.scheduling.scheduler.types import TaskReport
@@ -59,13 +63,7 @@ def _supervise(store: RepairStore, run: RepairRun) -> str:
         return finish_run(store, run)
     directory = store.directory(run.id)
     directory.mkdir(parents=True, exist_ok=True)
-    command = [
-        sys.executable,
-        "-m",
-        "integrations.github.tools.ci_repair_loop.worker",
-        str(store.root),
-        run.id,
-    ]
+    command = opensre_command(CI_REPAIR_WORKER_COMMAND, str(store.root), run.id)
     with (directory / "worker.log").open("a", encoding="utf-8") as log:
         process = subprocess.Popen(command, stdout=log, stderr=log, start_new_session=True)
         stopped: RepairStatus | None = None

--- a/integrations/github/tools/ci_repair_loop/tool.py
+++ b/integrations/github/tools/ci_repair_loop/tool.py
@@ -8,12 +8,14 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel, report_run_error
 from core.tool_framework import tool
-from integrations.github.client import GitHubApiError
+from integrations.github.client import GitHubApiError, GitHubRestClient
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
 )
+from integrations.github.tools.ci_repair_loop.credentials import configured_token
+from integrations.github.tools.ci_repair_loop.fixture import object_response
 from integrations.github.tools.ci_repair_loop.models import RepairRun
 from integrations.github.tools.ci_repair_loop.report import render_report
 from integrations.github.tools.ci_repair_loop.schedule import schedule_repair
@@ -130,6 +132,9 @@ def schedule_ci_repair_loop(
     surfaces=(ToolSurface.ACTION,),
     side_effect_level=SideEffectLevel.READ_ONLY,
     parallel_safe=True,
+    is_available=github_source_available,
+    extract_params=_credentials,
+    injected_params=GITHUB_INJECTED_PARAMS,
     input_schema={
         "type": "object",
         "properties": {
@@ -148,17 +153,24 @@ def schedule_ci_repair_loop(
         "additionalProperties": False,
     },
 )
-def get_ci_repair_loop(task_id: str, wait_seconds: int = 0, **_kwargs: Any) -> dict[str, Any]:
+def get_ci_repair_loop(
+    task_id: str, wait_seconds: int = 0, github_token: str | None = None, **_kwargs: Any
+) -> dict[str, Any]:
     """Retrieve the same report while the shell is open or after returning later."""
     until = time.monotonic() + min(60, max(0, wait_seconds))
     try:
         store = RepairStore()
+        token = configured_token(github_token)
+        user = object_response(GitHubRestClient(token).request("GET", "user"))
+        actor = str(user.get("login") or "").casefold()
         while True:
             run = store.get(task_id)
+            if not actor or run.actor.casefold() != actor:
+                return {"ok": False, "error": "This repair belongs to a different GitHub account."}
             if run.terminal or time.monotonic() >= until:
                 return _result(run, store)
             time.sleep(min(1, max(0, until - time.monotonic())))
-    except (ValueError, OSError, RuntimeError) as exc:
+    except (ValueError, OSError, RuntimeError, GitHubApiError) as exc:
         report_run_error(
             exc,
             tool_name="get_ci_repair_loop",
@@ -166,4 +178,7 @@ def get_ci_repair_loop(task_id: str, wait_seconds: int = 0, **_kwargs: Any) -> d
             component=__name__,
             method="RepairStore.get",
         )
-        return {"ok": False, "error": str(exc)}
+        return {
+            "ok": False,
+            "error": "Could not read the repair report; check your GitHub connection and run id.",
+        }

--- a/integrations/github/tools/ci_repair_loop/tool.py
+++ b/integrations/github/tools/ci_repair_loop/tool.py
@@ -14,7 +14,7 @@ from integrations.github.helpers import (
     github_creds,
     github_source_available,
 )
-from integrations.github.tools.ci_repair_loop.credentials import configured_token
+from integrations.github.tools.ci_repair_loop.credentials import account_id, configured_token
 from integrations.github.tools.ci_repair_loop.fixture import object_response
 from integrations.github.tools.ci_repair_loop.models import RepairRun
 from integrations.github.tools.ci_repair_loop.report import render_report
@@ -162,10 +162,10 @@ def get_ci_repair_loop(
         store = RepairStore()
         token = configured_token(github_token)
         user = object_response(GitHubRestClient(token).request("GET", "user"))
-        actor = str(user.get("login") or "").casefold()
+        actor_id = account_id(user)
         while True:
             run = store.get(task_id)
-            if not actor or run.actor.casefold() != actor:
+            if not run.actor_id or run.actor_id != actor_id:
                 return {"ok": False, "error": "This repair belongs to a different GitHub account."}
             if run.terminal or time.monotonic() >= until:
                 return _result(run, store)

--- a/integrations/github/tools/ci_repair_loop/worker.py
+++ b/integrations/github/tools/ci_repair_loop/worker.py
@@ -21,9 +21,14 @@ from integrations.github.tools.ci_fix.errors import GitHubCiFixError
 from integrations.github.tools.ci_fix.gh import run_gh_json
 from integrations.github.tools.ci_fix.ledger import record_ci_fix_outcome
 from integrations.github.tools.ci_fix.runner import run_ci_fix
-from integrations.github.tools.ci_fix.verification import CheckState, wait_for_pr_checks
+from integrations.github.tools.ci_fix.verification import (
+    CheckState,
+    check_failed,
+    wait_for_pr_checks,
+)
 from integrations.github.tools.ci_repair_loop.credentials import configured_token
 from integrations.github.tools.ci_repair_loop.fixture import (
+    DemoRepositoryMismatch,
     cleanup_demo,
     object_response,
     prepare_demo,
@@ -46,7 +51,8 @@ def _read_pr(run: RepairRun, token: str) -> dict[str, Any]:
 def _run_link(rows: list[dict[str, Any]], *, failed: bool) -> str:
     for row in rows:
         conclusion = str(row.get("conclusion") or row.get("state") or "").upper()
-        if (conclusion in {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED"}) == failed:
+        matches = check_failed(row, expected_skips=set()) if failed else conclusion == "SUCCESS"
+        if matches:
             link = str(row.get("detailsUrl") or row.get("targetUrl") or "")
             if link.startswith("https://github.com/"):
                 return link
@@ -100,11 +106,7 @@ def _repair(run: RepairRun, store: RepairStore, token: str) -> None:
             run.status, run.reason = RepairStatus.CANCELLED, "The PR was closed."
             return
         rows = pr.get("statusCheckRollup") or []
-        failed = any(
-            str(row.get("conclusion") or row.get("state") or "").upper()
-            in {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}
-            for row in rows
-        )
+        failed = any(check_failed(row, expected_skips=set()) for row in rows)
         if not failed:
             # A new fixture must first be observed failing. Empty or queued checks prove nothing.
             if (
@@ -210,9 +212,18 @@ def main() -> None:
                     if exc.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
                     else "GitHub could not complete the demo; inspect retained diagnostics."
                 )
-            except (ValueError, GitHubCiFixError) as exc:
+            except DemoRepositoryMismatch:
+                logger.exception("Demo repository ownership or baseline check failed")
+                run.status, run.reason = (
+                    RepairStatus.FAILED,
+                    "The fixed repository is unrecognized or modified; existing files were preserved.",
+                )
+            except (ValueError, GitHubCiFixError):
                 logger.exception("CI repair could not continue")
-                run.status, run.reason = RepairStatus.FAILED, str(exc)
+                run.status, run.reason = (
+                    RepairStatus.FAILED,
+                    "The repair could not continue; inspect the local worker log.",
+                )
             except Exception as exc:
                 logger.exception("CI repair worker failed")
                 run.status, run.reason = (

--- a/integrations/github/tools/ci_repair_loop/worker.py
+++ b/integrations/github/tools/ci_repair_loop/worker.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import shutil
-import sys
 import time
 from http import HTTPStatus
 from pathlib import Path
@@ -26,7 +25,7 @@ from integrations.github.tools.ci_fix.verification import (
     check_failed,
     wait_for_pr_checks,
 )
-from integrations.github.tools.ci_repair_loop.credentials import configured_token
+from integrations.github.tools.ci_repair_loop.credentials import account_id, configured_token
 from integrations.github.tools.ci_repair_loop.fixture import (
     DemoRepositoryMismatch,
     cleanup_demo,
@@ -170,7 +169,7 @@ def execute_repair(run: RepairRun, store: RepairStore) -> None:
     token = configured_token()
     client = GitHubRestClient(token)
     user = object_response(client.request("GET", "user"))
-    if str(user.get("login", "")).casefold() != run.actor.casefold():
+    if not run.actor_id or account_id(user) != run.actor_id:
         raise ValueError("The background GitHub account changed; repair stopped.")
     if run.demo:
         prepare_demo(client, run, store)
@@ -190,10 +189,11 @@ def execute_repair(run: RepairRun, store: RepairStore) -> None:
         run.status = RepairStatus.SUCCEEDED
 
 
-def main() -> None:
+def run_ci_repair_worker(store_directory: Path, run_id: str) -> None:
+    """Run a persisted repair in the supervised child process."""
     logging.basicConfig(level=logging.INFO)
-    store = RepairStore(Path(sys.argv[1]))
-    run = store.get(sys.argv[2])
+    store = RepairStore(store_directory)
+    run = store.get(run_id)
     work_deadline = run.deadline - CI_REPAIR_FINISH_RESERVE_SECONDS
     watchdog = start_watchdog(work_deadline)
     try:
@@ -234,7 +234,3 @@ def main() -> None:
         store.save(run)
     finally:
         watchdog.set()
-
-
-if __name__ == "__main__":
-    main()

--- a/surfaces/cli/commands/ci_repair_worker.py
+++ b/surfaces/cli/commands/ci_repair_worker.py
@@ -1,0 +1,18 @@
+"""Hidden child-process entry for supervised CI repair in installed binaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from config.constants.ci_repair import CI_REPAIR_WORKER_COMMAND
+from integrations.github import run_ci_repair_worker
+
+
+@click.command(name=CI_REPAIR_WORKER_COMMAND, hidden=True)
+@click.argument("store_directory", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("run_id")
+def ci_repair_worker_command(store_directory: Path, run_id: str) -> None:
+    """Execute the already-authorized repair under the supervisor's deadline."""
+    run_ci_repair_worker(store_directory, run_id)

--- a/surfaces/cli/commands/command_specs.py
+++ b/surfaces/cli/commands/command_specs.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 
 import click
 
+from config.constants.ci_repair import CI_REPAIR_WORKER_COMMAND
+
 
 @dataclass(frozen=True, slots=True)
 class CommandSpec:
@@ -27,6 +29,12 @@ class CommandSpec:
 # Help strings are the first line of each command's docstring. A test loads
 # the real Click object and fails if these drift.
 COMMAND_SPECS: tuple[CommandSpec, ...] = (
+    CommandSpec(
+        CI_REPAIR_WORKER_COMMAND,
+        "",
+        "surfaces.cli.commands.ci_repair_worker:ci_repair_worker_command",
+        hidden=True,
+    ),
     CommandSpec(
         "account",
         "Sign in to OpenSRE and inspect the local account.",

--- a/tests/cli/test_ci_repair_worker.py
+++ b/tests/cli/test_ci_repair_worker.py
@@ -1,0 +1,44 @@
+"""The packaged worker command reaches the same deadline-guarded implementation."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from config.constants.ci_repair import CI_REPAIR_WORKER_COMMAND
+from infrastructure.process import entrypoint
+from integrations.github.tools.ci_repair_loop.models import RepairRun, RepairStatus
+from integrations.github.tools.ci_repair_loop.storage import RepairStore
+from surfaces.cli.app import cli
+
+
+def test_frozen_child_command_is_parseable_and_obeys_the_saved_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = RepairStore(tmp_path)
+    run = RepairRun(
+        id="a" * 12,
+        owner="alice",
+        actor="alice",
+        repo="demo",
+        demo=True,
+        started_at=time.time() - 601,
+        deadline=time.time() - 1,
+    )
+    store.save(run)
+    monkeypatch.setattr(entrypoint.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(entrypoint.sys, "executable", "/Applications/opensre")
+    command = entrypoint.opensre_command(CI_REPAIR_WORKER_COMMAND, str(tmp_path), run.id)
+    assert command[:2] == ["/Applications/opensre", CI_REPAIR_WORKER_COMMAND]
+    result = CliRunner().invoke(cli, command[1:])
+    assert result.exit_code == 0, result.output
+    assert store.get(run.id).status is RepairStatus.TIMED_OUT
+    assert entrypoint.opensre_command("cron", "start", "--service") == [
+        "/Applications/opensre",
+        "cron",
+        "start",
+        "--service",
+    ]

--- a/tests/cli/test_cli_inventory.py
+++ b/tests/cli/test_cli_inventory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import click
 
+from config.constants.ci_repair import CI_REPAIR_WORKER_COMMAND
 from surfaces.cli.app import cli
 
 #: Every user-visible top-level command, alphabetized. Update deliberately —
@@ -41,7 +42,7 @@ EXPECTED_VISIBLE_COMMANDS = frozenset(
     }
 )
 
-EXPECTED_HIDDEN_COMMANDS = frozenset({"_package-smoke"})
+EXPECTED_HIDDEN_COMMANDS = frozenset({"_package-smoke", CI_REPAIR_WORKER_COMMAND})
 
 
 def _command_inventory() -> tuple[frozenset[str], frozenset[str]]:

--- a/tests/integrations/github/test_ci_repair_loop.py
+++ b/tests/integrations/github/test_ci_repair_loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import subprocess
 import sys
 import time
@@ -13,6 +14,7 @@ from typing import Any
 
 import psutil
 import pytest
+from filelock import FileLock
 
 from config.constants.ci_repair import CI_REPAIR_FINISH_RESERVE_SECONDS
 from config.constants.github import GITHUB_CI_DEMO_REPOSITORY
@@ -73,6 +75,28 @@ def test_corrupt_or_future_storage_is_preserved(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="version"):
         store.reserve(_run())
     assert store.path.read_text() == original
+
+
+def test_expired_legacy_run_releases_scope_only_after_its_supervisor_stops(tmp_path: Path) -> None:
+    store = RepairStore(tmp_path)
+    legacy = _run().model_dump()
+    legacy.pop("actor_id")
+    legacy["deadline"] = time.time() - 1
+    store.path.write_text(json.dumps({"version": 1, "runs": {legacy["id"]: legacy}}))
+    candidate = _run("b" * 12).model_copy(update={"actor_id": 456})
+    with FileLock(str(store.directory(str(legacy["id"]))) + ".execution.lock"):
+        with pytest.raises(ValueError, match="stopping"):
+            store.reserve(candidate)
+        assert store.get(str(legacy["id"])).status is RepairStatus.QUEUED
+    fresh, reused = RepairStore(tmp_path).reserve(candidate)
+    assert not reused and fresh.id == candidate.id and fresh.actor_id == 456
+    previous = store.get(str(legacy["id"]))
+    assert previous.status is RepairStatus.TIMED_OUT and previous.actor_id == 0
+    assert previous.deadline == legacy["deadline"] and previous.finished_at is not None
+    resumed, reused = RepairStore(tmp_path).reserve(
+        _run("c" * 12).model_copy(update={"actor_id": 456})
+    )
+    assert reused and resumed.id == fresh.id and resumed.deadline == fresh.deadline
 
 
 def _git_sha(content: str) -> str:

--- a/tests/integrations/github/test_ci_repair_loop.py
+++ b/tests/integrations/github/test_ci_repair_loop.py
@@ -497,3 +497,118 @@ def test_existing_green_pr_still_waits_for_late_checks(
     worker._repair(run, RepairStore(tmp_path), "test-token")
     assert checked == ["green-head"]
     assert run.status is RepairStatus.CANCELLED
+
+
+def test_reports_require_the_recorded_github_account(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from integrations.github.tools.ci_repair_loop import tool
+
+    store = RepairStore(tmp_path)
+    run = _run(pr_number=123)
+    store.save(run)
+    monkeypatch.setattr(tool, "RepairStore", lambda: store)
+    monkeypatch.setattr(tool, "configured_token", lambda _token: "request-token", raising=False)
+
+    class Reader:
+        actor = "other-user"
+
+        def request(self, *_args: Any) -> dict[str, str]:
+            return {"login": self.actor}
+
+    reader = Reader()
+    monkeypatch.setattr(tool, "GitHubRestClient", lambda _token: reader, raising=False)
+    rejected = tool.get_ci_repair_loop(run.id)
+    assert not rejected["ok"] and run.repo not in str(rejected) and run.pr_url not in str(rejected)
+    reader.actor = "alice"
+    allowed = tool.get_ci_repair_loop(run.id)
+    assert allowed["ok"] and allowed["pr_url"] == run.pr_url
+
+
+def test_interrupted_registration_recovers_original_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = RepairStore(tmp_path)
+    original, _ = store.reserve(_run())
+    tasks: dict[str, ScheduledTask] = {}
+    monkeypatch.setattr(schedule, "configured_token", lambda _token: "test-token")
+    monkeypatch.setattr(schedule, "GitHubRestClient", lambda _token: _GitHub())
+    monkeypatch.setattr(schedule, "get_task", tasks.get)
+    monkeypatch.setattr(schedule, "ensure_background_service", lambda **_kw: None)
+
+    def add(task: ScheduledTask) -> ScheduledTask:
+        tasks[task.id] = task
+        return task
+
+    monkeypatch.setattr(schedule, "add_task", add)
+    resumed, reused, _ = schedule.schedule_repair(demo=True, store=store)
+    assert reused and resumed.id == original.id and resumed.deadline == original.deadline
+    assert resumed.status is RepairStatus.QUEUED and len(tasks) == 1
+
+
+def test_evidence_links_require_the_reported_outcome() -> None:
+    from integrations.github.tools.ci_repair_loop import worker
+
+    prefix = "https://github.com/alice/demo/actions/runs/"
+    rows = [
+        {"conclusion": "", "status": "QUEUED", "detailsUrl": prefix + "queued"},
+        {"conclusion": "ACTION_REQUIRED", "detailsUrl": prefix + "action-required"},
+        {"conclusion": "SKIPPED", "detailsUrl": prefix + "skipped"},
+        {"conclusion": "SUCCESS", "detailsUrl": prefix + "passed"},
+    ]
+    assert worker._run_link(rows, failed=True) == prefix + "action-required"
+    assert worker._run_link(rows, failed=False) == prefix + "passed"
+
+
+def test_setup_exception_details_stay_out_of_persisted_reports(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = RepairStore(tmp_path)
+    monkeypatch.setattr(schedule, "configured_token", lambda _token: "test-token")
+    monkeypatch.setattr(schedule, "GitHubRestClient", lambda _token: _GitHub())
+    monkeypatch.setattr(schedule, "get_task", lambda _id: None)
+
+    def fail_service(**_kwargs: Any) -> None:
+        raise RuntimeError("secret-provider-internal-detail")
+
+    monkeypatch.setattr(schedule, "ensure_background_service", fail_service)
+    run, _, _ = schedule.schedule_repair(demo=True, store=store)
+    assert run.status is RepairStatus.FAILED
+    assert "secret-provider-internal-detail" not in render_report(store.get(run.id), tmp_path)
+
+
+def test_worker_exception_details_stay_in_local_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import threading
+
+    from integrations.github.tools.ci_repair_loop import worker
+
+    store = RepairStore(tmp_path)
+    run = _run()
+    store.save(run)
+    monkeypatch.setattr(worker.sys, "argv", ["worker", str(tmp_path), run.id])
+    monkeypatch.setattr(worker, "start_watchdog", lambda _deadline: threading.Event())
+
+    def fail(*_args: Any) -> None:
+        raise ValueError("private-provider-exception-detail")
+
+    monkeypatch.setattr(worker, "execute_repair", fail)
+    worker.main()
+    saved = store.get(run.id)
+    assert saved.status is RepairStatus.FAILED
+    assert "private-provider-exception-detail" not in render_report(saved, tmp_path)
+    assert "private-provider-exception-detail" in caplog.text
+
+
+def test_registration_publish_preserves_an_already_started_worker(tmp_path: Path) -> None:
+    store = RepairStore(tmp_path)
+    run, _ = store.reserve(_run())
+    active = run.model_copy(update={"status": RepairStatus.RUNNING, "pr_number": 17})
+    store.save(active)
+    published = store.mark_registered(run.id)
+    assert (
+        published.registered
+        and published.pr_number == 17
+        and published.status is RepairStatus.RUNNING
+    )

--- a/tests/integrations/github/test_ci_repair_loop.py
+++ b/tests/integrations/github/test_ci_repair_loop.py
@@ -30,6 +30,7 @@ def _run(run_id: str = "a" * 12, **kwargs: Any) -> RepairRun:
         id=run_id,
         owner="alice",
         actor="alice",
+        actor_id=123,
         repo=GITHUB_CI_DEMO_REPOSITORY,
         demo=True,
         started_at=now,
@@ -58,7 +59,7 @@ def test_concurrent_reservations_and_restarts_keep_one_run_and_deadline(tmp_path
     resumed, reused = RepairStore(tmp_path).reserve(_run("f" * 12))
     assert reused and resumed.deadline == winner.deadline
     with pytest.raises(ValueError, match="Another GitHub account"):
-        store.reserve(_run("e" * 12).model_copy(update={"actor": "someone-else"}))
+        store.reserve(_run("e" * 12).model_copy(update={"actor_id": 456}))
     winner.status = RepairStatus.FAILED
     store.save(winner)
     fresh, reused = store.reserve(_run("f" * 12))
@@ -108,7 +109,7 @@ class _GitHub:
         route = path.removeprefix(f"repos/alice/{GITHUB_CI_DEMO_REPOSITORY}")
         body = kwargs.get("body", {})
         if path == "user":
-            return {"login": "alice"}
+            return {"login": "alice", "id": 123}
         if path == "user/repos":
             assert self.repository is None
             return self._create()
@@ -398,7 +399,12 @@ def test_account_change_stops_before_any_remote_write(
     monkeypatch.setattr(worker, "configured_token", lambda: "test-token")
     monkeypatch.setattr(worker, "verify_coding_agent", lambda: (True, "ready"))
     monkeypatch.setattr(worker, "GitHubRestClient", lambda _token: api)
-    run = _run().model_copy(update={"actor": "different-account"})
+    run = _run().model_copy(update={"actor_id": 456})
+
+    def refuse_clone(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("An unauthorized worker must not reach a repository checkout.")
+
+    monkeypatch.setattr(worker, "clone_repository", refuse_clone)
     with pytest.raises(ValueError, match="account changed"):
         worker.execute_repair(run, RepairStore(tmp_path))
     assert [(method, path) for method, path, _ in api.calls] == [("GET", "user")]
@@ -511,25 +517,29 @@ def test_reports_require_the_recorded_github_account(
     monkeypatch.setattr(tool, "configured_token", lambda _token: "request-token", raising=False)
 
     class Reader:
-        actor = "other-user"
+        actor = "alice"
+        account_id = 456
 
-        def request(self, *_args: Any) -> dict[str, str]:
-            return {"login": self.actor}
+        def request(self, *_args: Any) -> dict[str, Any]:
+            return {"login": self.actor, "id": self.account_id}
 
     reader = Reader()
     monkeypatch.setattr(tool, "GitHubRestClient", lambda _token: reader, raising=False)
     rejected = tool.get_ci_repair_loop(run.id)
     assert not rejected["ok"] and run.repo not in str(rejected) and run.pr_url not in str(rejected)
-    reader.actor = "alice"
+    reader.actor = "renamed-alice"
+    reader.account_id = 123
     allowed = tool.get_ci_repair_loop(run.id)
     assert allowed["ok"] and allowed["pr_url"] == run.pr_url
+    store.save(run.model_copy(update={"actor_id": 0}))
+    assert not tool.get_ci_repair_loop(run.id)["ok"]
 
 
 def test_interrupted_registration_recovers_original_run(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = RepairStore(tmp_path)
-    original, _ = store.reserve(_run())
+    original, _ = store.reserve(_run().model_copy(update={"actor": "old-alice"}))
     tasks: dict[str, ScheduledTask] = {}
     monkeypatch.setattr(schedule, "configured_token", lambda _token: "test-token")
     monkeypatch.setattr(schedule, "GitHubRestClient", lambda _token: _GitHub())
@@ -587,14 +597,13 @@ def test_worker_exception_details_stay_in_local_logs(
     store = RepairStore(tmp_path)
     run = _run()
     store.save(run)
-    monkeypatch.setattr(worker.sys, "argv", ["worker", str(tmp_path), run.id])
     monkeypatch.setattr(worker, "start_watchdog", lambda _deadline: threading.Event())
 
     def fail(*_args: Any) -> None:
         raise ValueError("private-provider-exception-detail")
 
     monkeypatch.setattr(worker, "execute_repair", fail)
-    worker.main()
+    worker.run_ci_repair_worker(tmp_path, run.id)
     saved = store.get(run.id)
     assert saved.status is RepairStatus.FAILED
     assert "private-provider-exception-detail" not in render_report(saved, tmp_path)


### PR DESCRIPTION
Persisted CI repair runs must remain bound to the same GitHub account across username changes, and supervised workers must launch from both Python installs and packaged executables. This follow-up to #6229 also recovers interrupted registration and corrects retained report evidence.

#### Describe the changes you have made in this PR -

- Persist the stable numeric GitHub account ID and require it for report reads, active-run reuse and background execution. A renamed account retains access; a later holder of its old username does not. Legacy records without a numeric ID remain available locally but cannot authorize a remote account.
- Launch the worker through a hidden CLI command and share frozen-aware child command construction with scheduler service setup. Packaged executables receive CLI arguments rather than Python `-m` flags.
- Retire expired reservations only after the previous supervisor releases execution, allowing legacy interrupted runs to be replaced without adopting their reports or extending their deadlines.
- Recover a queued run interrupted before trigger registration, retaining its ID and original deadline. Previously registered stopped/removed schedules remain cancelled. Record registration without overwriting a worker that already started.
- Share failure classification with the CI verifier and require explicit SUCCESS for passing evidence links.
- Keep exception details in local logs; use fixed public errors for setup, worker and report-read failures. Preserve an actionable fixed message for an incompatible demo repository.

### Demo/Screenshot for feature changes and bug fixes -

```text
test_reports_require_the_recorded_github_account PASSED
test_interrupted_registration_recovers_original_run PASSED
test_registration_publish_preserves_an_already_started_worker PASSED
test_evidence_links_require_the_reported_outcome PASSED
test_setup_exception_details_stay_out_of_persisted_reports PASSED
test_worker_exception_details_stay_in_local_logs PASSED
test_frozen_child_command_is_parseable_and_obeys_the_saved_deadline PASSED
```

Validation: `make lint`, `make format-check`, `make typecheck`, and 151 focused repair lifecycle, verification, discovery, CLI startup/inventory, scheduler, packaging, constants and API-border tests. The original four review regressions and the account rename/reassignment regressions failed before their fixes. Tests use isolated stores, real scheduler/process lifecycle checks, and API-shaped fixtures; no live GitHub demo run is claimed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Implemented and self-reviewed by Codex; this does not claim human review. The fixes stay in the GitHub repair domain and use existing credential injection, stable GitHub account IDs, check classification and locked persistence. The CLI worker imports through the GitHub public API and shares process command construction with scheduler setup. Public reports contain fixed messages while local logs keep diagnostic detail. Regression tests cover cross-account reads, interrupted registration, concurrent worker startup, evidence classification and exception sanitization.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the related PR
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
