### PR TITLE
feat(observability): add opt-in Langfuse tracing for turns, LLM calls and tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -400,6 +400,15 @@ OPENSRE_SENTRY_LOGGING_DISABLED=0
 # Common values: railway, ec2, vercel, local. Defaults to "local" when unset.
 # OPENSRE_DEPLOYMENT_METHOD=local
 
+# Langfuse (optional LLM tracing)
+# Off unless both keys are set and the extra is installed: `uv sync --extra langfuse`.
+# One trace per chat turn: prompts, responses, token usage, tool calls.
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+# LANGFUSE_BASE_URL=https://cloud.langfuse.com
+# Set to 1 to keep tracing off even when the keys above are present.
+# OPENSRE_LANGFUSE_DISABLED=0
+
 # Interactive-shell prompt logging (for local eval mining + PostHog LLM analytics).
 # Set OPENSRE_PROMPT_LOG_DISABLED=1 to disable prompt/response logging entirely.
 OPENSRE_PROMPT_LOG_DISABLED=0

--- a/bootstrap/process.py
+++ b/bootstrap/process.py
@@ -60,6 +60,7 @@ class BootStep(StrEnum):
 
     ENV = "env"
     SENTRY = "sentry"
+    LLM_TRACING = "llm_tracing"
     HARNESS_ADAPTERS = "harness_adapters"
     SCHEDULER_RUNNERS = "scheduler_runners"
     CAPABILITY_WARNINGS = "capability_warnings"
