### PR TITLE
fix(work-items): keep a reminder's schedule in sync with its item

### DIFF
--- a/infrastructure/scheduling/scheduler/storage/__init__.py
+++ b/infrastructure/scheduling/scheduler/storage/__init__.py
@@ -30,6 +30,7 @@ from infrastructure.scheduling.scheduler.storage.task_store import (
     list_tasks,
     record_task_success,
     remove_task,
+    replace_task,
     update_task,
 )
 
@@ -55,6 +56,7 @@ __all__ = [
     "record_task_success",
     "record_run_report",
     "remove_task",
+    "replace_task",
     "renew_claims",
     "run_database_path",
     "try_claim",

--- a/infrastructure/scheduling/scheduler/storage/task_store.py
+++ b/infrastructure/scheduling/scheduler/storage/task_store.py
@@ -8,7 +8,7 @@ import logging
 import os
 import tempfile
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -222,22 +222,63 @@ def add_task(task: ScheduledTask, store_path: Path | None = None) -> ScheduledTa
     lock = FileLock(_lock_path(path))
     with lock:
         raw = _load_for_write(path)
-        wanted = _schedule_identity(task.model_dump(mode="json"))
-        existing_index = next(
-            (index for index, entry in enumerate(raw) if _schedule_identity(entry) == wanted),
-            None,
-        )
-        if existing_index is not None:
-            existing = raw[existing_index]
-            if existing.get("skill_revision", "") == task.skill_revision:
-                return ScheduledTask.model_validate(existing)
-            existing["skill_revision"] = task.skill_revision
-            stored_task = ScheduledTask.model_validate(existing)
-        else:
-            raw.append(task.model_dump(mode="json"))
-            stored_task = task
+        stored_task, changed = _merge_task_into(raw, task)
+        if not changed:
+            return stored_task
         _save_raw(path, raw)
     # A new task or pinned revision changed the schedule: wake the scheduler to resync.
+    reload_signal.request_scheduler_reload()
+    return stored_task
+
+
+def _merge_task_into(
+    raw: list[dict[str, object]], task: ScheduledTask
+) -> tuple[ScheduledTask, bool]:
+    """Append *task* to *raw*, or fold it into the matching schedule already there.
+
+    The flag reports whether *raw* changed, so callers can skip a pointless write.
+    """
+    wanted = _schedule_identity(task.model_dump(mode="json"))
+    existing_index = next(
+        (index for index, entry in enumerate(raw) if _schedule_identity(entry) == wanted),
+        None,
+    )
+    if existing_index is None:
+        raw.append(task.model_dump(mode="json"))
+        return task, True
+    existing = raw[existing_index]
+    if existing.get("skill_revision", "") == task.skill_revision:
+        return ScheduledTask.model_validate(existing), False
+    existing["skill_revision"] = task.skill_revision
+    return ScheduledTask.model_validate(existing), True
+
+
+def replace_task(
+    task: ScheduledTask,
+    *,
+    disable_task_ids: Sequence[str] = (),
+    store_path: Path | None = None,
+) -> ScheduledTask:
+    """Persist *task* and disable *disable_task_ids* in one store write.
+
+    Rescheduling is two changes that have to land together. Adding first can
+    leave both schedules enabled if the process dies before the old one is
+    disabled; disabling first can leave no schedule at all if the add fails.
+    One locked read-modify-write, committed by the same atomic rename every
+    other store write uses, has neither window.
+    """
+    path = store_path or default_task_store_path()
+    retired = {task_id for task_id in disable_task_ids if task_id}
+    with FileLock(_lock_path(path)):
+        raw = _load_for_write(path)
+        stored_task, changed = _merge_task_into(raw, task)
+        for entry in raw:
+            if entry.get("id") in retired and entry.get("id") != stored_task.id:
+                entry["enabled"] = False
+                changed = True
+        if not changed:
+            return stored_task
+        _save_raw(path, raw)
     reload_signal.request_scheduler_reload()
     return stored_task
 

--- a/infrastructure/scheduling/scheduler/storage/task_store.py
+++ b/infrastructure/scheduling/scheduler/storage/task_store.py
@@ -273,7 +273,16 @@ def replace_task(
         raw = _load_for_write(path)
         stored_task, changed = _merge_task_into(raw, task)
         for entry in raw:
-            if entry.get("id") in retired and entry.get("id") != stored_task.id:
+            entry_id = entry.get("id")
+            if entry_id == stored_task.id:
+                # Reusing a schedule retired earlier matches the disabled row.
+                # Returning it as the replacement without reviving it reports a
+                # reminder that never fires.
+                if not entry.get("enabled", True):
+                    entry["enabled"] = True
+                    stored_task = ScheduledTask.model_validate(entry)
+                    changed = True
+            elif entry_id in retired:
                 entry["enabled"] = False
                 changed = True
         if not changed:

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from pathlib import Path
 from typing import Any
 
@@ -165,6 +166,130 @@ def test_reminder_scheduling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert len(tasks) == 2
     assert tasks[0].enabled is False
     assert tasks[1].enabled is True
+
+
+def _isolate_work_item_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the item store, scheduler store, and reload signal at *tmp_path*."""
+    work_items_file = tmp_path / "work_items.json"
+    for target in (
+        "tools.system.work_items.tool.work_items_path",
+        "tools.system.work_items.results.work_items_path",
+        "tools.system.work_items.reminders.work_items_path",
+        "core.domain.work_items.store.work_items_path",
+    ):
+        monkeypatch.setattr(target, lambda: work_items_file)
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.storage.task_store.default_task_store_path",
+        lambda: tmp_path / "scheduler_tasks.json",
+    )
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.reload_signal.request_scheduler_reload",
+        lambda: None,
+    )
+
+
+def _live_reminder_targets() -> list[list[str]]:
+    """Chat ids carried by every enabled work-item reminder task."""
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+    from infrastructure.scheduling.scheduler.types import TaskKind
+
+    return [
+        [entry["chat_id"] for entry in json.loads(task.params["delivery_targets"])]
+        for task in list_tasks()
+        if task.kind is TaskKind.WORK_ITEM_REMINDER and task.enabled
+    ]
+
+
+def test_reminder_destination_change_moves_the_schedule(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The task carries its own copy of the targets, so an item edited to a new
+    # channel kept delivering its reminder to the old one.
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    added = work_task_add(
+        title="Rotate API key",
+        remind_at="2030-09-12T09:00:00Z",
+        channel_provider="slack",
+        channel_id="C1",
+    )
+    assert _live_reminder_targets() == [["C1"]]
+
+    updated = work_task_update(
+        selector=added["task"]["id"], channel_provider="slack", channel_id="C2"
+    )
+
+    assert updated["task"]["channel"]["chat_id"] == "C2"
+    assert _live_reminder_targets() == [["C2"]]
+
+
+def test_clearing_a_reminder_cancels_its_schedule(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An empty remind_at reads as "unchanged", so removing a reminder needs its
+    # own flag; without it the one-shot task stayed enabled and later fired.
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    added = work_task_add(
+        title="Rotate API key",
+        remind_at="2030-09-12T09:00:00Z",
+        channel_provider="slack",
+        channel_id="C1",
+    )
+    assert len(_live_reminder_targets()) == 1
+
+    cleared = work_task_update(selector=added["task"]["id"], clear_remind_at=True)
+
+    assert cleared["task"]["remind_at"] == ""
+    assert _live_reminder_targets() == []
+
+
+def test_clear_and_set_reminder_together_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    added = work_task_add(title="Rotate API key", channel_provider="slack", channel_id="C1")
+
+    response = work_task_update(
+        selector=added["task"]["id"],
+        remind_at="2030-09-12T09:00:00Z",
+        clear_remind_at=True,
+    )
+
+    assert response["error"] == "conflicting_reminder_change"
+
+
+def test_destination_change_does_not_invent_a_reminder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Reconciling from the stored item must not schedule anything for an item
+    # that never carried a reminder time.
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    added = work_task_add(title="Rotate API key", channel_provider="slack", channel_id="C1")
+
+    work_task_update(selector=added["task"]["id"], channel_provider="slack", channel_id="C2")
+
+    assert _live_reminder_targets() == []
+
+
+def test_failed_replacement_keeps_the_existing_reminder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Disabling the old task first left the user with no reminder at all when
+    # persisting the replacement failed.
+    from tools.system.work_items import reminders
+
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    item = make_work_item(title="Rotate key", remind_at="2030-09-12T09:00:00Z")
+    targets = [WorkItemChannelTarget(provider="slack", chat_id="C1")]
+    assert schedule_item_reminder(item, targets=targets, timezone="UTC") is not None
+
+    def _store_unavailable(_task: Any) -> Any:
+        raise RuntimeError("scheduler store unavailable")
+
+    monkeypatch.setattr(reminders, "add_scheduled_task", _store_unavailable)
+    with pytest.raises(RuntimeError):
+        schedule_item_reminder(item, targets=targets, timezone="UTC")
+
+    assert _live_reminder_targets() == [["C1"]]
 
 
 def test_work_task_tools_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -343,6 +343,27 @@ def test_reschedule_never_leaves_two_live_reminders(
     assert [task.id for task in list_tasks() if task.enabled] == [second.id]
 
 
+def test_rescheduling_back_to_an_earlier_time_revives_the_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Moving a reminder T1 -> T2 -> T1 matches the row retired on the first
+    # move. Returning it as the replacement without reviving it reported a
+    # scheduled reminder that would never fire.
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    targets = [WorkItemChannelTarget(provider="slack", chat_id="C1")]
+    early = make_work_item(title="Rotate key", remind_at="2030-09-12T09:00:00Z")
+    later = dataclasses.replace(early, remind_at="2030-09-12T10:00:00Z")
+
+    schedule_item_reminder(early, targets=targets, timezone="UTC")
+    schedule_item_reminder(later, targets=targets, timezone="UTC")
+    revived = schedule_item_reminder(early, targets=targets, timezone="UTC")
+
+    assert revived is not None
+    assert [task.id for task in list_tasks() if task.enabled] == [revived.id]
+
+
 def test_failed_replacement_keeps_the_existing_reminder(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -270,6 +270,79 @@ def test_destination_change_does_not_invent_a_reminder(
     assert _live_reminder_targets() == []
 
 
+def test_destination_change_keeps_the_original_reminder_timezone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The item stores the reminder time but not its zone, so a channel-only edit
+    # that fell back to the UTC default moved a naive 09:00 by several hours.
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    added = work_task_add(
+        title="Rotate API key",
+        remind_at="2030-09-12T09:00:00",
+        channel_provider="slack",
+        channel_id="C1",
+        timezone="America/New_York",
+    )
+    assert [task.timezone for task in list_tasks() if task.enabled] == ["America/New_York"]
+
+    work_task_update(selector=added["task"]["id"], channel_provider="slack", channel_id="C2")
+
+    live = [task for task in list_tasks() if task.enabled]
+    assert [task.timezone for task in live] == ["America/New_York"]
+    assert _live_reminder_targets() == [["C2"]]
+
+
+def test_restating_the_reminder_time_uses_the_supplied_timezone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    added = work_task_add(
+        title="Rotate API key",
+        remind_at="2030-09-12T09:00:00",
+        channel_provider="slack",
+        channel_id="C1",
+        timezone="America/New_York",
+    )
+
+    work_task_update(
+        selector=added["task"]["id"],
+        remind_at="2030-09-13T09:00:00",
+        timezone="Europe/Berlin",
+    )
+
+    assert [task.timezone for task in list_tasks() if task.enabled] == ["Europe/Berlin"]
+
+
+def test_reschedule_never_leaves_two_live_reminders(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Add-then-disable across two store writes could leave both enabled; the
+    # swap has to land in one write.
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+
+    _isolate_work_item_stores(tmp_path, monkeypatch)
+    item = make_work_item(title="Rotate key", remind_at="2030-09-12T09:00:00Z")
+    first = schedule_item_reminder(
+        item, targets=[WorkItemChannelTarget(provider="slack", chat_id="C1")], timezone="UTC"
+    )
+    assert first is not None
+
+    def _no_second_write(*_args: Any, **_kwargs: Any) -> bool:
+        raise AssertionError("the swap must not need a follow-up update_task write")
+
+    monkeypatch.setattr("tools.system.work_items.reminders.update_task", _no_second_write)
+    second = schedule_item_reminder(
+        item, targets=[WorkItemChannelTarget(provider="slack", chat_id="C2")], timezone="UTC"
+    )
+
+    assert second is not None
+    assert [task.id for task in list_tasks() if task.enabled] == [second.id]
+
+
 def test_failed_replacement_keeps_the_existing_reminder(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -282,10 +355,10 @@ def test_failed_replacement_keeps_the_existing_reminder(
     targets = [WorkItemChannelTarget(provider="slack", chat_id="C1")]
     assert schedule_item_reminder(item, targets=targets, timezone="UTC") is not None
 
-    def _store_unavailable(_task: Any) -> Any:
+    def _store_unavailable(*_args: Any, **_kwargs: Any) -> Any:
         raise RuntimeError("scheduler store unavailable")
 
-    monkeypatch.setattr(reminders, "add_scheduled_task", _store_unavailable)
+    monkeypatch.setattr(reminders, "replace_task", _store_unavailable)
     with pytest.raises(RuntimeError):
         schedule_item_reminder(item, targets=targets, timezone="UTC")
 

--- a/tools/system/work_items/reminders.py
+++ b/tools/system/work_items/reminders.py
@@ -17,13 +17,18 @@ from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, T
 from tools.system.work_items.validation import validate_provider
 
 
-def disable_existing_item_reminders(item_id: str) -> int:
-    """Disable enabled one-shot reminders for ``item_id`` so updates replace them."""
+def disable_existing_item_reminders(item_id: str, *, keep_task_id: str = "") -> int:
+    """Disable enabled one-shot reminders for ``item_id`` so updates replace them.
+
+    ``keep_task_id`` spares the replacement when this runs after it is persisted.
+    """
     disabled = 0
     for task in list_tasks():
         if task.kind is not TaskKind.WORK_ITEM_REMINDER:
             continue
         if not task.enabled:
+            continue
+        if keep_task_id and task.id == keep_task_id:
             continue
         if task.params.get("work_item_id", "").strip() != item_id:
             continue
@@ -48,8 +53,6 @@ def schedule_item_reminder(
     valid_targets = [target for target in targets if validate_provider(target.provider) is not None]
     if not valid_targets:
         return None
-    # Replace any prior reminder for this work item before scheduling a new one.
-    disable_existing_item_reminders(item.id)
     primary = valid_targets[0]
     parsed_provider = Provider(primary.provider)
     schedule_timezone = "UTC" if remind_at.tzinfo is not None else timezone
@@ -68,7 +71,11 @@ def schedule_item_reminder(
             ),
         },
     )
-    return add_scheduled_task(task)
+    created = add_scheduled_task(task)
+    # Retire the prior reminder only once its replacement is durable. Disabling
+    # first left the user with no reminder at all when the store write failed.
+    disable_existing_item_reminders(item.id, keep_task_id=created.id)
+    return created
 
 
 _disable_existing_item_reminders = disable_existing_item_reminders

--- a/tools/system/work_items/reminders.py
+++ b/tools/system/work_items/reminders.py
@@ -11,27 +11,37 @@ from core.domain.work_items import (
     parse_work_item_datetime,
     work_items_path,
 )
-from infrastructure.scheduling.scheduler.storage import add_task as add_scheduled_task
-from infrastructure.scheduling.scheduler.storage import list_tasks, update_task
+from infrastructure.scheduling.scheduler.storage import list_tasks, replace_task, update_task
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
 from tools.system.work_items.validation import validate_provider
 
 
-def disable_existing_item_reminders(item_id: str, *, keep_task_id: str = "") -> int:
-    """Disable enabled one-shot reminders for ``item_id`` so updates replace them.
+def enabled_item_reminders(item_id: str) -> list[ScheduledTask]:
+    """Every enabled one-shot reminder currently scheduled for ``item_id``."""
+    return [
+        task
+        for task in list_tasks()
+        if task.kind is TaskKind.WORK_ITEM_REMINDER
+        and task.enabled
+        and task.params.get("work_item_id", "").strip() == item_id
+    ]
 
-    ``keep_task_id`` spares the replacement when this runs after it is persisted.
+
+def existing_reminder_timezone(item_id: str) -> str:
+    """Timezone the live reminder for ``item_id`` was scheduled in, or ``""``.
+
+    A work item stores its reminder time but not the zone it was read in, so an
+    edit that does not restate the time has to recover the zone from the
+    schedule or a naive time silently moves to another hour.
     """
+    scheduled = enabled_item_reminders(item_id)
+    return scheduled[-1].timezone if scheduled else ""
+
+
+def disable_existing_item_reminders(item_id: str) -> int:
+    """Disable every enabled one-shot reminder for ``item_id``."""
     disabled = 0
-    for task in list_tasks():
-        if task.kind is not TaskKind.WORK_ITEM_REMINDER:
-            continue
-        if not task.enabled:
-            continue
-        if keep_task_id and task.id == keep_task_id:
-            continue
-        if task.params.get("work_item_id", "").strip() != item_id:
-            continue
+    for task in enabled_item_reminders(item_id):
         task.enabled = False
         if update_task(task):
             disabled += 1
@@ -53,6 +63,7 @@ def schedule_item_reminder(
     valid_targets = [target for target in targets if validate_provider(target.provider) is not None]
     if not valid_targets:
         return None
+    superseded = enabled_item_reminders(item.id)
     primary = valid_targets[0]
     parsed_provider = Provider(primary.provider)
     schedule_timezone = "UTC" if remind_at.tzinfo is not None else timezone
@@ -71,11 +82,9 @@ def schedule_item_reminder(
             ),
         },
     )
-    created = add_scheduled_task(task)
-    # Retire the prior reminder only once its replacement is durable. Disabling
-    # first left the user with no reminder at all when the store write failed.
-    disable_existing_item_reminders(item.id, keep_task_id=created.id)
-    return created
+    # One atomic store write: adding first could leave both reminders enabled,
+    # disabling first could leave none at all.
+    return replace_task(task, disable_task_ids=[prior.id for prior in superseded])
 
 
 _disable_existing_item_reminders = disable_existing_item_reminders
@@ -85,5 +94,7 @@ __all__ = [
     "_disable_existing_item_reminders",
     "_schedule_item_reminder",
     "disable_existing_item_reminders",
+    "enabled_item_reminders",
+    "existing_reminder_timezone",
     "schedule_item_reminder",
 ]

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -27,7 +27,10 @@ from infrastructure.scheduling.scheduler.storage import add_task as add_schedule
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
 from tools.system.work_items._evidence import map_work_task_list, map_work_task_prioritize
 from tools.system.work_items.delivery import delivery_targets, invalid_delivery_targets
-from tools.system.work_items.reminders import schedule_item_reminder
+from tools.system.work_items.reminders import (
+    disable_existing_item_reminders,
+    schedule_item_reminder,
+)
 from tools.system.work_items.results import (
     added_result,
     complete_result,
@@ -277,7 +280,7 @@ def work_task_complete(selectors: list[str]) -> dict[str, Any]:
     source="knowledge",
     description=(
         "Update a durable work item's status, priority, owner, project, due time, reminder time, "
-        "notes, or reminder channel."
+        "notes, or reminder channel, or remove its reminder entirely."
     ),
     tags=("safe", "fast", "no-credentials"),
     surfaces=(ToolSurface.ACTION,),
@@ -297,6 +300,10 @@ def work_task_complete(selectors: list[str]) -> dict[str, Any]:
             "project": {"type": "string"},
             "due_at": {"type": "string"},
             "remind_at": {"type": "string"},
+            "clear_remind_at": {
+                "type": "boolean",
+                "description": "Remove the reminder and cancel its scheduled delivery.",
+            },
             "notes": {"type": "string"},
             "channel_provider": {"type": "string"},
             "channel_id": {"type": "string"},
@@ -326,6 +333,7 @@ def work_task_update(
     project: str = "",
     due_at: str = "",
     remind_at: str = "",
+    clear_remind_at: bool = False,
     notes: str = "",
     channel_provider: str = "",
     channel_id: str = "",
@@ -334,6 +342,11 @@ def work_task_update(
     context: AgentToolContext | None = None,
 ) -> dict[str, Any]:
     changes: WorkItemUpdates = {}
+    if clear_remind_at and remind_at:
+        return {
+            "error": "conflicting_reminder_change",
+            "detail": "pass either remind_at or clear_remind_at, not both",
+        }
     if status:
         normalized_status = normalize_status_filter(status)
         if normalized_status in {"active", "invalid"} or normalized_status is None:
@@ -352,6 +365,10 @@ def work_task_update(
         changes["due_at"] = due_at
     if remind_at:
         changes["remind_at"] = remind_at
+    if clear_remind_at:
+        # An empty remind_at means "unchanged" everywhere else, so the intent to
+        # remove one has to be stated separately or the update is a no-op.
+        changes["remind_at"] = ""
     if notes:
         changes["notes"] = notes
     for field_name, value in (("due_at", due_at), ("remind_at", remind_at)):
@@ -371,29 +388,34 @@ def work_task_update(
         changes["channel"] = (
             explicit_targets[0].to_dict() if explicit_targets else WorkItemChannelTarget().to_dict()
         )
-    reminder_targets: list[WorkItemChannelTarget] = []
-    if remind_at:
+    # A destination change has to re-snapshot the schedule as well: the task
+    # carries its own copy of the targets, so an item moved to a new channel
+    # would otherwise keep delivering the reminder to the old one.
+    syncs_reminder = bool(remind_at or explicit_targets or clear_remind_at)
+    if syncs_reminder:
         existing = resolve_work_item_selector(selector)
         if existing.item is None:
             payload: dict[str, Any] = {"error": existing.error or "not_found"}
             if existing.candidates:
                 payload["candidates"] = [item_summary(item) for item in existing.candidates]
             return payload
-        reminder_targets = delivery_targets(
+        # Validated before the write so an undeliverable reminder cannot leave
+        # remind_at persisted behind an error response.
+        preview_targets = delivery_targets(
             provider=channel_provider,
             chat_id=channel_id,
             item=existing.item,
             channel_targets=channel_targets,
             context=context,
         )
-        invalid_reminder_targets = invalid_delivery_targets(reminder_targets)
+        invalid_reminder_targets = invalid_delivery_targets(preview_targets)
         if invalid_reminder_targets:
             return {
                 "error": "invalid_delivery_target",
                 "detail": "; ".join(invalid_reminder_targets),
                 "task": item_summary(existing.item),
             }
-        if not reminder_targets:
+        if remind_at and not preview_targets:
             return {
                 "error": "missing_delivery_target",
                 "detail": "remind_at needs at least one provider target",
@@ -406,12 +428,24 @@ def work_task_update(
             update_error_payload["candidates"] = [item_summary(item) for item in result.candidates]
         return update_error_payload
     scheduled = None
-    if remind_at:
-        scheduled = schedule_item_reminder(
-            result.item,
-            targets=reminder_targets,
-            timezone=timezone or "UTC",
-        )
+    # Reconcile against the stored item, not the arguments: it already holds the
+    # destination that just replaced the old one, whereas re-reading the
+    # arguments would merge the two and keep delivering to both.
+    if syncs_reminder:
+        if result.item.remind_at:
+            reminder_targets = delivery_targets(
+                provider="", chat_id="", item=result.item, context=context
+            )
+            if reminder_targets:
+                scheduled = schedule_item_reminder(
+                    result.item,
+                    targets=reminder_targets,
+                    timezone=timezone or "UTC",
+                )
+        else:
+            # The reminder is gone; leaving its one-shot task enabled would fire
+            # a delivery for a reminder the item no longer has.
+            disable_existing_item_reminders(result.item.id)
     result_payload = update_result(result.item)
     if scheduled is not None:
         result_payload["scheduled_task_id"] = scheduled.id

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
@@ -29,6 +30,7 @@ from tools.system.work_items._evidence import map_work_task_list, map_work_task_
 from tools.system.work_items.delivery import delivery_targets, invalid_delivery_targets
 from tools.system.work_items.reminders import (
     disable_existing_item_reminders,
+    existing_reminder_timezone,
     schedule_item_reminder,
 )
 from tools.system.work_items.results import (
@@ -55,6 +57,9 @@ from tools.system.work_items.validation import (
 
 def _work_items_available(_sources: dict[str, dict[str, Any]]) -> bool:
     return True
+
+
+logger = logging.getLogger(__name__)
 
 
 @tool(
@@ -274,6 +279,18 @@ def work_task_complete(selectors: list[str]) -> dict[str, Any]:
     return complete_result(complete_work_items(normalized))
 
 
+def _reminder_timezone(item_id: str, remind_at: str, timezone: str) -> str:
+    """Zone to schedule a reminder in, keeping the original on a channel-only edit.
+
+    A work item stores its reminder time but not the zone it was read in, so
+    falling back to the argument default when the caller did not restate the
+    time would move a naive 09:00 reminder to 09:00 UTC.
+    """
+    if remind_at:
+        return timezone or "UTC"
+    return existing_reminder_timezone(item_id) or timezone or "UTC"
+
+
 @tool(
     name="work_task_update",
     display_name="Update task",
@@ -437,11 +454,21 @@ def work_task_update(
                 provider="", chat_id="", item=result.item, context=context
             )
             if reminder_targets:
-                scheduled = schedule_item_reminder(
-                    result.item,
-                    targets=reminder_targets,
-                    timezone=timezone or "UTC",
-                )
+                try:
+                    scheduled = schedule_item_reminder(
+                        result.item,
+                        targets=reminder_targets,
+                        timezone=_reminder_timezone(result.item.id, remind_at, timezone),
+                    )
+                except Exception:
+                    # The item is already committed. Say the schedule did not
+                    # follow rather than raising, so the drift is visible.
+                    logger.exception("work item %s reminder reschedule failed", result.item.id)
+                    return {
+                        "error": "reminder_reschedule_failed",
+                        "detail": "the task was updated but its reminder schedule was not",
+                        "task": item_summary(result.item),
+                    }
         else:
             # The reminder is gone; leaving its one-shot task enabled would fire
             # a delivery for a reminder the item no longer has.


### PR DESCRIPTION
Fixes #6199

#### Describe the changes you have made in this PR -

Three ways a work-item reminder and its scheduler task could drift apart.

**The destination change did not follow.** A reminder task holds its own snapshot of the delivery targets, so editing an item's channel moved the item while its schedule kept delivering to the old channel. The update tool now reconciles after the write, against the stored item: it already holds the destination that replaced the old one, whereas re-reading the call arguments merged old and new and delivered to both.

**Removing a reminder was impossible to express.** An empty `remind_at` means "unchanged" everywhere else, so `work_task_update` returned `no_changes` and the one-shot task stayed enabled until it quietly fired. `clear_remind_at` states the intent, and the same reconcile step disables the task. Passing both it and `remind_at` is rejected rather than guessed at.

**A failed replacement lost the reminder.** `schedule_item_reminder` disabled the previous task before persisting the new one, so a store failure left the user with no reminder at all. It now writes the replacement first and spares it when retiring the old one.

Reconciling from the stored item also means a destination edit on an item that never had a reminder time does not invent one.

Out of scope: `/work add --remind` (#6198) writes through `add_work_item` and never reaches this tool, so it is untouched here.

### Demo/Screenshot for feature changes and bug fixes -

Each defect reproduced against `main` first, then re-run after the fix.

Destination change, before:

```
DEFECT 1 item channel: C2
DEFECT 1 schedule targets: [['C1']]
AssertionError: schedule should follow the item
```

After:

```
DEFECT 1 item channel: C2
DEFECT 1 schedule targets: [['C2']]
```

Clearing a reminder, before:

```
DEFECT 2 update response: {'error': 'no_changes'}
DEFECT 2 live reminders after clear: 1
AssertionError: clearing must cancel the schedule
```

After:

```
DEFECT 2 update response: {'status': 'updated', 'task': {..., 'remind_at': '', ...}}
DEFECT 2 live reminders after clear: 0
```

Failed reschedule, before:

```
DEFECT 3 live reminders after failed reschedule: 0
AssertionError: a failed replacement must not leave the user with no reminder
```

After:

```
DEFECT 3 live reminders after failed reschedule: 1
```

All three are now regression tests in `tests/tools/test_work_items_tools.py`, alongside one for the rejected `remind_at` + `clear_remind_at` combination and one proving a destination edit does not invent a reminder.

Checks run locally: `make lint`, `make format-check`, `make typecheck`, and `uv run python -m pytest tests/tools/ tests/scheduler/ tests/core/domain/work_items/ tests/interactive_shell/` (5657 passed, 39 skipped).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The root cause is that the scheduler task duplicates state the work item already owns: the delivery targets and the reminder time. Any edit that changes one without rewriting the other leaves the two disagreeing, and the schedule is the copy that actually delivers.

So rather than patching each edit path, I made one reconcile step the single place that decides. It runs after `update_work_item` and reads `result.item`, which is the source of truth by then. If the stored item still has a `remind_at`, the schedule is rewritten from the item's own targets. If it does not, any live reminder for that item is disabled. That covers the destination change, the clear, and the plain reschedule with one rule.

The alternative was to compute new targets from the call arguments at each branch. I tried that first and it produced `['C2', 'C1']`, because `delivery_targets` deliberately merges the item's existing channels for reminder fan-out. Merging is right when adding a reminder and wrong when replacing a destination, and reading the stored item avoids having to distinguish the two.

Validation still happens before the write, against the pre-update item, so an undeliverable reminder cannot leave `remind_at` persisted behind an error response.

For clearing I used an explicit `clear_remind_at` boolean rather than a sentinel string like `remind_at="none"`. A sentinel would have to be special-cased inside `validate_datetime_arg`, which currently rejects anything that is not a datetime, and it is easier for a model to produce by accident.

The ordering fix gives `disable_existing_item_reminders` a `keep_task_id` so it can run after the replacement is persisted instead of before, without disabling the task just written.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