@@ -79,7 +80,7 @@ class ProcessProfile:
 CLI_PROFILE: Final = ProcessProfile(
     name=ProcessName.CLI,
     # CLI owns Sentry (update tolerates a missing SDK) and Rich product adapters.
-    steps=frozenset({BootStep.ENV}),
+    steps=frozenset({BootStep.ENV, BootStep.LLM_TRACING}),
 )
 GATEWAY_PROFILE: Final = ProcessProfile(
     name=ProcessName.GATEWAY,
@@ -87,6 +88,7 @@ GATEWAY_PROFILE: Final = ProcessProfile(
         {
             BootStep.ENV,
             BootStep.SENTRY,
+            BootStep.LLM_TRACING,
             BootStep.HARNESS_ADAPTERS,
             BootStep.CAPABILITY_WARNINGS,
             BootStep.PRELOAD_LLM,
@@ -96,7 +98,9 @@ GATEWAY_PROFILE: Final = ProcessProfile(
 )
 WEB_PROFILE: Final = ProcessProfile(
     name=ProcessName.WEB,
-    steps=frozenset({BootStep.ENV, BootStep.SENTRY, BootStep.HARNESS_ADAPTERS}),
+    steps=frozenset(
+        {BootStep.ENV, BootStep.SENTRY, BootStep.LLM_TRACING, BootStep.HARNESS_ADAPTERS}
+    ),
     sentry_entrypoint=SentryEntrypoint.WEBAPP,
 )
 SCHEDULER_WORKER_PROFILE: Final = ProcessProfile(
@@ -109,6 +113,7 @@ SCHEDULER_WORKER_PROFILE: Final = ProcessProfile(
         {
             BootStep.ENV,
             BootStep.SENTRY,
+            BootStep.LLM_TRACING,
             BootStep.HARNESS_ADAPTERS,
             BootStep.SCHEDULER_RUNNERS,
         }
@@ -126,8 +131,9 @@ SCHEDULED_COMMAND_PROFILE: Final = ProcessProfile(
 EMBEDDED_PROFILE: Final = ProcessProfile(
     name=ProcessName.EMBEDDED,
     # Driving the agent from Python inside someone else's process: register the
-    # adapters tools resolve through, and leave error reporting, scheduling and
-    # client preloading to the host.
+    # adapters tools resolve through, and leave error reporting, LLM tracing,
+    # scheduling and client preloading to the host (an embedder that wants
+    # Langfuse calls ``init_langfuse_tracing()`` itself).
     steps=frozenset({BootStep.ENV, BootStep.HARNESS_ADAPTERS}),
 )
 
@@ -140,6 +146,13 @@ def _run_sentry(profile: ProcessProfile, _log: logging.Logger) -> None:
     from infrastructure.observability.errors.sentry import init_sentry
 
     init_sentry(entrypoint=profile.sentry_entrypoint)
+
+
+def _run_llm_tracing(_profile: ProcessProfile, _log: logging.Logger) -> None:
+    # Opt-in via LANGFUSE_* keys; a no-op for everyone else.
+    from infrastructure.observability.langfuse import init_langfuse_tracing
+
+    init_langfuse_tracing()
 
 
 def _run_harness_adapters(_profile: ProcessProfile, _log: logging.Logger) -> None:
@@ -173,6 +186,7 @@ _STEP_ORDER: Final[
 ] = (
     (BootStep.ENV, _run_env),
     (BootStep.SENTRY, _run_sentry),
+    (BootStep.LLM_TRACING, _run_llm_tracing),
     (BootStep.HARNESS_ADAPTERS, _run_harness_adapters),
     (BootStep.SCHEDULER_RUNNERS, _run_scheduler_runners),
     (BootStep.CAPABILITY_WARNINGS, _run_capability_warnings),

--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -498,6 +498,24 @@ if TYPE_CHECKING:
     from config.constants.kubernetes import (
         KUBECONFIG_PATH_ENV as KUBECONFIG_PATH_ENV,
     )
+    from config.constants.langfuse import (
+        LANGFUSE_BASE_URL_ENV as LANGFUSE_BASE_URL_ENV,
+    )
+    from config.constants.langfuse import (
+        LANGFUSE_DEFAULT_BASE_URL as LANGFUSE_DEFAULT_BASE_URL,
+    )
+    from config.constants.langfuse import (
+        LANGFUSE_HOST_ENV as LANGFUSE_HOST_ENV,
+    )
+    from config.constants.langfuse import (
+        LANGFUSE_PUBLIC_KEY_ENV as LANGFUSE_PUBLIC_KEY_ENV,
+    )
+    from config.constants.langfuse import (
+        LANGFUSE_SECRET_KEY_ENV as LANGFUSE_SECRET_KEY_ENV,
+    )
+    from config.constants.langfuse import (
+        OPENSRE_LANGFUSE_DISABLED_ENV as OPENSRE_LANGFUSE_DISABLED_ENV,
+    )
     from config.constants.llm import (
         AZURE_OPENAI_API_KEY_ENV as AZURE_OPENAI_API_KEY_ENV,
     )

--- a/config/constants/exports.py
+++ b/config/constants/exports.py
@@ -205,6 +205,13 @@ EXPORTS: dict[str, str] = {
     "KAFKA_SASL_PASSWORD_ENV": "kafka",
     "KAFKA_SASL_USERNAME_ENV": "kafka",
     "KAFKA_SECURITY_PROTOCOL_ENV": "kafka",
+    # langfuse
+    "LANGFUSE_BASE_URL_ENV": "langfuse",
+    "LANGFUSE_DEFAULT_BASE_URL": "langfuse",
+    "LANGFUSE_HOST_ENV": "langfuse",
+    "LANGFUSE_PUBLIC_KEY_ENV": "langfuse",
+    "LANGFUSE_SECRET_KEY_ENV": "langfuse",
+    "OPENSRE_LANGFUSE_DISABLED_ENV": "langfuse",
     # kubernetes
     "KUBECONFIG_CONTENT_ENV": "kubernetes",
     "KUBECONFIG_CONTEXT_ENV": "kubernetes",

--- a/config/constants/langfuse.py
+++ b/config/constants/langfuse.py
@@ -1,0 +1,31 @@
+"""Langfuse LLM-tracing env-var names.
+
+Langfuse is an optional trace backend: tracing turns on only when both API
+keys are present and the ``langfuse`` extra is installed. The key/URL names
+match what the Langfuse SDK reads itself, so one ``.env`` serves both OpenSRE
+and ``langfuse-cli``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+LANGFUSE_PUBLIC_KEY_ENV: Final[str] = "LANGFUSE_PUBLIC_KEY"
+LANGFUSE_SECRET_KEY_ENV: Final[str] = "LANGFUSE_SECRET_KEY"
+LANGFUSE_BASE_URL_ENV: Final[str] = "LANGFUSE_BASE_URL"
+#: Legacy alias for the base URL that older Langfuse tooling still reads.
+LANGFUSE_HOST_ENV: Final[str] = "LANGFUSE_HOST"
+#: Kill switch for a machine whose shared ``.env`` carries Langfuse keys that
+#: should not receive traces from this process.
+OPENSRE_LANGFUSE_DISABLED_ENV: Final[str] = "OPENSRE_LANGFUSE_DISABLED"
+
+LANGFUSE_DEFAULT_BASE_URL: Final[str] = "https://cloud.langfuse.com"
+
+__all__ = [
+    "LANGFUSE_BASE_URL_ENV",
+    "LANGFUSE_DEFAULT_BASE_URL",
+    "LANGFUSE_HOST_ENV",
+    "LANGFUSE_PUBLIC_KEY_ENV",
+    "LANGFUSE_SECRET_KEY_ENV",
+    "OPENSRE_LANGFUSE_DISABLED_ENV",
+]

--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -54,6 +54,17 @@ from core.tool.execution import (
 from core.tool.live_catalog import LiveToolCatalog
 from infrastructure.observability.operations_log import record_operation
 from infrastructure.observability.trace.decisions import record_decision
+from infrastructure.observability.trace.llm_payloads import (
+    generation_input,
+    generation_output,
+    tool_names,
+)
+from infrastructure.observability.trace.observations import (
+    GenerationUsage,
+    is_observation_sink_active,
+    observe_agent,
+    observe_generation,
+)
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.observability.trace.spans import (
     llm_span,
@@ -63,6 +74,10 @@ from infrastructure.observability.trace.spans import (
 )
 
 logger = logging.getLogger(__name__)
+
+#: Observation names are an API for dashboards and evaluators; keep them stable.
+_AGENT_OBSERVATION_NAME = "run-react-loop"
+_GENERATION_OBSERVATION_NAME = "think"
 
 # After a provider rejects a request as too large, the run's budget drops to
 # this share of the rejected request's estimate, keeping at least this many
@@ -205,15 +220,22 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             )
         )
         self._record_loop_operation("agent_loop_started")
-        with loop_span(
-            "react_loop",
-            attributes={
-                "max_iterations": self._max_iterations,
-                "initial_message_count": len(self._messages),
-                "tool_count": len(self._runtime_tools),
-                "tool_schema_count": len(self._tool_schemas),
-            },
-        ) as loop_attrs:
+        with (
+            observe_agent(
+                _AGENT_OBSERVATION_NAME,
+                input=self._latest_user_content(),
+                metadata=self._agent_observation_metadata(),
+            ) as agent_observation,
+            loop_span(
+                "react_loop",
+                attributes={
+                    "max_iterations": self._max_iterations,
+                    "initial_message_count": len(self._messages),
+                    "tool_count": len(self._runtime_tools),
+                    "tool_schema_count": len(self._tool_schemas),
+                },
+            ) as loop_attrs,
+        ):
             try:
                 if self._cancel_requested():
                     self._mark_cancelled()
@@ -232,6 +254,10 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                         self._run_safety_handoff()
                 run_result = self._finalize()
                 self._mark_loop_span(loop_attrs)
+                agent_observation.update(
+                    output=self._final_text or None,
+                    metadata=self._agent_outcome_metadata(),
+                )
                 self._record_loop_finished()
                 return run_result
             except KeyboardInterrupt as exc:
@@ -391,19 +417,48 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                 },
             )
         )
-        model_name = str(getattr(self._llm, "model_id", None) or "invoke")
-        with llm_span(
-            model_name,
-            iteration=iteration,
-            attributes={
-                "message_count": len(provider_request.messages),
-                "tool_schema_count": len(provider_request.tools or []),
-            },
-        ) as span_attrs:
+        model_id = getattr(self._llm, "model_id", None)
+        model_name = str(model_id or "invoke")
+        with (
+            observe_generation(
+                _GENERATION_OBSERVATION_NAME,
+                model=str(model_id) if model_id else None,
+                input=(
+                    generation_input(provider_request.system, provider_request.messages)
+                    if is_observation_sink_active()
+                    else None
+                ),
+                metadata={
+                    "iteration": iteration,
+                    "request_kind": request_kind,
+                    "message_count": len(provider_request.messages),
+                    "tool_schema_count": len(provider_request.tools or []),
+                },
+            ) as generation,
+            llm_span(
+                model_name,
+                iteration=iteration,
+                attributes={
+                    "message_count": len(provider_request.messages),
+                    "tool_schema_count": len(provider_request.tools or []),
+                },
+            ) as span_attrs,
+        ):
             response = self._invoke_within_budget(provider_request)
             span_attrs["has_tool_calls"] = response.has_tool_calls
             span_attrs["tool_call_count"] = len(response.tool_calls)
             span_attrs["content_chars"] = len(response.content or "")
+            if is_observation_sink_active():
+                generation.update(
+                    output=generation_output(response),
+                    usage=GenerationUsage(
+                        input_tokens=getattr(response, "input_tokens", None),
+                        output_tokens=getattr(response, "output_tokens", None),
+                        cache_read_tokens=getattr(response, "cache_read_tokens", None),
+                        cache_creation_tokens=getattr(response, "cache_creation_tokens", None),
+                    ),
+                    metadata={"stop_reason": str(getattr(response, "stop_reason", "") or "")},
+                )
         input_tokens = int(getattr(response, "input_tokens", 0) or 0)
         output_tokens = int(getattr(response, "output_tokens", 0) or 0)
         cache_read_tokens = int(getattr(response, "cache_read_tokens", 0) or 0)
@@ -823,6 +878,39 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             tool_result_count=len(self._tool_results),
             final_text_chars=len(self._final_text),
         )
+
+    def _latest_user_content(self) -> str | None:
+        """The user text this run answers; ``None`` when no user message is queued."""
+        for message in reversed(self._messages):
+            if isinstance(message, UserRuntimeMessage):
+                content = getattr(message, "content", None)
+                return content if isinstance(content, str) else None
+        return None
+
+    def _agent_observation_metadata(self) -> dict[str, Any]:
+        base = self._operation_base()
+        return {
+            "run_id": base["run_id"],
+            "model": base["model"],
+            "provider": base["provider"],
+            "max_iterations": self._max_iterations,
+            "max_stagnant_iterations": self._max_stagnant_iterations,
+            "tool_count": len(self._runtime_tools),
+            "tools": tool_names(self._runtime_tools),
+        }
+
+    def _agent_outcome_metadata(self) -> dict[str, Any]:
+        return {
+            "stop_reason": self._stop_reason,
+            "iterations_used": self._iterations_used,
+            "hit_iteration_cap": self._hit_cap,
+            "terminated_by_tool": self._terminated_by_tool,
+            "cancelled": self._cancelled,
+            "safety_handoff_attempted": self._safety_handoff_attempted,
+            "tool_call_count": len(self._executed),
+            # Token totals are deliberately absent: Langfuse sums generation
+            # usage per trace, and a ``*_tokens`` key would be key-redacted.
+        }
 
     def _mark_loop_error(self, span_attrs: dict[str, Any], exc: BaseException) -> None:
         mark_span_outcome(

--- a/core/agent_harness/prompts/skills/AGENTS.md
+++ b/core/agent_harness/prompts/skills/AGENTS.md
@@ -136,7 +136,11 @@ both.
 Report delivery and asking what to do next are separate actions: first
 respond with the report as Markdown text; only after it has been shown may
 the next step open a menu. Saying "the report is ready" or updating the plan
-does not deliver the report.
+does not deliver the report. A report step that precedes further plan steps
+must carry `deliverable: true` in `update_plan` (tell the card's reader to
+set it); the host shows a text-only reply before the plan is settled only
+when the current or next step is flagged, and treats any other one as a
+premature stop.
 
 ## Default recommended plan
 

--- a/core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   - GitHub authentication with read access to the repository's Actions history.
   - The analyze_github_ci_reliability and scan_local_git_workspace tools.
   - For local discovery, a local Git checkout; the example repository does not require one.
-  version: '1.15'
+  version: '1.16'
 ---
 
 # CI/CD analytics
@@ -33,6 +33,9 @@ After reading this skill, use `update_plan` to create or revise the live
 CI/CD Reliability Progress plan using the six numbered workflow headings
 below as its steps. Keep showing the table and offering the next step as
 separate plan items; update statuses as each step's completion condition is met.
+Mark step 5 with `deliverable: true` in every `update_plan` call: its work is
+the reply itself, and without that flag the host treats a text-only reply
+before the plan is settled as a premature stop and does not show it.
 
 - [ ] Step 1. Scan local repositories with scan_local_git_workspace.
 - [ ] Step 2. Select a repository using ask_user_choice.

--- a/core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/SKILL.md
@@ -9,7 +9,7 @@ demo_order: 1
 metadata:
   owner: Vincent
   last_changed_by: Jan
-  last_changed_at: 2026-09-12
+  last_changed_at: 2026-09-13
   usecases:
   - For repository maintainers analyzing CI reliability over the previous 30 days.
   - For engineering teams assessing estimated developer waiting time and failure patterns.
@@ -18,7 +18,7 @@ metadata:
   - GitHub authentication with read access to the repository's Actions history.
   - The analyze_github_ci_reliability and scan_local_git_workspace tools.
   - For local discovery, a local Git checkout; the example repository does not require one.
-  version: '1.14'
+  version: '1.15'
 ---
 
 # CI/CD analytics
@@ -30,13 +30,16 @@ requests. Use a 30-day window unless the request specifies another period.
 ## Plan
 
 After reading this skill, use `update_plan` to create or revise the live
-CI/CD Reliability Progress plan using the five numbered workflow headings below as its steps. 
+CI/CD Reliability Progress plan using the six numbered workflow headings
+below as its steps. Keep showing the table and offering the next step as
+separate plan items; update statuses as each step's completion condition is met.
 
 - [ ] Step 1. Scan local repositories with scan_local_git_workspace.
 - [ ] Step 2. Select a repository using ask_user_choice.
 - [ ] Step 3. Collect and compute the 30-day metrics with analyze_github_ci_reliability.
-- [ ] Step 4. Display a metrics table as Markdown text
-- [ ] Step 5. Use ask_user_choice to offer scheduling, Slack setup, or finish.
+- [ ] Step 4. Prepare the metrics table as Markdown text from the benchmarks reference.
+- [ ] Step 5. Show the metrics table as a text-only reply.
+- [ ] Step 6. Use ask_user_choice to offer scheduling, Slack setup, or finish.
 
 ## Workflow
 
@@ -83,7 +86,7 @@ when the user asks how a figure is defined.
 Complete when `analyze_github_ci_reliability` has returned in this turn,
 either with `key_results` or with a named blocker.
 
-### 4. Display a metrics table as Markdown text
+### 4. Prepare a metrics table as Markdown text
 
 Read [Benchmarks](references/benchmarks.md) via
 `skill_view(name="analyzing-github-ci-performance", reference="benchmarks")` now for
@@ -95,10 +98,9 @@ step 3: reread `coverage_notices` for the named gap, and if the analysis did
 not return success, run it again once. A cell still without a source is
 `n/a` with the gap stated under the table; never estimate it.
 
-Prepare the report below for delivery.
+Prepare the report below for delivery in step 5.
 
 #### Report format
-After calculating the metrics, respond directly with the report as a Markdown table. Writing that response delivers the report.
 
 Identify the repository, default branch, UTC window, and coverage. Render
 this table as text, replacing every placeholder with a calculated value or a
@@ -125,9 +127,17 @@ What insights stand out:
 ```
 
 Complete when `skill_view` has returned the benchmarks reference in this
-turn and the assistant reply contains the table.
+turn and every table cell has a source or is `n/a` with its gap stated.
 
-### 5. Offer the next step
+### 5. Show the metrics table
+
+Reply with the step 4 report as Markdown text and nothing else; call no
+tool in that message. The host paints that reply and then continues the
+plan with step 6 — do not repeat the report afterwards.
+
+Complete when the assistant reply containing the table has been shown.
+
+### 6. Offer the next step
 
 Call `ask_user_choice` with the title
 `What would you like to do next?` and these options:

--- a/core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/test_workflow.py
+++ b/core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/test_workflow.py
@@ -36,6 +36,7 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
 _REPOSITORY_QUESTION = "Which repository should I analyze?"
 _NEXT_QUESTION = "What would you like to do next?"
 _SCHEDULE_LOOPS = "Schedule local loops"
+_PREMATURE_STOP = "The analysis is done; the report is ready."
 _REPORT = (
     "Developer impact:\n- 191 developer-hours spent waiting on CI across 12 developers.\n\n"
     "| Metric | acme/widget | langchain-ai/langchain | anomalyco/opencode |\n"
@@ -52,12 +53,17 @@ _PLAN_STEPS = (
 )
 
 
-def _plan(*, completed: int, in_progress: int) -> list[dict[str, str]]:
+_DELIVERABLE_STEP = 5
+
+
+def _plan(*, completed: int, in_progress: int) -> list[dict[str, Any]]:
     """Plan payload with the first ``completed`` steps done and one step active."""
-    plan = [{"step": step, "status": "pending"} for step in _PLAN_STEPS]
+    plan: list[dict[str, Any]] = [{"step": step, "status": "pending"} for step in _PLAN_STEPS]
     for item in plan[:completed]:
         item["status"] = "completed"
     plan[in_progress - 1]["status"] = "in_progress"
+    # The card flags the report step so the host shows that reply mid-plan.
+    plan[_DELIVERABLE_STEP - 1]["deliverable"] = True
     return plan
 
 
@@ -184,6 +190,10 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
         {"title": _NEXT_QUESTION, "options": [_SCHEDULE_LOOPS, "Slack setup", "Finish"]},
     )
     handoff_call = tool_response(skill_view.name, {"name": SCHEDULING_GITHUB_CI_FIXES_SKILL_NAME})
+    benchmarks_call = tool_response(
+        skill_view.name,
+        {"name": ANALYZING_GITHUB_CI_PERFORMANCE_SKILL_NAME, "reference": "benchmarks"},
+    )
     received: list[list[dict[str, Any]]] = []
 
     class SkillLLM(FakeActionLLM):
@@ -222,9 +232,18 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
                 tool_response(update_plan.name, {"plan": _plan(completed=2, in_progress=3)}),
                 analyze_call,
             ),
+            # A premature stop while step 3 is still open: the plan gate rejects
+            # it and, with the deliverable step not yet next, keeps it off the
+            # screen.
+            no_tool_response(_PREMATURE_STOP),
+            _batch(
+                tool_response(update_plan.name, {"plan": _plan(completed=3, in_progress=4)}),
+                benchmarks_call,
+            ),
             # Step 5 as the card writes it: the report is a text-only reply while
-            # the menu step is still open. The plan gate defers it; the report
-            # must still reach the user before the menu opens.
+            # the menu step is still open. The plan gate defers it; the flagged
+            # deliverable step is next, so the report reaches the user before
+            # the menu opens.
             no_tool_response(_REPORT),
             _batch(next_menu, handoff_call),
             next_menu,
@@ -268,13 +287,19 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
     analysis = agent.handle(repository_answer, binding)
 
     assert calls == [(scan.name, {}), (analyze.name, analyze_args)]
-    assert llm.invocations == 7
+    assert llm.invocations == 9
     assert session.active_skill == skill.name
+    # The premature stop never reached the user and the model was not told it had.
+    assert _PREMATURE_STOP not in output.streamed
+    assert _PREMATURE_STOP not in analysis.primary_response_text
+    premature_nudge = str(received[5][-1].get("content", ""))
+    assert "unfinished steps" in premature_nudge
+    assert not premature_nudge.startswith("Your last reply has been shown")
     # The report was painted exactly once, before the menu, and stays in the
     # turn's history so the sibling skill can reuse it.
     assert output.streamed.count(_REPORT) == 1
     assert _REPORT in analysis.primary_response_text
-    nudge = str(received[5][-1].get("content", ""))
+    nudge = str(received[7][-1].get("content", ""))
     assert nudge.startswith("Your last reply has been shown")
     next_answer = _answer(session, title=_NEXT_QUESTION, option=_SCHEDULE_LOOPS)
 
@@ -285,7 +310,7 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
     assert calls == [(scan.name, {}), (analyze.name, analyze_args)]
     assert session.active_skill == SCHEDULING_GITHUB_CI_FIXES_SKILL_NAME
     assert session.pending_user_choice is None
-    assert llm.invocations == 9
+    assert llm.invocations == 11
     assert not llm.responses
     assert "Following the scheduling skill." in result.primary_response_text
     assert output.streamed.count(_REPORT) == 1

--- a/core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/test_workflow.py
+++ b/core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/test_workflow.py
@@ -16,6 +16,7 @@ from config.constants.skills import (
 from core.agent_harness.ports import TurnBinding
 from core.agent_harness.prompts.skills import list_action_skills, load_skill_body
 from core.agent_harness.session.pending_choice import PendingUserChoice, format_ask_user_answers
+from core.agent_harness.task_plan.plan import TaskPlan
 from core.agent_harness.tools.action_tools import get_action_tool
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.headless_adapters import (
@@ -35,6 +36,29 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
 _REPOSITORY_QUESTION = "Which repository should I analyze?"
 _NEXT_QUESTION = "What would you like to do next?"
 _SCHEDULE_LOOPS = "Schedule local loops"
+_REPORT = (
+    "Developer impact:\n- 191 developer-hours spent waiting on CI across 12 developers.\n\n"
+    "| Metric | acme/widget | langchain-ai/langchain | anomalyco/opencode |\n"
+    "|---|---:|---:|---:|\n"
+    "| PR failure rate | 31% | 12% | 9% |"
+)
+_PLAN_STEPS = (
+    "Step 1. Scan local repositories with scan_local_git_workspace.",
+    "Step 2. Select a repository using ask_user_choice.",
+    "Step 3. Collect and compute the 30-day metrics with analyze_github_ci_reliability.",
+    "Step 4. Prepare a metrics table as Markdown text.",
+    "Step 5. Show the metrics table as Markdown text.",
+    "Step 6. Use ask_user_choice to offer scheduling, Slack setup, or finish.",
+)
+
+
+def _plan(*, completed: int, in_progress: int) -> list[dict[str, str]]:
+    """Plan payload with the first ``completed`` steps done and one step active."""
+    plan = [{"step": step, "status": "pending"} for step in _PLAN_STEPS]
+    for item in plan[:completed]:
+        item["status"] = "completed"
+    plan[in_progress - 1]["status"] = "in_progress"
+    return plan
 
 
 @dataclass
@@ -50,6 +74,7 @@ class _Terminal:
 class _Session(InMemorySessionState):
     active_skill: str | None = None
     pending_user_choice: PendingUserChoice | None = None
+    task_plan: TaskPlan | None = None
     skills_already_prompted: set[str] = field(default_factory=set)
     questions_already_answered: set[str] = field(default_factory=set)
     terminal: _Terminal = field(default_factory=_Terminal)
@@ -147,6 +172,7 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
     )
     ask_user_choice = _real_action_tool("ask_user_choice")
     skill_view = _real_action_tool("skill_view")
+    update_plan = _real_action_tool("update_plan")
     analyze_args = {"owner": "acme", "repo": "widget", "days": 30}
     analyze_call = tool_response(analyze.name, analyze_args)
     repository_menu = tool_response(
@@ -158,6 +184,7 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
         {"title": _NEXT_QUESTION, "options": [_SCHEDULE_LOOPS, "Slack setup", "Finish"]},
     )
     handoff_call = tool_response(skill_view.name, {"name": SCHEDULING_GITHUB_CI_FIXES_SKILL_NAME})
+    received: list[list[dict[str, Any]]] = []
 
     class SkillLLM(FakeActionLLM):
         def invoke(
@@ -171,18 +198,35 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
                 load_skill_body(skill.name) in str(message.get("content", ""))
                 for message in messages
             )
+            received.append(messages)
             return super().invoke(messages, system=system, tools=tools)
 
     llm = SkillLLM(
         [
             # Deliberately cram the scan, the menu and the next action into one
             # response: the runtime executes none of it and the model must
-            # re-issue one call at a time, with each menu ending its turn.
-            _batch(tool_response(scan.name), repository_menu, analyze_call),
-            tool_response(scan.name),
+            # re-issue one action at a time. Plan bookkeeping may ride with
+            # that action; each menu must stand alone and ends its turn.
+            _batch(
+                tool_response(update_plan.name, {"plan": _plan(completed=0, in_progress=1)}),
+                tool_response(scan.name),
+                repository_menu,
+                analyze_call,
+            ),
+            _batch(
+                tool_response(update_plan.name, {"plan": _plan(completed=0, in_progress=1)}),
+                tool_response(scan.name),
+            ),
             repository_menu,
-            _batch(analyze_call, next_menu, handoff_call),
-            analyze_call,
+            _batch(
+                tool_response(update_plan.name, {"plan": _plan(completed=2, in_progress=3)}),
+                analyze_call,
+            ),
+            # Step 5 as the card writes it: the report is a text-only reply while
+            # the menu step is still open. The plan gate defers it; the report
+            # must still reach the user before the menu opens.
+            no_tool_response(_REPORT),
+            _batch(next_menu, handoff_call),
             next_menu,
             handoff_call,
             no_tool_response("Following the scheduling skill."),
@@ -192,7 +236,14 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
     provider = DefaultToolProvider(
         session,
         output,
-        precomputed_action_tools=[scan, analyze, schedule, ask_user_choice, skill_view],
+        precomputed_action_tools=[
+            scan,
+            analyze,
+            schedule,
+            ask_user_choice,
+            skill_view,
+            update_plan,
+        ],
         slash_ports_factory=_Ports,
     )
     agent = InMemoryHeadlessBuild(session=session, output=output).agent(
@@ -211,13 +262,20 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
     # The rejected batch ran nothing; the scan ran once on re-issue.
     assert calls == [(scan.name, {})]
     assert llm.invocations == 3
+    assert _REPORT not in output.streamed
     repository_answer = _answer(session, title=_REPOSITORY_QUESTION, option="acme/widget")
 
-    agent.handle(repository_answer, binding)
+    analysis = agent.handle(repository_answer, binding)
 
     assert calls == [(scan.name, {}), (analyze.name, analyze_args)]
-    assert llm.invocations == 6
+    assert llm.invocations == 7
     assert session.active_skill == skill.name
+    # The report was painted exactly once, before the menu, and stays in the
+    # turn's history so the sibling skill can reuse it.
+    assert output.streamed.count(_REPORT) == 1
+    assert _REPORT in analysis.primary_response_text
+    nudge = str(received[5][-1].get("content", ""))
+    assert nudge.startswith("Your last reply has been shown")
     next_answer = _answer(session, title=_NEXT_QUESTION, option=_SCHEDULE_LOOPS)
 
     result = agent.handle(next_answer, binding)
@@ -227,6 +285,7 @@ def test_local_analysis_waits_for_choices_before_analyzing_and_handing_off(
     assert calls == [(scan.name, {}), (analyze.name, analyze_args)]
     assert session.active_skill == SCHEDULING_GITHUB_CI_FIXES_SKILL_NAME
     assert session.pending_user_choice is None
-    assert llm.invocations == 8
+    assert llm.invocations == 9
     assert not llm.responses
     assert "Following the scheduling skill." in result.primary_response_text
+    assert output.streamed.count(_REPORT) == 1

--- a/core/agent_harness/task_plan/display.py
+++ b/core/agent_harness/task_plan/display.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from core.agent_harness.task_plan.plan import PlanStep, PlanStepStatus, TaskPlan
 
 
@@ -55,7 +57,7 @@ def ensure_active_step(plan: TaskPlan) -> TaskPlan:
     promoted = False
     for item in plan.steps:
         if not promoted and item.status is PlanStepStatus.PENDING:
-            steps.append(PlanStep(step=item.step, status=PlanStepStatus.IN_PROGRESS))
+            steps.append(replace(item, status=PlanStepStatus.IN_PROGRESS))
             promoted = True
         else:
             steps.append(item)

--- a/core/agent_harness/task_plan/plan.py
+++ b/core/agent_harness/task_plan/plan.py
@@ -41,10 +41,17 @@ TERMINAL_STATUSES: frozenset[PlanStepStatus] = frozenset(
 
 @dataclass(frozen=True, slots=True)
 class PlanStep:
-    """One plan step with a 1-sentence outcome and a status."""
+    """One plan step with a 1-sentence outcome and a status.
+
+    ``deliverable`` marks a step whose work *is* a text-only assistant reply
+    (a report, a table): the host shows that reply even though later steps
+    remain. It is the structured signal that separates an intended mid-plan
+    deliverable from a premature stop the plan gate rejects.
+    """
 
     step: str
     status: PlanStepStatus
+    deliverable: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,6 +117,29 @@ class TaskPlan:
             item.status is PlanStepStatus.PENDING for item in self.steps
         )
 
+    @property
+    def awaits_reply(self) -> bool:
+        """True when the step in progress, or the pending step right after it, is a deliverable.
+
+        A deliverable further down the plan does not count: work before it is
+        still open, so a text-only reply now is a premature stop, not the report.
+        """
+        current: PlanStep | None = None
+        for item in self.steps:
+            if item.status is PlanStepStatus.IN_PROGRESS:
+                current = item
+                break
+        if current is None:
+            first_pending = next(
+                (item for item in self.steps if item.status is PlanStepStatus.PENDING), None
+            )
+            return first_pending is not None and first_pending.deliverable
+        if current.deliverable:
+            return True
+        after = self.steps[self.steps.index(current) + 1 :]
+        next_pending = next((item for item in after if item.status is PlanStepStatus.PENDING), None)
+        return next_pending is not None and next_pending.deliverable
+
 
 def parse_task_plan(args: dict[str, Any]) -> tuple[TaskPlan | None, str | None]:
     """Validate ``update_plan`` arguments. Returns ``(plan, error)``."""
@@ -138,7 +168,9 @@ def parse_task_plan(args: dict[str, Any]) -> tuple[TaskPlan | None, str | None]:
         status = PlanStepStatus(status_raw)
         if status is PlanStepStatus.IN_PROGRESS:
             in_progress += 1
-        steps.append(PlanStep(step=step_text, status=status))
+        steps.append(
+            PlanStep(step=step_text, status=status, deliverable=item.get("deliverable") is True)
+        )
     if in_progress > 1:
         return None, "at most one step can be in_progress at a time"
     last = steps[-1]
@@ -149,10 +181,17 @@ def parse_task_plan(args: dict[str, Any]) -> tuple[TaskPlan | None, str | None]:
     return TaskPlan(steps=tuple(steps), explanation=explanation), None
 
 
+def _step_payload(item: PlanStep) -> dict[str, Any]:
+    payload: dict[str, Any] = {"step": item.step, "status": str(item.status)}
+    if item.deliverable:
+        payload["deliverable"] = True
+    return payload
+
+
 def task_plan_to_payload(plan: TaskPlan) -> dict[str, Any]:
     """JSON-ready dict for persistence and tool results."""
     payload: dict[str, Any] = {
-        "plan": [{"step": item.step, "status": str(item.status)} for item in plan.steps],
+        "plan": [_step_payload(item) for item in plan.steps],
         "current": plan.current_index,
         "total": plan.total,
         "completed": plan.completed_count,

--- a/core/agent_harness/task_plan/update_plan_policy.py
+++ b/core/agent_harness/task_plan/update_plan_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from core.agent_harness.session.pending_choice import parse_ask_user_answers
@@ -76,7 +77,7 @@ def demote_unevidenced_completions(
             steps.append(item)
             continue
         demoted.append(item.step)
-        steps.append(PlanStep(step=item.step, status=PlanStepStatus.PENDING))
+        steps.append(replace(item, status=PlanStepStatus.PENDING))
     if not demoted:
         return plan, ()
     return TaskPlan(steps=tuple(steps), explanation=plan.explanation), tuple(demoted)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -16,8 +16,8 @@ import json
 import logging
 import re
 import shlex
-from collections.abc import Sequence
-from dataclasses import dataclass
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
 from typing import Any
 
 from core.agent import Agent
@@ -107,6 +107,24 @@ class ActionTurnPlan:
     user_message: str
     llm: Any
     max_iterations: int
+    # Replies the plan gate deferred and the sink already painted mid-turn.
+    # They join ``response_text`` for history but are never streamed again.
+    deferred_replies: list[str] = field(default_factory=list)
+
+
+def _deferred_reply_presenter(
+    output: OutputSink, deferred_replies: list[str]
+) -> Callable[[str], None]:
+    """Paint a plan-deferred reply now (same gutter as a final reply) and keep it."""
+
+    def present(text: str) -> None:
+        deferred_replies.append(text)
+        try:
+            output.stream(label="OpenSRE", chunks=iter([text]))
+        except Exception:  # noqa: BLE001 - presentation must never break the loop
+            log.debug("deferred reply render failed; ignoring", exc_info=True)
+
+    return present
 
 
 class _StaticToolCallLLM:
@@ -510,6 +528,7 @@ def _build_action_agent(
     tool_hooks: ToolExecutionHooks | None,
     tool_resources: dict[str, Any],
     observer: Any,
+    output: OutputSink,
 ) -> ActionTurnPlan:
     """Build the Agent for one action turn; return an ``ActionTurnPlan``.
 
@@ -528,6 +547,7 @@ def _build_action_agent(
     # so "did the agent reach the goal" is not a meaningful question there.
     goal: Goal | None = None
     executed_tool_names: list[str] = []
+    deferred_replies: list[str] = []
 
     if bang_command is not None:
         # Explicit `!` shell escape: dispatch the verbatim text as a shell_run call.
@@ -574,6 +594,7 @@ def _build_action_agent(
                 task_plan=getattr(session, "task_plan", None),
                 plan_only=bool(getattr(session, "plan_only_until_authorized", False)),
             ),
+            on_plan_deferred_reply=_deferred_reply_presenter(output, deferred_replies),
             trace_context=lambda: turn_trace_state(session),
         )
 
@@ -607,6 +628,7 @@ def _build_action_agent(
         user_message=user_message,
         llm=llm,
         max_iterations=_MAX_TOOL_CALLING_ITERATIONS,
+        deferred_replies=deferred_replies,
     )
 
 
@@ -714,6 +736,7 @@ def _compose_response(
     result: Any,
     session: SessionState,
     counts: _TurnCounts,
+    deferred_replies: Sequence[str] = (),
 ) -> tuple[str, list[str], bool]:
     """Build the turn's response text and what to show on screen.
 
@@ -721,7 +744,8 @@ def _compose_response(
     on purpose: self-recording tools (shell, slash) already printed their own
     output, so the console shows only the closing text, generic tool results and
     any hint. ``response_text`` keeps the history as well, because persistence
-    and non-TTY surfaces have nothing else to read.
+    and non-TTY surfaces have nothing else to read. ``deferred_replies`` were
+    painted mid-turn by the plan gate, so they join the history, not the screen.
 
     Consumes the session's pending outcome hint.
     """
@@ -809,6 +833,7 @@ def _compose_response(
         chunk
         for chunk in (
             _response_text_from_history_entries(counts.executed_entries),
+            *deferred_replies,
             final_text_chunk,
             generic_text,
             hint,
@@ -994,6 +1019,7 @@ def _run_action_turn(
             ),
             tool_resources=tool_resources,
             observer=observer,
+            output=args.output,
         )
         result = run_react_agent_with_telemetry(
             built.agent,
@@ -1048,10 +1074,15 @@ def _run_action_turn(
         )
 
     counts = _count_turn(result, session, history_start)
-    response_text, display_chunks, use_final_text = _compose_response(result, session, counts)
+    response_text, display_chunks, use_final_text = _compose_response(
+        result, session, counts, built.deferred_replies
+    )
     cancelled = tool_resources_cancel_requested(tool_resources) or bool(
         getattr(result, "cancelled", False)
     )
+    # A deferred reply already went through the sink, so the turn host must not
+    # finalize ``response_text`` a second time (it would repost the report).
+    response_streamed = bool((use_final_text or built.deferred_replies) and not cancelled)
     # Cancelled turns stop before the host records or finalizes the response.
     # Discovery tools that opt into ``summarize_observation`` (via tool tags)
     # return structured JSON users should not see raw. Stash only those results.
@@ -1103,7 +1134,7 @@ def _run_action_turn(
         False,
         False if cancelled else counts.handled,
         response_text="" if cancelled else response_text,
-        response_streamed=bool(use_final_text and not cancelled),
+        response_streamed=response_streamed,
         hit_iteration_cap=bool(result.hit_iteration_cap and not cancelled),
         cancelled=cancelled,
         input_tokens=int(getattr(result, "input_tokens", 0) or 0),

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -61,6 +61,7 @@ from core.agent_harness.turns.display_text import (
 from core.agent_harness.turns.goal_review import (
     build_goal_reviewer,
     tap_executed_tool_names,
+    task_plan_awaits_reply,
     task_plan_blocks_conclusion,
 )
 from core.agent_harness.turns.plan_evidence_hook import with_plan_evidence
@@ -114,15 +115,22 @@ class ActionTurnPlan:
 
 def _deferred_reply_presenter(
     output: OutputSink, deferred_replies: list[str]
-) -> Callable[[str], None]:
-    """Paint a plan-deferred reply now (same gutter as a final reply) and keep it."""
+) -> Callable[[str], bool]:
+    """Paint a plan-deferred reply now (same gutter as a final reply); keep it once shown.
 
-    def present(text: str) -> None:
-        deferred_replies.append(text)
+    Returns whether the reply reached the sink. A failed stream leaves it out of
+    ``deferred_replies`` so the turn is not marked as streamed and the host's
+    normal finalization still delivers the response text.
+    """
+
+    def present(text: str) -> bool:
         try:
             output.stream(label="OpenSRE", chunks=iter([text]))
         except Exception:  # noqa: BLE001 - presentation must never break the loop
-            log.debug("deferred reply render failed; ignoring", exc_info=True)
+            log.debug("deferred reply render failed; not marking it shown", exc_info=True)
+            return False
+        deferred_replies.append(text)
+        return True
 
     return present
 
@@ -593,6 +601,9 @@ def _build_action_agent(
             plan_incomplete=lambda: task_plan_blocks_conclusion(
                 task_plan=getattr(session, "task_plan", None),
                 plan_only=bool(getattr(session, "plan_only_until_authorized", False)),
+            ),
+            plan_awaits_reply=lambda: task_plan_awaits_reply(
+                task_plan=getattr(session, "task_plan", None)
             ),
             on_plan_deferred_reply=_deferred_reply_presenter(output, deferred_replies),
             trace_context=lambda: turn_trace_state(session),

--- a/core/agent_harness/turns/goal_review.py
+++ b/core/agent_harness/turns/goal_review.py
@@ -159,6 +159,11 @@ _PLAN_INCOMPLETE_NUDGE = (
     "with its blocker in explanation, never completed. End the turn only when "
     "every plan step is completed or blocked."
 )
+# Prefix for the nudge when the deferred reply was painted for the user: the
+# model must not restate a report it can already see in its own transcript.
+_PLAN_DEFERRED_REPLY_SHOWN = (
+    "Your last reply has been shown to the user exactly as written; do not repeat it. "
+)
 
 
 _PLAN_TOOL_NAME = "update_plan"
@@ -304,6 +309,7 @@ def build_goal_reviewer(
     executed_tool_names: list[str],
     *,
     plan_incomplete: Callable[[], bool] | None = None,
+    on_plan_deferred_reply: Callable[[str], None] | None = None,
     trace_context: Callable[[], dict[str, Any]] | None = None,
 ) -> Goal:
     """Build a reviewed :class:`Goal` for one action turn over ``user_goal``.
@@ -315,6 +321,12 @@ def build_goal_reviewer(
     task plan still has unfinished steps, so the shell does not go idle with
     ``Plan · n/m`` and a mid-list ``●``. It applies only to a turn that
     worked the plan (see :func:`plan_worked_this_turn`).
+
+    ``on_plan_deferred_reply`` receives the non-empty reply text a plan
+    rejection defers. That reply is a step's deliverable (a report the plan
+    then follows with a menu), not a premature stop: without this hook it is
+    never painted, because only the accepted conclusion streams. The nudge then
+    tells the model the reply was shown so it does not restate it.
     """
     reviewer = _LLMGoalReviewer(
         llm=llm,
@@ -324,12 +336,16 @@ def build_goal_reviewer(
         trace_context=trace_context,
     )
 
-    def _nudge(_observation: GoalObservation) -> str:
+    def _nudge(observation: GoalObservation) -> str:
         if (
             plan_incomplete is not None
             and plan_worked_this_turn(executed_tool_names)
             and plan_incomplete()
         ):
+            deferred_reply = (observation.final_text or "").strip()
+            if deferred_reply and on_plan_deferred_reply is not None:
+                on_plan_deferred_reply(deferred_reply)
+                return _PLAN_DEFERRED_REPLY_SHOWN + _PLAN_INCOMPLETE_NUDGE
             return _PLAN_INCOMPLETE_NUDGE
         return (
             f"Goal not yet met: {user_goal}. "

--- a/core/agent_harness/turns/goal_review.py
+++ b/core/agent_harness/turns/goal_review.py
@@ -204,6 +204,15 @@ def task_plan_blocks_conclusion(
     return any(getattr(item, "status", None) not in {"completed", "blocked"} for item in steps)
 
 
+def task_plan_awaits_reply(*, task_plan: Any | None) -> bool:
+    """True when the plan's current or next step is a ``deliverable`` text reply.
+
+    This is the explicit signal that lets a plan-rejected conclusion reach the
+    user; a plan without it keeps every rejected reply off the screen.
+    """
+    return task_plan is not None and getattr(task_plan, "awaits_reply", False) is True
+
+
 @dataclass
 class _LLMGoalReviewer:
     """``Goal.verify`` predicate: one bounded, fail-open LLM review per turn."""
@@ -309,7 +318,8 @@ def build_goal_reviewer(
     executed_tool_names: list[str],
     *,
     plan_incomplete: Callable[[], bool] | None = None,
-    on_plan_deferred_reply: Callable[[str], None] | None = None,
+    plan_awaits_reply: Callable[[], bool] | None = None,
+    on_plan_deferred_reply: Callable[[str], bool] | None = None,
     trace_context: Callable[[], dict[str, Any]] | None = None,
 ) -> Goal:
     """Build a reviewed :class:`Goal` for one action turn over ``user_goal``.
@@ -323,10 +333,11 @@ def build_goal_reviewer(
     worked the plan (see :func:`plan_worked_this_turn`).
 
     ``on_plan_deferred_reply`` receives the non-empty reply text a plan
-    rejection defers. That reply is a step's deliverable (a report the plan
-    then follows with a menu), not a premature stop: without this hook it is
-    never painted, because only the accepted conclusion streams. The nudge then
-    tells the model the reply was shown so it does not restate it.
+    rejection defers, but only while ``plan_awaits_reply`` says the plan's
+    current or next step is a ``deliverable`` (a report the plan then follows
+    with a menu). Any other rejected reply is a premature stop and stays off
+    the screen. The presenter returns whether the reply reached the user; only
+    then does the nudge tell the model it was shown so it does not restate it.
     """
     reviewer = _LLMGoalReviewer(
         llm=llm,
@@ -343,8 +354,13 @@ def build_goal_reviewer(
             and plan_incomplete()
         ):
             deferred_reply = (observation.final_text or "").strip()
-            if deferred_reply and on_plan_deferred_reply is not None:
-                on_plan_deferred_reply(deferred_reply)
+            if (
+                deferred_reply
+                and on_plan_deferred_reply is not None
+                and plan_awaits_reply is not None
+                and plan_awaits_reply()
+                and on_plan_deferred_reply(deferred_reply)
+            ):
                 return _PLAN_DEFERRED_REPLY_SHOWN + _PLAN_INCOMPLETE_NUDGE
             return _PLAN_INCOMPLETE_NUDGE
         return (

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -30,10 +30,14 @@ from core.agent_harness.turns.turn_results import (
     TurnResult,
 )
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
+from infrastructure.observability.trace.observations import TraceAttributes, observe_span
 
 log = logging.getLogger(__name__)
 
 _ITERATION_CAP_MESSAGE = "Agent stopped before producing a final answer (iteration limit reached)."
+
+#: Root observation of one chat turn; trace input/output derive from it.
+_TURN_OBSERVATION_NAME = "handle-turn"
 
 
 def stage_turn_error(session: Any, kind: str, message: str) -> None:
@@ -77,6 +81,17 @@ def _cancelled_turn_result(
     )
 
 
+def _turn_outcome_metadata(result: TurnResult) -> dict[str, Any]:
+    action = result.action_result
+    return {
+        "final_intent": result.final_intent,
+        "cancelled": action.cancelled,
+        "hit_iteration_cap": action.hit_iteration_cap,
+        "executed_count": action.executed_count,
+        "executed_success_count": action.executed_success_count,
+    }
+
+
 def run_turn(
     text: str,
     session: SessionState,
@@ -88,7 +103,46 @@ def run_turn(
     surface: str = "interactive_shell",
     output: OutputSink | None = None,
 ) -> TurnResult:
-    """Run one ReAct turn whose accepted conclusion is the user-facing answer."""
+    """Run one ReAct turn whose accepted conclusion is the user-facing answer.
+
+    One turn is one trace for the observation sink: the user text is the trace
+    input, the assistant reply the output, and ``session_id`` groups the turns
+    of a conversation.
+    """
+    trace = TraceAttributes(
+        session_id=getattr(session, "session_id", None),
+        tags=(surface,),
+        metadata={"surface": surface},
+    )
+    with observe_span(_TURN_OBSERVATION_NAME, input=text, trace=trace) as observation:
+        result = _run_turn(
+            text,
+            session,
+            execute_actions=execute_actions,
+            accounting=accounting,
+            confirm_fn=confirm_fn,
+            is_tty=is_tty,
+            surface=surface,
+            output=output,
+        )
+        observation.update(
+            output=result.primary_response_text or None,
+            metadata=_turn_outcome_metadata(result),
+        )
+        return result
+
+
+def _run_turn(
+    text: str,
+    session: SessionState,
+    *,
+    execute_actions: ExecuteActions,
+    accounting: TurnAccounting,
+    confirm_fn: ConfirmFn | None,
+    is_tty: bool | None,
+    surface: str,
+    output: OutputSink | None,
+) -> TurnResult:
     auto_compact_if_needed(session)
     prior_messages = getattr(session, "cli_agent_messages", None) or ()
     expanded = expand_affirmative_follow_up(

--- a/core/tool/execution.py
+++ b/core/tool/execution.py
@@ -14,6 +14,11 @@ from core.domain.types.tools import ToolRole
 from core.llm.types import ToolCall
 from core.tool.contracts import AgentTool, AgentToolContext, RuntimeTool
 from infrastructure.observability.errors.boundary import report_exception
+from infrastructure.observability.trace.observations import (
+    ObservationLevel,
+    is_observation_sink_active,
+    observe_tool,
+)
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.observability.trace.spans import mark_span_outcome, tool_span
 
@@ -254,18 +259,29 @@ def execute_tool_calls(
 
     results: list[ToolExecutionResult] = []
     for tc in tool_calls:
-        with tool_span(tc.name, tool_call_id=tc.id) as span_attrs:
-            results.append(
-                _execute_one_tool_call(
-                    tc,
-                    tool_map=tool_map,
-                    tool_sources=tool_sources,
-                    resolved_integrations=resolved_integrations,
-                    runtime_resources=runtime_resources,
-                    hooks=hooks,
-                    span_attrs=span_attrs,
-                )
+        with (
+            observe_tool(
+                tc.name,
+                input=public_tool_input(tc.input) if is_observation_sink_active() else None,
+                metadata={"tool_call_id": tc.id},
+            ) as observation,
+            tool_span(tc.name, tool_call_id=tc.id) as span_attrs,
+        ):
+            result = _execute_one_tool_call(
+                tc,
+                tool_map=tool_map,
+                tool_sources=tool_sources,
+                resolved_integrations=resolved_integrations,
+                runtime_resources=runtime_resources,
+                hooks=hooks,
+                span_attrs=span_attrs,
             )
+            observation.update(
+                output=result.compat_payload(),
+                level=ObservationLevel.ERROR if result.is_error else None,
+                metadata={"is_error": result.is_error, "terminate": result.terminate},
+            )
+            results.append(result)
     return results
 
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -374,6 +374,35 @@ Want credentials only from the environment, never on disk? Set `OPENSRE_DISABLE_
 | `SENTRY_TRACES_SAMPLE_RATE` | `1.0` | Trace sampling rate for Sentry |
 | `SENTRY_ERROR_SAMPLE_RATE` | `1.0` | Error sampling rate for Sentry |
 
+### LLM tracing with Langfuse (optional)
+
+Every chat turn can be exported as a [Langfuse](https://langfuse.com) trace:
+one trace per turn, with the user message and the reply on the root, a
+`generation` per model call (model, prompt, response, token usage) and a
+`tool` per tool execution nested under the agent loop. Traces of the same
+session share a Langfuse `session_id`.
+
+Tracing is off unless **both** keys are set and the extra is installed:
+
+```bash
+uv sync --extra langfuse          # or: pip install 'opensre[langfuse]'
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_SECRET_KEY=sk-lf-...
+```
+
+Without the keys — or without the package — the agent runs exactly as before;
+nothing is buffered or exported. Credential-shaped values (API keys, bearer
+tokens, `password`/`token` fields) are masked before a span leaves the process.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `LANGFUSE_PUBLIC_KEY` |  | Langfuse project public key (required to enable tracing) |
+| `LANGFUSE_SECRET_KEY` |  | Langfuse project secret key (required to enable tracing) |
+| `LANGFUSE_BASE_URL` | `https://cloud.langfuse.com` | Langfuse host; use `https://us.cloud.langfuse.com` for the US region or your self-hosted URL (`LANGFUSE_HOST` is accepted as a legacy alias) |
+| `LANGFUSE_SAMPLE_RATE` | `1.0` | Fraction of traces to export (read by the Langfuse SDK) |
+| `LANGFUSE_DEBUG` | `False` | Verbose Langfuse SDK logging (read by the Langfuse SDK) |
+| `OPENSRE_LANGFUSE_DISABLED` | `0` | Keep tracing off even when keys are present, e.g. on a machine that shares a `.env` with `langfuse-cli` |
+
 ## Paths & Directories
 
 | Variable | Default | Description |

--- a/infrastructure/observability/langfuse/__init__.py
+++ b/infrastructure/observability/langfuse/__init__.py
@@ -1,0 +1,16 @@
+"""Optional Langfuse backend for the observation port.
+
+Only the names that do not import the ``langfuse`` package are exported here;
+``sink`` and ``masking`` are loaded by :func:`init_langfuse_tracing` once the
+package is known to be installed.
+"""
+
+from __future__ import annotations
+
+from infrastructure.observability.langfuse.install import init_langfuse_tracing
+from infrastructure.observability.langfuse.settings import (
+    LangfuseSettings,
+    resolve_langfuse_settings,
+)
+
+__all__ = ["LangfuseSettings", "init_langfuse_tracing", "resolve_langfuse_settings"]

--- a/infrastructure/observability/langfuse/install.py
+++ b/infrastructure/observability/langfuse/install.py
@@ -1,0 +1,67 @@
+"""Turn Langfuse tracing on for this process when the operator opted in.
+
+Opt-in is ``LANGFUSE_PUBLIC_KEY`` + ``LANGFUSE_SECRET_KEY`` in the environment
+and the ``langfuse`` extra installed. Anything else leaves the noop
+observation sink in place, so contributors without a Langfuse project run
+the same code path with zero overhead.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from infrastructure.observability.langfuse.settings import resolve_langfuse_settings
+from infrastructure.observability.trace.observations import (
+    is_observation_sink_active,
+    set_observation_sink,
+)
+
+log = logging.getLogger(__name__)
+
+_MISSING_PACKAGE_HINT = (
+    "Langfuse keys are set but the `langfuse` package is not installed; LLM tracing "
+    "stays off. Install it with `uv sync --extra langfuse` or "
+    "`pip install 'opensre[langfuse]'`."
+)
+
+
+def init_langfuse_tracing() -> bool:
+    """Install the Langfuse observation sink; return whether tracing is on.
+
+    Idempotent: a process that already has a sink keeps it. Never raises — a
+    misconfigured tracing backend must not stop the agent from booting.
+    """
+    if is_observation_sink_active():
+        return True
+    settings = resolve_langfuse_settings()
+    if settings is None:
+        return False
+    try:
+        from langfuse import Langfuse
+    except ImportError:
+        log.warning(_MISSING_PACKAGE_HINT)
+        return False
+
+    from config.environment import get_environment
+    from config.version import get_opensre_version
+    from infrastructure.observability.langfuse.masking import mask_otel_spans
+    from infrastructure.observability.langfuse.sink import LangfuseObservationSink
+
+    try:
+        client = Langfuse(
+            public_key=settings.public_key,
+            secret_key=settings.secret_key,
+            base_url=settings.base_url,
+            environment=get_environment().value,
+            release=f"opensre@{get_opensre_version()}",
+            mask_otel_spans=mask_otel_spans,
+        )
+    except Exception:  # noqa: BLE001 - boot must survive a broken tracing backend
+        log.warning("Langfuse client could not be created; LLM tracing stays off", exc_info=True)
+        return False
+    set_observation_sink(LangfuseObservationSink(client))
+    log.info("Langfuse LLM tracing enabled (%s)", settings.base_url)
+    return True
+
+
+__all__ = ["init_langfuse_tracing"]

--- a/infrastructure/observability/langfuse/masking.py
+++ b/infrastructure/observability/langfuse/masking.py
@@ -1,0 +1,52 @@
+"""Export-stage credential masking for spans leaving this process to Langfuse.
+
+Runs on the Langfuse exporter thread over the final OpenTelemetry attributes,
+so it also covers text a call site did not think to redact (tool output that
+echoes a token, an exception message carrying a bearer header).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from langfuse.types import (
+    MaskOtelSpansParams,
+    MaskOtelSpansResult,
+    OtelSpanIdentifier,
+    OtelSpanPatch,
+)
+
+from infrastructure.safety.secret_redaction import redact_text
+
+_AttributeValue = (
+    str | bool | int | float | Sequence[str] | Sequence[bool] | Sequence[int] | Sequence[float]
+)
+
+
+def _masked(value: _AttributeValue) -> _AttributeValue | None:
+    """Redacted copy of ``value`` when a credential pattern matched, else ``None``."""
+    if isinstance(value, str):
+        redacted = redact_text(value)
+        return redacted if redacted != value else None
+    if isinstance(value, Sequence) and value and all(isinstance(item, str) for item in value):
+        originals = [str(item) for item in value]
+        redacted_items = [redact_text(item) for item in originals]
+        return redacted_items if redacted_items != originals else None
+    return None
+
+
+def mask_otel_spans(*, params: MaskOtelSpansParams) -> MaskOtelSpansResult:
+    """Replace credential-shaped substrings in every string attribute of the batch."""
+    patches: dict[OtelSpanIdentifier, OtelSpanPatch | None] = {}
+    for identifier, span in params.spans.items():
+        replacements: dict[str, _AttributeValue] = {}
+        for key, value in span.attributes.items():
+            masked = _masked(value)
+            if masked is not None:
+                replacements[key] = masked
+        if replacements:
+            patches[identifier] = OtelSpanPatch(set_attributes=replacements)
+    return MaskOtelSpansResult(span_patches=patches)
+
+
+__all__ = ["mask_otel_spans"]

--- a/infrastructure/observability/langfuse/settings.py
+++ b/infrastructure/observability/langfuse/settings.py
@@ -1,0 +1,57 @@
+"""Resolve whether, and where, this process should send Langfuse traces."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from config.constants.langfuse import (
+    LANGFUSE_BASE_URL_ENV,
+    LANGFUSE_DEFAULT_BASE_URL,
+    LANGFUSE_HOST_ENV,
+    LANGFUSE_PUBLIC_KEY_ENV,
+    LANGFUSE_SECRET_KEY_ENV,
+    OPENSRE_LANGFUSE_DISABLED_ENV,
+)
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+@dataclass(frozen=True, slots=True)
+class LangfuseSettings:
+    """Credentials and endpoint for one Langfuse project."""
+
+    public_key: str
+    secret_key: str
+    base_url: str
+
+
+def _clean(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def resolve_langfuse_settings(
+    environ: Mapping[str, str] | None = None,
+) -> LangfuseSettings | None:
+    """Settings when tracing is opted in; ``None`` when keys are missing or disabled.
+
+    Both keys are required — a lone public key is what ``langfuse-cli`` users
+    often leave behind and must not turn tracing on.
+    """
+    env = os.environ if environ is None else environ
+    if _clean(env.get(OPENSRE_LANGFUSE_DISABLED_ENV)).lower() in _TRUTHY:
+        return None
+    public_key = _clean(env.get(LANGFUSE_PUBLIC_KEY_ENV))
+    secret_key = _clean(env.get(LANGFUSE_SECRET_KEY_ENV))
+    if not public_key or not secret_key:
+        return None
+    base_url = (
+        _clean(env.get(LANGFUSE_BASE_URL_ENV))
+        or _clean(env.get(LANGFUSE_HOST_ENV))
+        or LANGFUSE_DEFAULT_BASE_URL
+    ).rstrip("/")
+    return LangfuseSettings(public_key=public_key, secret_key=secret_key, base_url=base_url)
+
+
+__all__ = ["LangfuseSettings", "resolve_langfuse_settings"]

--- a/infrastructure/observability/langfuse/sink.py
+++ b/infrastructure/observability/langfuse/sink.py
@@ -1,0 +1,210 @@
+"""``ObservationSink`` backed by the Langfuse Python SDK (v4, OpenTelemetry-based).
+
+Nesting comes from the OpenTelemetry context the SDK manages, so a
+``generation`` opened inside an ``agent`` inside the turn root lands in the
+right place without callers passing parents around. Every SDK call is guarded:
+a tracing failure degrades to a missing observation, never a failed turn.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator, Mapping
+from contextlib import AbstractContextManager, ExitStack, contextmanager
+from typing import Any, Final, Literal
+
+from langfuse import Langfuse, propagate_attributes
+
+from infrastructure.observability.trace.observations import (
+    NOOP_OBSERVATION,
+    GenerationUsage,
+    Observation,
+    ObservationKind,
+    ObservationLevel,
+    TraceAttributes,
+)
+from infrastructure.observability.trace.redaction import redact_sensitive
+from infrastructure.safety.secret_redaction import redact_text
+
+log = logging.getLogger(__name__)
+
+#: Exception text is useful for debugging a failed step but is bounded so a
+#: provider error that echoes a whole request does not become the observation.
+_STATUS_MESSAGE_MAX_CHARS = 400
+
+
+def _usage_kwargs(usage: GenerationUsage) -> dict[str, Any]:
+    """Exclusive ``input`` / ``output`` buckets; cache counters go to metadata.
+
+    Providers disagree on whether ``input_tokens`` already includes cache reads
+    (OpenAI: yes, Anthropic: no), so cache counts are recorded but never added
+    as a second billing bucket — that would double-count on one of them.
+    """
+    details: dict[str, int] = {}
+    if usage.input_tokens is not None:
+        details["input"] = usage.input_tokens
+    if usage.output_tokens is not None:
+        details["output"] = usage.output_tokens
+    kwargs: dict[str, Any] = {}
+    if details:
+        kwargs["usage_details"] = details
+    cache_metadata = {
+        key: value
+        for key, value in (
+            ("cache_read_tokens", usage.cache_read_tokens),
+            ("cache_creation_tokens", usage.cache_creation_tokens),
+        )
+        if value is not None
+    }
+    if cache_metadata:
+        kwargs["metadata"] = cache_metadata
+    return kwargs
+
+
+class _LangfuseObservation:
+    """Adapter from the port's ``update`` vocabulary to the SDK span wrapper."""
+
+    def __init__(self, span: Any) -> None:
+        self._span = span
+
+    def update(
+        self,
+        *,
+        output: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+        usage: GenerationUsage | None = None,
+        level: ObservationLevel | None = None,
+        status_message: str | None = None,
+    ) -> None:
+        kwargs: dict[str, Any] = {}
+        if output is not None:
+            kwargs["output"] = redact_sensitive(output)
+        merged_metadata: dict[str, Any] = dict(redact_sensitive(dict(metadata))) if metadata else {}
+        if usage is not None:
+            usage_kwargs = _usage_kwargs(usage)
+            merged_metadata.update(usage_kwargs.pop("metadata", {}))
+            kwargs.update(usage_kwargs)
+        if merged_metadata:
+            kwargs["metadata"] = merged_metadata
+        if level is not None:
+            kwargs["level"] = level.value
+        if status_message:
+            kwargs["status_message"] = status_message
+        if not kwargs:
+            return
+        try:
+            self._span.update(**kwargs)
+        except Exception:  # noqa: BLE001 - tracing must never break the turn
+            log.debug("langfuse observation update failed", exc_info=True)
+
+    def mark_error(self, exc: BaseException) -> None:
+        text = redact_text(f"{type(exc).__name__}: {exc}")
+        self.update(
+            level=ObservationLevel.ERROR,
+            status_message=text[:_STATUS_MESSAGE_MAX_CHARS],
+        )
+
+
+def _trace_kwargs(trace: TraceAttributes) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if trace.session_id:
+        kwargs["session_id"] = trace.session_id
+    if trace.user_id:
+        kwargs["user_id"] = trace.user_id
+    if trace.tags:
+        kwargs["tags"] = list(trace.tags)
+    if trace.metadata:
+        kwargs["metadata"] = {key: str(value) for key, value in trace.metadata.items()}
+    return kwargs
+
+
+_NON_GENERATION_KINDS: Final[Mapping[ObservationKind, Literal["span", "agent", "tool"]]] = {
+    ObservationKind.SPAN: "span",
+    ObservationKind.AGENT: "agent",
+    ObservationKind.TOOL: "tool",
+}
+
+
+class LangfuseObservationSink:
+    """Materialise port observations as Langfuse observations."""
+
+    def __init__(self, client: Langfuse) -> None:
+        self._client = client
+
+    @property
+    def client(self) -> Langfuse:
+        return self._client
+
+    def _start(
+        self,
+        kind: ObservationKind,
+        name: str,
+        *,
+        input: Any,
+        metadata: Mapping[str, Any] | None,
+        model: str | None,
+    ) -> AbstractContextManager[Any]:
+        redacted_input = None if input is None else redact_sensitive(input)
+        redacted_metadata = None if metadata is None else redact_sensitive(dict(metadata))
+        if kind is ObservationKind.GENERATION:
+            # Only generations carry ``model``; the SDK overloads reject it elsewhere.
+            return self._client.start_as_current_observation(
+                as_type="generation",
+                name=name,
+                input=redacted_input,
+                metadata=redacted_metadata,
+                model=model,
+            )
+        return self._client.start_as_current_observation(
+            as_type=_NON_GENERATION_KINDS[kind],
+            name=name,
+            input=redacted_input,
+            metadata=redacted_metadata,
+        )
+
+    @contextmanager
+    def observe(
+        self,
+        kind: ObservationKind,
+        name: str,
+        *,
+        input: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+        model: str | None = None,
+        trace: TraceAttributes | None = None,
+    ) -> Iterator[Observation]:
+        with ExitStack() as stack:
+            try:
+                span = stack.enter_context(
+                    self._start(kind, name, input=input, metadata=metadata, model=model)
+                )
+                trace_kwargs = _trace_kwargs(trace) if trace is not None else {}
+                if trace_kwargs:
+                    stack.enter_context(propagate_attributes(**trace_kwargs))
+            except Exception:  # noqa: BLE001 - tracing must never break the turn
+                log.debug(
+                    "langfuse observation %s/%s could not start", kind.value, name, exc_info=True
+                )
+                yield NOOP_OBSERVATION
+                return
+            observation = _LangfuseObservation(span)
+            try:
+                yield observation
+            except Exception as exc:
+                observation.mark_error(exc)
+                raise
+
+    def flush(self) -> None:
+        try:
+            self._client.flush()
+        except Exception:  # noqa: BLE001 - shutdown paths must not raise
+            log.debug("langfuse flush failed", exc_info=True)
+
+    def shutdown(self) -> None:
+        try:
+            self._client.shutdown()
+        except Exception:  # noqa: BLE001 - shutdown paths must not raise
+            log.debug("langfuse shutdown failed", exc_info=True)
+
+
+__all__ = ["LangfuseObservationSink"]

--- a/infrastructure/observability/trace/llm_payloads.py
+++ b/infrastructure/observability/trace/llm_payloads.py
@@ -1,0 +1,66 @@
+"""Shape LLM request / response payloads for observation sinks.
+
+Backends render a list of ``{"role", "content"}`` messages as a chat
+transcript and an assistant message's ``tool_calls`` (OpenAI function shape,
+JSON-encoded ``arguments``) as tool-call cards, so every provider's request is
+normalised to that shape here rather than at each call site.
+
+Callers build these payloads only when
+:func:`~infrastructure.observability.trace.observations.is_observation_sink_active`
+is true; nothing here runs on an uninstrumented process.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+
+def _tool_call_card(tool_call: Any) -> dict[str, Any]:
+    arguments = getattr(tool_call, "input", None)
+    try:
+        encoded = json.dumps(arguments, default=str)
+    except (TypeError, ValueError):
+        encoded = json.dumps(str(arguments))
+    return {
+        "id": str(getattr(tool_call, "id", "") or ""),
+        "type": "function",
+        "function": {
+            "name": str(getattr(tool_call, "name", "") or ""),
+            "arguments": encoded,
+        },
+    }
+
+
+def generation_input(
+    system: str | None,
+    messages: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """The full prompt as a chat transcript: system first, then the provider messages."""
+    transcript: list[dict[str, Any]] = []
+    if system:
+        transcript.append({"role": "system", "content": system})
+    transcript.extend(dict(message) for message in messages)
+    return transcript
+
+
+def generation_output(response: Any) -> dict[str, Any]:
+    """The assistant turn the model produced, tool calls in OpenAI function shape."""
+    payload: dict[str, Any] = {
+        "role": "assistant",
+        "content": str(getattr(response, "content", "") or ""),
+    }
+    tool_calls: Iterable[Any] = getattr(response, "tool_calls", None) or ()
+    cards = [_tool_call_card(tool_call) for tool_call in tool_calls]
+    if cards:
+        payload["tool_calls"] = cards
+    return payload
+
+
+def tool_names(tools: Iterable[Any]) -> list[str]:
+    """Stable, sorted tool names for agent-level metadata."""
+    return sorted(str(getattr(tool, "name", "tool")) for tool in tools)
+
+
+__all__ = ["generation_input", "generation_output", "tool_names"]

--- a/infrastructure/observability/trace/observations.py
+++ b/infrastructure/observability/trace/observations.py
@@ -1,0 +1,245 @@
+"""LLM-observability port: typed observations that carry input and output.
+
+``spans.py`` records duration-only spans for the local JSONL session trace.
+This is the second, richer seam: an *observation* is a typed region
+(``span`` / ``agent`` / ``generation`` / ``tool``) with input, output, token
+usage and metadata, nested by the active execution context and exported by an
+installed backend such as Langfuse (``infrastructure.observability.langfuse``).
+
+Design for production safety
+----------------------------
+* Default sink is :class:`NoopObservationSink`; the helpers hand back one
+  shared inert observation, so an uninstrumented process pays an ``isinstance``
+  check and nothing else.
+* Call sites gate payload construction on :func:`is_observation_sink_active`
+  so message copies and redaction run only when a backend is listening.
+* A sink must never raise into product code; adapters guard their own calls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+
+class ObservationKind(StrEnum):
+    """Langfuse-compatible observation types this codebase emits."""
+
+    SPAN = "span"
+    AGENT = "agent"
+    GENERATION = "generation"
+    TOOL = "tool"
+
+
+class ObservationLevel(StrEnum):
+    """Severity attached to an observation on completion."""
+
+    DEFAULT = "DEFAULT"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+
+@dataclass(frozen=True, slots=True)
+class TraceAttributes:
+    """Trace-wide attributes applied to a root observation and everything under it."""
+
+    session_id: str | None = None
+    user_id: str | None = None
+    tags: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationUsage:
+    """Provider-reported token counts for one model invocation.
+
+    ``input_tokens`` / ``output_tokens`` are passed through as the provider
+    reported them. Cache counters travel separately because providers disagree
+    on whether ``input_tokens`` already includes cache reads; a backend must
+    not add them into a second billing bucket.
+    """
+
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+
+
+class Observation(Protocol):
+    """One open observation; ``update`` may be called any number of times."""
+
+    def update(
+        self,
+        *,
+        output: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+        usage: GenerationUsage | None = None,
+        level: ObservationLevel | None = None,
+        status_message: str | None = None,
+    ) -> None:
+        """Attach output, metadata, usage or a completion level to the observation."""
+
+
+class ObservationSink(Protocol):
+    """Backend that materialises observations (Langfuse, a test recorder, ...)."""
+
+    def observe(
+        self,
+        kind: ObservationKind,
+        name: str,
+        *,
+        input: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+        model: str | None = None,
+        trace: TraceAttributes | None = None,
+    ) -> AbstractContextManager[Observation]:
+        """Open ``name`` nested under the currently active observation.
+
+        ``trace`` is only meaningful on the root observation of a trace; it is
+        propagated to every observation opened inside the returned context.
+        """
+
+    def flush(self) -> None:
+        """Block until buffered observations have been exported."""
+
+    def shutdown(self) -> None:
+        """Flush and release exporter resources."""
+
+
+class _NoopObservation:
+    def update(
+        self,
+        *,
+        output: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+        usage: GenerationUsage | None = None,
+        level: ObservationLevel | None = None,
+        status_message: str | None = None,
+    ) -> None:
+        del output, metadata, usage, level, status_message
+
+
+#: Shared inert observation; sinks hand it back when a backend call fails.
+NOOP_OBSERVATION: Observation = _NoopObservation()
+
+
+class NoopObservationSink:
+    """Default sink before a host installs a backend."""
+
+    def observe(
+        self,
+        kind: ObservationKind,
+        name: str,
+        *,
+        input: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+        model: str | None = None,
+        trace: TraceAttributes | None = None,
+    ) -> AbstractContextManager[Observation]:
+        del kind, name, input, metadata, model, trace
+        return nullcontext(NOOP_OBSERVATION)
+
+    def flush(self) -> None:
+        return None
+
+    def shutdown(self) -> None:
+        return None
+
+
+_sink: ObservationSink = NoopObservationSink()
+
+
+def get_observation_sink() -> ObservationSink:
+    return _sink
+
+
+def set_observation_sink(sink: ObservationSink | None) -> None:
+    """Install ``sink`` process-wide; ``None`` restores the noop default."""
+    global _sink
+    _sink = sink if sink is not None else NoopObservationSink()
+
+
+def is_observation_sink_active() -> bool:
+    """True when a real backend is installed; gate payload construction on this."""
+    return not isinstance(_sink, NoopObservationSink)
+
+
+def flush_observations() -> None:
+    _sink.flush()
+
+
+def shutdown_observations() -> None:
+    _sink.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Semantic helpers — call sites use these, not ``observe`` with a kind kwarg
+# ---------------------------------------------------------------------------
+
+
+def observe_span(
+    name: str,
+    *,
+    input: Any = None,
+    metadata: Mapping[str, Any] | None = None,
+    trace: TraceAttributes | None = None,
+) -> AbstractContextManager[Observation]:
+    """A generic unit of work; pass ``trace`` only on the root of a trace."""
+    return _sink.observe(ObservationKind.SPAN, name, input=input, metadata=metadata, trace=trace)
+
+
+def observe_agent(
+    name: str,
+    *,
+    input: Any = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> AbstractContextManager[Observation]:
+    """A reasoning loop that decides control flow and may call tools."""
+    return _sink.observe(ObservationKind.AGENT, name, input=input, metadata=metadata)
+
+
+def observe_generation(
+    name: str,
+    *,
+    model: str | None,
+    input: Any = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> AbstractContextManager[Observation]:
+    """One model invocation; ``update(usage=...)`` once the provider reports tokens."""
+    return _sink.observe(
+        ObservationKind.GENERATION, name, input=input, metadata=metadata, model=model
+    )
+
+
+def observe_tool(
+    name: str,
+    *,
+    input: Any = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> AbstractContextManager[Observation]:
+    """One tool execution, a sibling of the generation that requested it."""
+    return _sink.observe(ObservationKind.TOOL, name, input=input, metadata=metadata)
+
+
+__all__ = [
+    "NOOP_OBSERVATION",
+    "GenerationUsage",
+    "NoopObservationSink",
+    "Observation",
+    "ObservationKind",
+    "ObservationLevel",
+    "ObservationSink",
+    "TraceAttributes",
+    "flush_observations",
+    "get_observation_sink",
+    "is_observation_sink_active",
+    "observe_agent",
+    "observe_generation",
+    "observe_span",
+    "observe_tool",
+    "set_observation_sink",
+    "shutdown_observations",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,15 @@ dev = [
     "boto3-stubs[essential]",
     "huggingface_hub>=0.26.0",
     "datasets>=3.0.0",
+    # Exercises the Langfuse trace adapter in CI; production installs opt in
+    # via the ``langfuse`` extra.
+    "langfuse>=4.15.2,<5",
+]
+# Optional LLM tracing backend. Activated only when LANGFUSE_PUBLIC_KEY and
+# LANGFUSE_SECRET_KEY are set; without the extra installed the runtime keeps
+# running with the noop observation sink.
+langfuse = [
+    "langfuse>=4.15.2,<5",
 ]
 release-dist = [
     "build>=1.2.0",

--- a/tests/bootstrap/test_process.py
+++ b/tests/bootstrap/test_process.py
@@ -32,6 +32,10 @@ def test_configure_process_gateway_order(monkeypatch: pytest.MonkeyPatch) -> Non
         lambda **_kw: order.append("sentry"),
     )
     monkeypatch.setattr(
+        "infrastructure.observability.langfuse.init_langfuse_tracing",
+        lambda: order.append("llm_tracing"),
+    )
+    monkeypatch.setattr(
         "bootstrap.process.install_harness_adapters",
         lambda: order.append("adapters"),
     )
@@ -50,10 +54,10 @@ def test_configure_process_gateway_order(monkeypatch: pytest.MonkeyPatch) -> Non
 
     configure_process(GATEWAY_PROFILE, logger=logging.getLogger("test.process"))
 
-    assert order == ["env", "sentry", "adapters", "caps", "preload"], order
+    assert order == ["env", "sentry", "llm_tracing", "adapters", "caps", "preload"], order
 
 
-def test_configure_process_cli_only_boots_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_configure_process_cli_boots_env_and_llm_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
     """CLI_PROFILE leaves Sentry and Rich adapters to surfaces/cli/startup."""
     order: list[str] = []
     monkeypatch.setattr(
@@ -63,6 +67,10 @@ def test_configure_process_cli_only_boots_env(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(
         "infrastructure.observability.errors.sentry.init_sentry",
         lambda **_kw: order.append("sentry"),
+    )
+    monkeypatch.setattr(
+        "infrastructure.observability.langfuse.init_langfuse_tracing",
+        lambda: order.append("llm_tracing"),
     )
     monkeypatch.setattr(
         "bootstrap.process.install_harness_adapters",
@@ -75,7 +83,7 @@ def test_configure_process_cli_only_boots_env(monkeypatch: pytest.MonkeyPatch) -
 
     configure_process(CLI_PROFILE)
 
-    assert order == ["env"], order
+    assert order == ["env", "llm_tracing"], order
 
 
 def test_configure_process_web_skips_llm_preload(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -87,6 +95,10 @@ def test_configure_process_web_skips_llm_preload(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(
         "infrastructure.observability.errors.sentry.init_sentry",
         lambda **_kw: order.append("sentry"),
+    )
+    monkeypatch.setattr(
+        "infrastructure.observability.langfuse.init_langfuse_tracing",
+        lambda: order.append("llm_tracing"),
     )
     monkeypatch.setattr(
         "bootstrap.process.install_harness_adapters",
@@ -103,7 +115,7 @@ def test_configure_process_web_skips_llm_preload(monkeypatch: pytest.MonkeyPatch
 
     configure_process(WEB_PROFILE)
 
-    assert order == ["env", "sentry", "adapters"], order
+    assert order == ["env", "sentry", "llm_tracing", "adapters"], order
 
 
 def test_configure_process_is_idempotent_per_profile(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -117,6 +129,9 @@ def test_configure_process_is_idempotent_per_profile(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(
         "infrastructure.observability.errors.sentry.init_sentry",
         lambda **_kw: None,
+    )
+    monkeypatch.setattr(
+        "infrastructure.observability.langfuse.init_langfuse_tracing", lambda: False
     )
     monkeypatch.setattr("bootstrap.process.install_harness_adapters", lambda: None)
     monkeypatch.setattr("bootstrap.process.install_scheduled_delivery_adapters", lambda: None)
@@ -160,6 +175,7 @@ class TestEmbeddedProfile:
 
         # Assert
         assert BootStep.SENTRY not in EMBEDDED_PROFILE.steps
+        assert BootStep.LLM_TRACING not in EMBEDDED_PROFILE.steps
         assert BootStep.PRELOAD_LLM not in EMBEDDED_PROFILE.steps
         assert BootStep.SCHEDULER_RUNNERS not in EMBEDDED_PROFILE.steps
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 
 import config.constants.paths as paths
 from config.constants import (
+    OPENSRE_LANGFUSE_DISABLED_ENV,
     OPENSRE_MEMORY_AUTOEXTRACT_DISABLED_ENV,
     OPENSRE_MEMORY_DIR_ENV,
 )
@@ -23,6 +24,7 @@ def pytest_configure(config: pytest.Config) -> None:
     _ = config
     _load_env()
     _disable_sentry()
+    _disable_langfuse()
     _mark_tests_for_analytics()
 
 
@@ -35,6 +37,12 @@ def _disable_sentry() -> None:
     os.environ["OPENSRE_SENTRY_DISABLED"] = "1"
 
 
+def _disable_langfuse() -> None:
+    # A developer ``.env`` may carry real Langfuse keys; boot-path tests must
+    # not export traces. Adapter tests re-enable it explicitly.
+    os.environ[OPENSRE_LANGFUSE_DISABLED_ENV] = "1"
+
+
 def _mark_tests_for_analytics() -> None:
     os.environ["OPENSRE_NO_TELEMETRY"] = "1"
     os.environ["OPENSRE_INVESTIGATION_SOURCE"] = "test"
@@ -42,6 +50,7 @@ def _mark_tests_for_analytics() -> None:
 
 _load_env()
 _disable_sentry()
+_disable_langfuse()
 _mark_tests_for_analytics()
 
 
@@ -65,6 +74,19 @@ def _isolate_session_trace_store() -> Iterator[None]:
     previous = get_session_trace_store()
     yield
     set_session_trace_store(previous)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_observation_sink() -> Iterator[None]:
+    """Restore the process-global LLM observation sink after every test."""
+    from infrastructure.observability.trace.observations import (
+        get_observation_sink,
+        set_observation_sink,
+    )
+
+    previous = get_observation_sink()
+    yield
+    set_observation_sink(previous)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/agent/test_react_loop_observations.py
+++ b/tests/core/agent/test_react_loop_observations.py
@@ -1,0 +1,158 @@
+"""ReAct loop emits Langfuse-shaped observations: one ``agent`` per run, one
+``generation`` per model call (never aggregated), and each ``tool`` as a
+sibling of the generation that requested it.
+
+The noop default must leave the loop untouched — no payload copies, no
+observation calls — which is what makes the backend safe to leave uninstalled.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+from core.agent import Agent
+from core.llm.types import AgentLLMResponse, ToolCall
+from infrastructure.observability.trace.observations import (
+    GenerationUsage,
+    ObservationKind,
+    is_observation_sink_active,
+    set_observation_sink,
+)
+from tests.utils.observations import RecordingObservationSink
+
+
+class _ToolThenDoneLLM:
+    model_id = "test-model"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def tool_schemas(self, tools: Sequence[Any]) -> list[dict[str, Any]]:
+        return [
+            {"name": tool.name, "description": "", "parameters": tool.parameters} for tool in tools
+        ]
+
+    def invoke(
+        self,
+        _messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AgentLLMResponse:
+        _ = (system, tools)
+        self.calls += 1
+        if self.calls == 1:
+            return AgentLLMResponse(
+                content="",
+                tool_calls=[ToolCall(id="c1", name="echo", input={"token": "ghp_" + "a" * 36})],
+                stop_reason="tool_use",
+                input_tokens=120,
+                output_tokens=15,
+                cache_read_tokens=100,
+            )
+        return AgentLLMResponse(content="done", input_tokens=200, output_tokens=5)
+
+    @staticmethod
+    def build_assistant_message(content: str, tool_calls: list[object]) -> dict[str, object]:
+        return {"role": "assistant", "content": content, "tool_calls": tool_calls}
+
+    @staticmethod
+    def build_tool_result_message(
+        _tool_calls: list[object], _results: list[object]
+    ) -> dict[str, object]:
+        return {"role": "tool", "content": "[]"}
+
+
+class _EchoTool:
+    name = "echo"
+    description = "echo"
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": {"token": {"type": "string"}},
+        "additionalProperties": False,
+    }
+
+    def validate_public_input(self, value: dict[str, Any]) -> str | None:
+        _ = value
+        return None
+
+    def extract_params(self, resolved: dict[str, Any]) -> dict[str, Any]:
+        return dict(resolved)
+
+    def run(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": True, "echoed": kwargs}
+
+
+def _agent() -> Agent:
+    return Agent(
+        llm=_ToolThenDoneLLM(),
+        system="sys",
+        tools=[_EchoTool()],
+        resolved_integrations={},
+        max_iterations=3,
+    )
+
+
+def test_agent_run_emits_agent_generation_and_tool_observations() -> None:
+    sink = RecordingObservationSink()
+    set_observation_sink(sink)
+
+    result = _agent().run([{"role": "user", "content": "hello"}])
+
+    assert result.final_text == "done"
+    agents = sink.of_kind(ObservationKind.AGENT)
+    generations = sink.of_kind(ObservationKind.GENERATION)
+    tools = sink.of_kind(ObservationKind.TOOL)
+    assert [a.name for a in agents] == ["run-react-loop"]
+    assert [g.name for g in generations] == ["think", "think"]
+    assert [t.name for t in tools] == ["echo"]
+    assert all(record.closed for record in sink.observations)
+
+    agent = agents[0]
+    assert agent.input == "hello"
+    assert agent.output == "done"
+    assert agent.metadata["tools"] == ["echo"]
+    assert agent.metadata["stop_reason"] == "completed"
+    assert agent.metadata["tool_call_count"] == 1
+    assert not any(key.endswith("_tokens") for key in agent.metadata), (
+        "token keys are key-redacted by the sink; usage belongs on generations"
+    )
+
+    first, second = generations
+    assert first.parent is agent and second.parent is agent
+    assert first.model == "test-model"
+    assert first.input[0] == {"role": "system", "content": "sys"}
+    assert first.input[-1]["role"] == "user"
+    assert first.output["tool_calls"][0]["function"]["name"] == "echo"
+    assert first.usage == GenerationUsage(
+        input_tokens=120, output_tokens=15, cache_read_tokens=100, cache_creation_tokens=None
+    )
+    assert first.metadata["stop_reason"] == "tool_use"
+    assert second.output == {"role": "assistant", "content": "done"}
+    assert second.usage == GenerationUsage(input_tokens=200, output_tokens=5)
+
+    tool = tools[0]
+    assert tool.parent is agent, "a tool is a sibling of the generation that requested it"
+    assert tool.metadata["tool_call_id"] == "c1"
+    assert tool.metadata["is_error"] is False
+    assert tool.output["ok"] is True
+    assert tool.level is None
+
+
+def test_noop_sink_skips_payload_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a backend the loop must not build generation payloads or call the sink."""
+    assert is_observation_sink_active() is False
+
+    def _unexpected(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("payload built while no sink is active")
+
+    monkeypatch.setattr("core.agent.react_loop.generation_input", _unexpected)
+    monkeypatch.setattr("core.agent.react_loop.generation_output", _unexpected)
+    monkeypatch.setattr("core.tool.execution.public_tool_input", _unexpected)
+
+    result = _agent().run([{"role": "user", "content": "hello"}])
+
+    assert result.final_text == "done"

--- a/tests/core/agent_harness/task_plan/test_deliverable_step.py
+++ b/tests/core/agent_harness/task_plan/test_deliverable_step.py
@@ -1,0 +1,55 @@
+"""A ``deliverable`` plan step is the only thing that lets a mid-plan reply show."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.task_plan.plan import (
+    TaskPlan,
+    parse_task_plan,
+    task_plan_from_payload,
+    task_plan_to_payload,
+)
+from core.agent_harness.task_plan.update_plan_policy import demote_unevidenced_completions
+
+
+def _plan(statuses: list[str], *, deliverable_index: int = 3) -> TaskPlan:
+    items: list[dict[str, Any]] = [
+        {"step": f"Step {i + 1}", "status": status} for i, status in enumerate(statuses)
+    ]
+    items[deliverable_index]["deliverable"] = True
+    plan, error = parse_task_plan({"plan": items})
+    assert error is None and plan is not None
+    return plan
+
+
+def test_awaits_reply_only_when_the_deliverable_is_current_or_next() -> None:
+    # Work still open before the report step: a text-only reply is premature.
+    assert (
+        _plan(["completed", "in_progress", "pending", "pending", "pending"]).awaits_reply is False
+    )
+    # The report step is next after the step in progress, or is itself in progress.
+    assert _plan(["completed", "completed", "in_progress", "pending", "pending"]).awaits_reply
+    assert _plan(["completed", "completed", "completed", "in_progress", "pending"]).awaits_reply
+    # No step in progress: only the first pending step counts.
+    assert _plan(["completed", "completed", "completed", "pending", "pending"]).awaits_reply
+    assert _plan(["completed", "completed", "pending", "pending", "pending"]).awaits_reply is False
+    # A plan without the flag never asks for a reply to be shown.
+    unflagged, error = parse_task_plan(
+        {"plan": [{"step": "a", "status": "in_progress"}, {"step": "b", "status": "pending"}]}
+    )
+    assert error is None and unflagged is not None
+    assert unflagged.awaits_reply is False
+
+
+def test_deliverable_flag_survives_payload_round_trip_and_status_demotion() -> None:
+    plan = _plan(["completed", "completed", "completed", "completed", "pending"])
+    payload = task_plan_to_payload(plan)
+    assert [item.get("deliverable") for item in payload["plan"]] == [None, None, None, True, None]
+    restored = task_plan_from_payload(payload)
+    assert restored is not None
+    assert [item.deliverable for item in restored.steps] == [False, False, False, True, False]
+
+    demoted, names = demote_unevidenced_completions(plan, prior=None, evidence=False)
+    assert names
+    assert [item.deliverable for item in demoted.steps] == [False, False, False, True, False]

--- a/tests/core/agent_harness/test_goal_review_structured.py
+++ b/tests/core/agent_harness/test_goal_review_structured.py
@@ -9,11 +9,15 @@ import pytest
 from config.constants.llm import OPENSRE_REACT_GOAL_LLM_REVIEW_ENV
 from core.agent.goals import GoalObservation
 from core.agent_harness.session.pending_choice import AskUserQuestion, format_ask_user_answers
-from core.agent_harness.turns.action_driver import _goal_review_user_request
+from core.agent_harness.turns.action_driver import (
+    _deferred_reply_presenter,
+    _goal_review_user_request,
+)
 from core.agent_harness.turns.goal_review import (
     build_gather_goal_reviewer,
     build_goal_reviewer,
 )
+from core.agent_harness.turns.headless_adapters import BufferOutputSink
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from core.llm.types import AgentLLMResponse
 
@@ -74,13 +78,20 @@ def test_goal_reviewer_shows_a_plan_deferred_reply_before_nudging() -> None:
     accepted conclusion was empty, so the report never reached the screen.
     """
     shown: list[str] = []
+    awaits_reply = True
     llm = _ScriptedLLM('{"verdict": "GOAL_REACHED"}')
+
+    def _present(text: str) -> bool:
+        shown.append(text)
+        return True
+
     goal = build_goal_reviewer(
         llm,
         "analyze CI reliability",
         executed_tool_names=["update_plan", "analyze_github_ci_reliability"],
         plan_incomplete=lambda: True,
-        on_plan_deferred_reply=shown.append,
+        plan_awaits_reply=lambda: awaits_reply,
+        on_plan_deferred_reply=_present,
     )
     assert goal.verify is not None and goal.nudge is not None
 
@@ -94,7 +105,50 @@ def test_goal_reviewer_shows_a_plan_deferred_reply_before_nudging() -> None:
     assert goal.nudge(_obs(text="   ")) == goal.nudge(_obs(text=""))
     assert not goal.nudge(_obs(text="")).startswith("Your last reply")
     assert shown == ["| Metric | repo |\n|---|---:|"]
+    # Without the plan's explicit deliverable signal a rejected reply is a
+    # premature stop: it stays off the screen and the model is not told otherwise.
+    awaits_reply = False
+    nudge = goal.nudge(_obs(text="All done, the report is ready."))
+    assert shown == ["| Metric | repo |\n|---|---:|"]
+    assert not nudge.startswith("Your last reply has been shown")
+    assert "unfinished steps" in nudge
     assert llm.invokes == 0
+
+
+def test_deferred_reply_presenter_records_only_replies_that_reached_the_sink() -> None:
+    """A failed stream must not mark the turn streamed, or the reply is lost."""
+    delivered: list[str] = []
+
+    class _BrokenSink(BufferOutputSink):
+        def stream(self, *_args: Any, **_kwargs: Any) -> None:
+            raise OSError("terminal went away")
+
+    working = BufferOutputSink()
+    assert _deferred_reply_presenter(working, delivered)("| Metric |") is True
+    assert delivered == ["| Metric |"]
+    assert working.streamed == ["| Metric |"]
+
+    assert _deferred_reply_presenter(_BrokenSink(), delivered)("| Lost |") is False
+    assert delivered == ["| Metric |"]
+
+
+def test_goal_reviewer_does_not_claim_a_reply_was_shown_when_presenting_failed() -> None:
+    """A presenter that could not paint the reply must not make the nudge say it did."""
+    llm = _ScriptedLLM('{"verdict": "GOAL_REACHED"}')
+    goal = build_goal_reviewer(
+        llm,
+        "analyze CI reliability",
+        executed_tool_names=["update_plan"],
+        plan_incomplete=lambda: True,
+        plan_awaits_reply=lambda: True,
+        on_plan_deferred_reply=lambda _text: False,
+    )
+    assert goal.nudge is not None
+
+    nudge = goal.nudge(_obs(text="| Metric | repo |"))
+
+    assert not nudge.startswith("Your last reply has been shown")
+    assert "unfinished steps" in nudge
 
 
 def test_goal_reviewer_lets_an_active_goal_redirect_over_a_stale_plan() -> None:

--- a/tests/core/agent_harness/test_goal_review_structured.py
+++ b/tests/core/agent_harness/test_goal_review_structured.py
@@ -66,6 +66,37 @@ def test_goal_reviewer_rejects_while_task_plan_incomplete() -> None:
     assert "unfinished steps" in goal.nudge(_obs())
 
 
+def test_goal_reviewer_shows_a_plan_deferred_reply_before_nudging() -> None:
+    """A mid-plan report is a step's deliverable: paint it, then say it was shown.
+
+    Observed live: the CI analytics card asked for the report as a text-only
+    reply followed by a menu step; the plan gate rejected the reply and the
+    accepted conclusion was empty, so the report never reached the screen.
+    """
+    shown: list[str] = []
+    llm = _ScriptedLLM('{"verdict": "GOAL_REACHED"}')
+    goal = build_goal_reviewer(
+        llm,
+        "analyze CI reliability",
+        executed_tool_names=["update_plan", "analyze_github_ci_reliability"],
+        plan_incomplete=lambda: True,
+        on_plan_deferred_reply=shown.append,
+    )
+    assert goal.verify is not None and goal.nudge is not None
+
+    assert goal.verify(_obs(text="| Metric | repo |\n|---|---:|")) is False
+    nudge = goal.nudge(_obs(text="| Metric | repo |\n|---|---:|"))
+
+    assert shown == ["| Metric | repo |\n|---|---:|"]
+    assert nudge.startswith("Your last reply has been shown")
+    assert "unfinished steps" in nudge
+    # An empty conclusion has nothing to show and must not claim otherwise.
+    assert goal.nudge(_obs(text="   ")) == goal.nudge(_obs(text=""))
+    assert not goal.nudge(_obs(text="")).startswith("Your last reply")
+    assert shown == ["| Metric | repo |\n|---|---:|"]
+    assert llm.invokes == 0
+
+
 def test_goal_reviewer_lets_an_active_goal_redirect_over_a_stale_plan() -> None:
     """A leftover plan must not pull a redirected /goal turn back into it."""
     llm = _ScriptedLLM('{"verdict": "GOAL_REACHED"}')

--- a/tests/core/agent_harness/test_run_turn_observation.py
+++ b/tests/core/agent_harness/test_run_turn_observation.py
@@ -1,0 +1,61 @@
+"""``run_turn`` is the root observation of one trace.
+
+Langfuse derives the trace's input/output and session grouping from this
+root, so the user text, the reply and the session id must land here — not on
+the agent loop underneath, which may run several times per turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from core.agent_harness.session import SessionCore
+from core.agent_harness.session.persistence.memory import InMemorySessionStore
+from core.agent_harness.turns.orchestrator import ExecuteActions, run_turn
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from infrastructure.observability.trace.observations import (
+    ObservationKind,
+    observe_agent,
+    set_observation_sink,
+)
+from tests.utils.observations import RecordingObservationSink
+
+
+class _Accounting:
+    def record_action_result(self, _result: ToolCallingTurnResult) -> None:
+        return None
+
+    def finalize(self, result: TurnResult) -> TurnResult:
+        return result
+
+
+def test_run_turn_opens_root_span_with_session_and_reply() -> None:
+    sink = RecordingObservationSink()
+    set_observation_sink(sink)
+    session = SessionCore(store=InMemorySessionStore())
+
+    def execute_actions(_text: str, **_kwargs: Any) -> ToolCallingTurnResult:
+        with observe_agent("run-react-loop"):
+            pass
+        return ToolCallingTurnResult(1, 1, 1, False, True, response_text="42")
+
+    result = run_turn(
+        "meaning of life?",
+        session,
+        execute_actions=cast(ExecuteActions, execute_actions),
+        accounting=_Accounting(),
+        surface="gateway",
+    )
+
+    assert result.primary_response_text == "42"
+    (root,) = sink.of_kind(ObservationKind.SPAN)
+    assert root.name == "handle-turn"
+    assert root.parent is None
+    assert root.input == "meaning of life?"
+    assert root.output == "42"
+    assert root.trace is not None
+    assert root.trace.session_id == session.session_id
+    assert root.trace.tags == ("gateway",)
+    assert root.metadata["executed_success_count"] == 1
+    (agent,) = sink.of_kind(ObservationKind.AGENT)
+    assert agent.parent is root

--- a/tests/core/tool/test_execution_observations.py
+++ b/tests/core/tool/test_execution_observations.py
@@ -1,0 +1,70 @@
+"""Tool execution records one observation per call under the caller's context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.tools import ToolRole
+from core.llm.types import ToolCall
+from core.tool.contracts import AgentTool
+from core.tool.execution import execute_tool_calls
+from infrastructure.observability.trace.observations import (
+    ObservationKind,
+    ObservationLevel,
+    observe_agent,
+    set_observation_sink,
+)
+from tests.utils.observations import RecordingObservationSink
+
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"value": {"type": "string"}},
+    "required": ["value"],
+    "additionalProperties": False,
+}
+
+
+def _tool(name: str, execute: Any, *, role: ToolRole = ToolRole.ACTION) -> AgentTool:
+    return AgentTool(
+        name=name,
+        description="test tool",
+        input_schema=_SCHEMA,
+        execute=execute,
+        role=role,
+        source="agent",
+    )
+
+
+def test_tool_observations_are_children_of_the_calling_observation() -> None:
+    sink = RecordingObservationSink()
+    set_observation_sink(sink)
+
+    def _echo(args: dict[str, Any], _ctx: Any) -> dict[str, Any]:
+        return {"value": args["value"]}
+
+    def _boom(_args: dict[str, Any], _ctx: Any) -> dict[str, Any]:
+        raise RuntimeError("tool exploded")
+
+    # One action plus one bookkeeping call is the largest batch the runtime runs.
+    with observe_agent("run-react-loop") as parent:
+        results = execute_tool_calls(
+            [
+                ToolCall(id="a-1", name="alpha", input={"value": "1"}),
+                ToolCall(id="b-1", name="beta", input={"value": "2"}),
+            ],
+            [_tool("alpha", _echo, role=ToolRole.BOOKKEEPING), _tool("beta", _boom)],
+            {},
+        )
+
+    assert [r.is_error for r in results] == [False, True]
+    tools = sink.of_kind(ObservationKind.TOOL)
+    assert [t.name for t in tools] == ["alpha", "beta"]
+    assert all(t.parent is parent for t in tools)
+
+    by_name = {t.name: t for t in tools}
+    assert by_name["alpha"].input == {"value": "1"}
+    assert by_name["alpha"].output == {"value": "1"}
+    assert by_name["alpha"].metadata["tool_call_id"] == "a-1"
+    assert by_name["alpha"].level is None
+    assert by_name["beta"].level is ObservationLevel.ERROR
+    assert by_name["beta"].metadata["is_error"] is True

--- a/tests/infrastructure/observability/langfuse/test_langfuse_adapter.py
+++ b/tests/infrastructure/observability/langfuse/test_langfuse_adapter.py
@@ -1,0 +1,266 @@
+"""Langfuse adapter: opt-in gating, secret masking at export, and port mapping.
+
+Tracing is optional for every contributor, so the failure modes worth pinning
+are the ones that would either turn it on by accident, leak a credential once
+it is on, or let a backend hiccup break a turn.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+from langfuse.types import MaskOtelSpansParams, OtelSpanData, OtelSpanIdentifier
+
+from config.constants import (
+    LANGFUSE_BASE_URL_ENV,
+    LANGFUSE_HOST_ENV,
+    LANGFUSE_PUBLIC_KEY_ENV,
+    LANGFUSE_SECRET_KEY_ENV,
+    OPENSRE_LANGFUSE_DISABLED_ENV,
+)
+from infrastructure.observability.langfuse import (
+    init_langfuse_tracing,
+    resolve_langfuse_settings,
+)
+from infrastructure.observability.langfuse.masking import mask_otel_spans
+from infrastructure.observability.langfuse.sink import LangfuseObservationSink
+from infrastructure.observability.trace.observations import (
+    NOOP_OBSERVATION,
+    GenerationUsage,
+    ObservationKind,
+    ObservationLevel,
+    TraceAttributes,
+    is_observation_sink_active,
+)
+
+_GITHUB_PAT = "ghp_" + "A" * 36
+_KEYS = {LANGFUSE_PUBLIC_KEY_ENV: "pk-lf-test", LANGFUSE_SECRET_KEY_ENV: "sk-lf-test"}
+
+
+# --------------------------------------------------------------------------- settings
+
+
+def test_settings_require_both_keys_and_honour_disable_switch() -> None:
+    assert resolve_langfuse_settings({}) is None
+    assert resolve_langfuse_settings({LANGFUSE_PUBLIC_KEY_ENV: "pk-lf-test"}) is None
+    assert resolve_langfuse_settings({**_KEYS, OPENSRE_LANGFUSE_DISABLED_ENV: "true"}) is None
+
+    settings = resolve_langfuse_settings(_KEYS)
+    assert settings is not None
+    assert settings.base_url == "https://cloud.langfuse.com"
+
+
+def test_settings_prefer_base_url_over_legacy_host() -> None:
+    both = {**_KEYS, LANGFUSE_HOST_ENV: "https://legacy/", LANGFUSE_BASE_URL_ENV: "https://eu/"}
+    legacy_only = {**_KEYS, LANGFUSE_HOST_ENV: "https://legacy/"}
+    assert resolve_langfuse_settings(both).base_url == "https://eu"  # type: ignore[union-attr]
+    assert resolve_langfuse_settings(legacy_only).base_url == "https://legacy"  # type: ignore[union-attr]
+
+
+# --------------------------------------------------------------------------- masking
+
+
+def _span(span_id: str, attributes: dict[str, Any]) -> tuple[OtelSpanIdentifier, OtelSpanData]:
+    identifier = OtelSpanIdentifier(trace_id="t", span_id=span_id)
+    return identifier, OtelSpanData(
+        trace_id="t",
+        span_id=span_id,
+        parent_span_id=None,
+        name="tool",
+        instrumentation_scope_name="langfuse-sdk",
+        instrumentation_scope_version=None,
+        attributes=attributes,
+        resource_attributes={},
+    )
+
+
+def test_mask_otel_spans_redacts_credentials_and_leaves_clean_spans_alone() -> None:
+    leaky_id, leaky = _span(
+        "leaky",
+        {
+            "langfuse.observation.output": f'{{"token": "{_GITHUB_PAT}"}}',
+            "langfuse.observation.metadata.tags": ["ok", f"Authorization: Bearer {_GITHUB_PAT}"],
+            "count": 3,
+        },
+    )
+    clean_id, clean = _span("clean", {"langfuse.observation.input": "hello"})
+
+    result = mask_otel_spans(params=MaskOtelSpansParams(spans={leaky_id: leaky, clean_id: clean}))
+
+    assert set(result.span_patches) == {leaky_id}
+    patch = result.span_patches[leaky_id]
+    assert patch is not None
+    assert _GITHUB_PAT not in str(patch.set_attributes)
+    assert "[REDACTED:github_pat]" in str(patch.set_attributes["langfuse.observation.output"])
+    assert patch.set_attributes["langfuse.observation.metadata.tags"][0] == "ok"  # type: ignore[index]
+    assert "count" not in patch.set_attributes
+
+
+# --------------------------------------------------------------------------- sink
+
+
+class _FakeSpan:
+    def __init__(self, kwargs: dict[str, Any]) -> None:
+        self.start_kwargs = kwargs
+        self.updates: list[dict[str, Any]] = []
+
+    def update(self, **kwargs: Any) -> None:
+        self.updates.append(kwargs)
+
+
+class _FakeLangfuse:
+    def __init__(self, *, fail_start: bool = False) -> None:
+        self.spans: list[_FakeSpan] = []
+        self.fail_start = fail_start
+
+    @contextmanager
+    def start_as_current_observation(self, **kwargs: Any) -> Any:
+        if self.fail_start:
+            raise RuntimeError("exporter down")
+        span = _FakeSpan(kwargs)
+        self.spans.append(span)
+        yield span
+
+
+def _sink(client: _FakeLangfuse) -> LangfuseObservationSink:
+    return LangfuseObservationSink(client)  # type: ignore[arg-type]
+
+
+def test_generation_carries_model_and_exclusive_usage_buckets() -> None:
+    client = _FakeLangfuse()
+    with _sink(client).observe(
+        ObservationKind.GENERATION, "think", model="gpt-x", input=[{"role": "user"}]
+    ) as observation:
+        observation.update(
+            output={"role": "assistant", "content": "hi"},
+            usage=GenerationUsage(
+                input_tokens=120, output_tokens=5, cache_read_tokens=100, cache_creation_tokens=None
+            ),
+        )
+
+    (span,) = client.spans
+    assert span.start_kwargs["as_type"] == "generation"
+    assert span.start_kwargs["model"] == "gpt-x"
+    (update,) = span.updates
+    assert update["usage_details"] == {"input": 120, "output": 5}
+    assert update["metadata"] == {"cache_read_tokens": 100}
+
+
+def test_non_generation_kinds_never_pass_model() -> None:
+    client = _FakeLangfuse()
+    with _sink(client).observe(ObservationKind.TOOL, "echo", model="ignored"):
+        pass
+    assert client.spans[0].start_kwargs["as_type"] == "tool"
+    assert "model" not in client.spans[0].start_kwargs
+
+
+def test_credential_keys_are_redacted_before_reaching_the_sdk() -> None:
+    """Key-based redaction runs in-process; value patterns are caught at export."""
+    client = _FakeLangfuse()
+    with _sink(client).observe(
+        ObservationKind.TOOL, "echo", input={"token": _GITHUB_PAT, "repo": "o/r"}
+    ) as observation:
+        observation.update(output={"password": "hunter2", "_client": object()})
+    span = client.spans[0]
+    assert span.start_kwargs["input"] == {"token": "[redacted]", "repo": "o/r"}
+    assert span.updates[0]["output"] == {"password": "[redacted]", "_client": "[runtime object]"}
+
+
+def test_body_exception_marks_error_and_propagates() -> None:
+    client = _FakeLangfuse()
+    with (
+        pytest.raises(ValueError, match="boom"),
+        _sink(client).observe(ObservationKind.SPAN, "handle-turn"),
+    ):
+        raise ValueError(f"boom {_GITHUB_PAT}")
+    (update,) = client.spans[0].updates
+    assert update["level"] == ObservationLevel.ERROR.value
+    assert update["status_message"].startswith("ValueError: boom")
+    assert _GITHUB_PAT not in update["status_message"]
+
+
+def test_backend_failure_degrades_to_noop_observation() -> None:
+    client = _FakeLangfuse(fail_start=True)
+    ran = False
+    with _sink(client).observe(
+        ObservationKind.SPAN, "handle-turn", trace=TraceAttributes(session_id="s1")
+    ) as observation:
+        ran = True
+        observation.update(output="still fine")
+    assert ran is True
+    assert observation is NOOP_OBSERVATION
+
+
+# --------------------------------------------------------------------------- install
+
+
+@pytest.fixture
+def _enabled_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OPENSRE_LANGFUSE_DISABLED_ENV, raising=False)
+    for key, value in _KEYS.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_init_without_keys_leaves_noop_sink(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OPENSRE_LANGFUSE_DISABLED_ENV, raising=False)
+    monkeypatch.delenv(LANGFUSE_PUBLIC_KEY_ENV, raising=False)
+    monkeypatch.delenv(LANGFUSE_SECRET_KEY_ENV, raising=False)
+
+    assert init_langfuse_tracing() is False
+    assert is_observation_sink_active() is False
+
+
+@pytest.mark.usefixtures("_enabled_env")
+def test_init_with_keys_but_no_package_warns_and_stays_off(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setitem(sys.modules, "langfuse", None)
+
+    with caplog.at_level(logging.WARNING):
+        assert init_langfuse_tracing() is False
+
+    assert is_observation_sink_active() is False
+    assert "uv sync --extra langfuse" in caplog.text
+
+
+@pytest.mark.usefixtures("_enabled_env")
+def test_init_installs_sink_with_environment_release_and_masking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[dict[str, Any]] = []
+
+    class _RecordingLangfuse:
+        def __init__(self, **kwargs: Any) -> None:
+            created.append(kwargs)
+
+    import langfuse
+
+    monkeypatch.setattr(langfuse, "Langfuse", _RecordingLangfuse)
+
+    assert init_langfuse_tracing() is True
+    assert init_langfuse_tracing() is True, "second call reuses the installed sink"
+
+    assert is_observation_sink_active() is True
+    (kwargs,) = created
+    assert kwargs["public_key"] == "pk-lf-test"
+    assert kwargs["base_url"] == "https://cloud.langfuse.com"
+    assert kwargs["release"].startswith("opensre@")
+    assert kwargs["environment"]
+    assert kwargs["mask_otel_spans"] is mask_otel_spans
+
+
+@pytest.mark.usefixtures("_enabled_env")
+def test_init_survives_a_broken_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    import langfuse
+
+    def _explode(**_kwargs: Any) -> Any:
+        raise RuntimeError("bad key format")
+
+    monkeypatch.setattr(langfuse, "Langfuse", _explode)
+
+    assert init_langfuse_tracing() is False
+    assert is_observation_sink_active() is False

--- a/tests/utils/observations.py
+++ b/tests/utils/observations.py
@@ -1,0 +1,125 @@
+"""In-memory ``ObservationSink`` that records nesting the way Langfuse would.
+
+Parentage follows a ``contextvars`` stack so tests can assert that worker
+threads inherit the caller's observation context, not only that observations
+were emitted.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import threading
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+from infrastructure.observability.trace.observations import (
+    GenerationUsage,
+    Observation,
+    ObservationKind,
+    ObservationLevel,
+    TraceAttributes,
+)
+
+
+@dataclass
+class RecordedObservation:
+    kind: ObservationKind
+    name: str
+    input: Any
+    metadata: dict[str, Any]
+    model: str | None
+    trace: TraceAttributes | None
+    parent: RecordedObservation | None
+    thread_name: str
+    output: Any = None
+    usage: GenerationUsage | None = None
+    level: ObservationLevel | None = None
+    status_message: str | None = None
+    closed: bool = False
+    updates: list[dict[str, Any]] = field(default_factory=list)
+
+    def update(
+        self,
+        *,
+        output: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+        usage: GenerationUsage | None = None,
+        level: ObservationLevel | None = None,
+        status_message: str | None = None,
+    ) -> None:
+        self.updates.append(
+            {
+                "output": output,
+                "metadata": metadata,
+                "usage": usage,
+                "level": level,
+                "status_message": status_message,
+            }
+        )
+        if output is not None:
+            self.output = output
+        if metadata:
+            self.metadata.update(metadata)
+        if usage is not None:
+            self.usage = usage
+        if level is not None:
+            self.level = level
+        if status_message is not None:
+            self.status_message = status_message
+
+
+_current: contextvars.ContextVar[RecordedObservation | None] = contextvars.ContextVar(
+    "recording_observation_current", default=None
+)
+
+
+class RecordingObservationSink:
+    """Collects every observation in open order; ``flushed``/``shut_down`` count calls."""
+
+    def __init__(self) -> None:
+        self.observations: list[RecordedObservation] = []
+        self.flushed = 0
+        self.shut_down = 0
+
+    @contextmanager
+    def observe(
+        self,
+        kind: ObservationKind,
+        name: str,
+        *,
+        input: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+        model: str | None = None,
+        trace: TraceAttributes | None = None,
+    ) -> Iterator[Observation]:
+        record = RecordedObservation(
+            kind=kind,
+            name=name,
+            input=input,
+            metadata=dict(metadata or {}),
+            model=model,
+            trace=trace,
+            parent=_current.get(),
+            thread_name=threading.current_thread().name,
+        )
+        self.observations.append(record)
+        token = _current.set(record)
+        try:
+            yield record
+        finally:
+            record.closed = True
+            _current.reset(token)
+
+    def flush(self) -> None:
+        self.flushed += 1
+
+    def shutdown(self) -> None:
+        self.shut_down += 1
+
+    def of_kind(self, kind: ObservationKind) -> list[RecordedObservation]:
+        return [record for record in self.observations if record.kind is kind]
+
+
+__all__ = ["RecordedObservation", "RecordingObservationSink"]

--- a/tools/interactive_shell/actions/update_plan.py
+++ b/tools/interactive_shell/actions/update_plan.py
@@ -39,6 +39,15 @@ _PLAN_ITEM_SCHEMA = {
             ),
             enum=("pending", "in_progress", "completed", "blocked"),
         ),
+        "deliverable": {
+            "type": "boolean",
+            "description": (
+                "True when this step's work is a text-only assistant reply the user "
+                "must see (a report or table) while later steps remain. Without it a "
+                "text-only reply before the plan is settled is treated as a premature "
+                "stop and is not shown."
+            ),
+        },
     },
     "required": ["step", "status"],
     "additionalProperties": False,

--- a/uv.lock
+++ b/uv.lock
@@ -315,6 +315,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.83"
 source = { registry = "https://pypi.org/simple" }
@@ -1162,6 +1171,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/f5/7af1dd74b9608a85274414fc423a7162844492b198ece3fe31f4e1f88237/grimp-3.17-cp313-cp313-win32.whl", hash = "sha256:34369739ed293accbb674494ae932351516b316e8e85d1d333d4c51796af846a", size = 1874244, upload-time = "2026-09-04T11:29:21.693Z" },
     { url = "https://files.pythonhosted.org/packages/8b/d4/af497adddfcf11f9bd4ab273625a49022bf5ba4f5fc389589f4e6edc67b9/grimp-3.17-cp313-cp313-win_amd64.whl", hash = "sha256:d21b859c50418bdb48b403a84450650fa7aab3102f3212d00d3c21c76a982167", size = 1998225, upload-time = "2026-09-04T11:29:10.5Z" },
     { url = "https://files.pythonhosted.org/packages/e2/2a/07fd537997281049af2390fc8641de5ae063ae4972cb6fcec85873674595/grimp-3.17-cp313-cp313-win_arm64.whl", hash = "sha256:206cd9f7c757b97934f48ba2b8ec6d649725fd6314d6b182dd327b19b4f35707", size = 1922071, upload-time = "2026-09-04T11:28:58.34Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e0/e11ea5aeb62534c9706e17952d142aa844ce5659e2d66b4b8ba9377407d6/grimp-3.17-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:0100ff6f08067c8eb8a77dd1433af5e173aea8dbf6a6b76f5372a3b49f2e0a43", size = 2161696, upload-time = "2026-09-11T10:36:49.104Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d6/ddf82f4428d8bdc54ced0db244cbf5d8e5638490c3ed6a8b9f5db55dfa51/grimp-3.17-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:67ada40a5c1cf4321183c0b0cd0393658ccd04b845caed002ac81dc2fdef828e", size = 2107301, upload-time = "2026-09-11T10:36:46.459Z" },
     { url = "https://files.pythonhosted.org/packages/86/1a/1dd0d9d2751e8078547e1cb7131e13d9624a2ea60700d926b3d624c15825/grimp-3.17-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:baa385915a4c17948bfb25f77509cbbfb33795f321d1c5ca7cc602e34ed58e99", size = 2278433, upload-time = "2026-09-04T11:27:03.075Z" },
     { url = "https://files.pythonhosted.org/packages/58/71/3768fd253e7455a83d668193055691c82d3a4d434047116c572a27d2bd39/grimp-3.17-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8322a435b5ee97ff3db823df36cbefea569faec505cc0ca66223c27b4b44cca6", size = 2221152, upload-time = "2026-09-04T11:27:12.642Z" },
     { url = "https://files.pythonhosted.org/packages/b4/4f/907a130e87554d57be14c2a7cedeb818d0ef519064877297d19636735f6b/grimp-3.17-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb953c21beb6ac85a59b5b54128be7fdddd89396d34b3c5705cf59829a85b431", size = 2371546, upload-time = "2026-09-04T11:27:41.195Z" },
@@ -1718,6 +1729,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/30/6a64dcf84de2f2eb4d03adbfd22cc7bdc95ce67e3e56cd6288405087fb8a/langfuse-4.15.2.tar.gz", hash = "sha256:7f818f38cc22daba88fdcec62d2addcee4e18d1af4529978b6d07501e86b6946", size = 391727, upload-time = "2026-09-09T16:01:25.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/de/e59da18cb5ca9cb8515a254199bd96ace8cf918788d13ded66aa2693e007/langfuse-4.15.2-py3-none-any.whl", hash = "sha256:98c27a3c06e18c4497045f2d4decce2c716ef11cb215cf5b27bbea6ee0877115", size = 705824, upload-time = "2026-09-09T16:01:23.696Z" },
 ]
 
 [[package]]
@@ -2442,6 +2473,7 @@ dev = [
     { name = "datasets" },
     { name = "huggingface-hub" },
     { name = "import-linter" },
+    { name = "langfuse" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -2459,6 +2491,9 @@ dev = [
 ]
 kafka = [
     { name = "confluent-kafka" },
+]
+langfuse = [
+    { name = "langfuse" },
 ]
 opensre-hub = [
     { name = "datasets" },
@@ -2521,6 +2556,8 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'opensre-hub'", specifier = ">=0.26.0" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "kubernetes", specifier = ">=28.1.0" },
+    { name = "langfuse", marker = "extra == 'dev'", specifier = ">=4.15.2,<5" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4.15.2,<5" },
     { name = "litellm", specifier = ">=1.90.0,<1.100.0" },
     { name = "mcp", specifier = ">=1.28.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
@@ -2570,7 +2607,7 @@ requires-dist = [
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
     { name = "yandexcloud", marker = "extra == 'yandex-cloud-logs'", specifier = ">=0.300.0" },
 ]
-provides-extras = ["dev", "release-dist", "release-binary", "release", "opensre-hub", "kafka", "clickhouse", "postgresql", "azure-sql", "yandex-cloud-logs"]
+provides-extras = ["dev", "langfuse", "release-dist", "release-binary", "release", "opensre-hub", "kafka", "clickhouse", "postgresql", "azure-sql", "yandex-cloud-logs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Adds opt-in Langfuse tracing for the agent runtime.

- `infrastructure/observability/trace/observations.py` — a provider-neutral observation API (`observe_span` / `observe_agent` / `observe_tool`, `ObservationLevel`, `TraceAttributes`) backed by a process-wide sink. The default sink is a no-op, so contributors without Langfuse run the same code path with zero overhead.
- `infrastructure/observability/langfuse/` — the Langfuse sink (`sink.py`), settings resolution (`settings.py`), payload masking (`masking.py`) and idempotent boot install (`install.py`). Enabled only when `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` are set and the `langfuse` extra is installed; a misconfigured backend never blocks boot.
- Instrumentation: one trace per chat turn (`turns/orchestrator.py::run_turn`, keyed by `session_id`), a generation per LLM call inside the ReAct loop (`core/agent/react_loop.py`, with `llm_payloads.py` shaping the public request/response), and a tool observation per tool call (`core/tool/execution.py`) with input, output and error level.
- Plan-gate fix for the CI/CD analytics skill: a text-only report the plan gate defers is now painted once for the user (`action_driver.py` deferred-reply presenter) and the nudge tells the model it was shown so it is not restated (`goal_review.py`). The skill card is split into "prepare table" / "show table" / "offer next step" (v1.15).
- Config/docs: `LANGFUSE_*` and `OPENSRE_LANGFUSE_DISABLED` in `config/constants/langfuse.py`, `.env.example`, and `docs/configuration/environment-variables.mdx`; `langfuse` optional extra in `pyproject.toml`.

Rebased onto `main` after #6233 (one action per response): tool observations wrap the sequential loop, and the colocated workflow test now exercises the plan-deferred report under the one-action rule.

### Demo/Screenshot for feature changes and bug fixes -

Focused tests run locally (all green):

```
uv run python -m pytest core/agent_harness/prompts/skills/onboarding-github-ci/a-analyzing-github-ci-performance/test_workflow.py \
  tests/core/tool/test_execution_observations.py tests/core/agent/test_react_loop_observations.py \
  tests/core/agent_harness/test_run_turn_observation.py tests/infrastructure/observability/langfuse/test_langfuse_adapter.py
```

`make pre-push`: lint, format, imports, types, tool-contracts, registries green; 14697 tests passed. The one local failure (`test_required_properties_have_descriptions` for `execute_github_issue_mutation`) is pre-existing on `main` and only reproduces when a local `.env` configures GitHub; it is untouched by this PR.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The runtime must not depend on the Langfuse SDK, so the loop, turn orchestrator and tool executor talk to a small observation port (`infrastructure/observability/trace/observations.py`) and the Langfuse adapter implements it. This keeps `core/` free of vendor imports, lets tests assert on a recording sink (`tests/utils/observations.py`), and means the `langfuse` package is an optional extra. Alternatives considered: instrumenting via the existing OpenTelemetry spans only (loses Langfuse's generation/prompt semantics) or calling the Langfuse SDK directly from the loop (couples `core/` to a vendor).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
